### PR TITLE
feat: Struct overlay enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.0.0] — 2026-05-01
+
+### Added
+
+- **Struct Overlay** — define named C-style struct types and pin them at any address in the memory view to decode live binary data field-by-field
+  - Field types: `uint8`, `uint16`, `uint32`, `uint64`, `int8`, `int16`, `int32`, `int64`, `float32`, `float64`; optional array count per field
+  - Inline type editor directly inside the Struct Overlay panel — create, edit, and delete struct types without leaving the sidebar
+  - **C natural alignment** by default: fields are padded to their natural alignment boundary, trailing padding rounds the struct to its maximum field alignment
+  - **`__attribute__((packed))` toggle button**: disable alignment/padding for packed structs
+  - **Live C code preview** while editing: updates in real time as you change the struct name, fields, types, array counts, and packed toggle
+  - Syntax highlighting in the C preview: `typedef`/`struct` in blue, field types and struct name in teal, `__attribute__((packed))` in purple, offset comments in green, padding lines rendered as `/* N bytes padding */` comments
+  - **Move up / move down** arrow buttons on each field row to reorder fields during editing
+  - Per-instance type preview button (⧉) that shows the C typedef of the assigned struct type
+  - Per-field value display with selectable format: Hex, Decimal, ASCII, Binary — switchable globally or per-field via right-click context menu
+  - Array fields collapse into a group header; expand to see individual element values
+  - Field rows in expanded instances highlight the corresponding bytes in the memory grid on hover/click
+  - **Repair checksums** action available per struct instance
+
+- **Sidebar collapsible sections** — all sidebar panels (Labels, Inspector, Bit View, Multi-byte, Struct Overlay) are now individually collapsible and persist their collapsed state
+
+- **Binary display type** in multi-byte interpreter and struct field values
+
+- **Click label to jump**: clicking a label row in the Labels panel switches to the Memory view and scrolls smoothly to that label's start address
+
+- **Error display and live reload**: parse errors and checksum warnings are surfaced in the UI; files are automatically reloaded when changed externally with a confirm prompt
+
+- **Quick repair**: one-click recompute and rewrite of all record checksums for corrupted files
+
+### Changed
+
+- Struct Overlay tab renamed from "Struct" to "Struct Overlay"; section header renamed to "Struct Instances"
+- All struct type management is now inline within the Struct Instances panel — the separate struct types panel has been removed
+- Padding in aligned structs is shown as `/* N bytes padding */` comment lines instead of explicit `uint8_t _padX[N]` pseudo-fields
+- Raw view and Records view styling improvements (per-field token colors, type badges)
+- Intel HEX TextMate grammar cleaned up for more precise per-field token scopes
+
+### Fixed
+
+- Null-dereference crash when opening the struct type preview before any type was created
+
+---
+
 ## [1.1.0] — 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # HexScope
 
-A lightweight VS Code custom editor for viewing, searching, and patching firmware image files (e.g. Intel HEX and Motorola SREC).
+A lightweight VS Code custom editor for viewing, searching, and patching firmware image files (Intel HEX and Motorola SREC), with a live **Struct Overlay** for decoding binary data directly in the memory view.
 
 ## Supported file types
 
-- Intel HEX: `.hex`
-- Motorola SREC: `.srec`, `.mot`, `.s19`, `.s28`, `.s37`
+| Format | Extensions |
+|---|---|
+| Intel HEX | `.hex` |
+| Motorola SREC | `.srec`, `.mot`, `.s19`, `.s28`, `.s37` |
 
 ## Quick usage
 
 | Action | How |
 |---|---|
-| Open | Right-click a supported file and select "Open with HexScope Viewer". |
-| Views | Use the toolbar to switch between Memory, Records, and Raw. |
-| Edit | Click "Edit" to patch bytes; click "Save" to write changes and recompute checksums. |
-| Search | Press `Ctrl+F` to search by hex, ASCII, or address. |
+| Open | Right-click a supported file → **Open with HexScope Viewer** |
+| Views | Toolbar: **Memory**, **Records**, **Raw** |
+| Edit | Click **Edit** to patch bytes; **Save** writes changes and recomputes checksums |
+| Search | `Ctrl+F` — search by hex sequence, ASCII string, or address |
+| Labels | Add named, color-coded address-range banners; click a label to jump to it |
+| Struct Overlay | Define C structs, pin them at addresses, and decode live binary data |
 
 ## Issues
 
-Found a bug or want to request a feature? Please open an issue at: [Issues](https://github.com/deviousprophet/vscode-hex-scope/issues)
+Found a bug or want to request a feature? Please open an issue: [Issues](https://github.com/deviousprophet/vscode-hex-scope/issues)
 
 Include a short description, steps to reproduce, and sample files when possible.
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # HexScope — Roadmap
 
-This file tracks planned features. Work through this list one branch at a time.
+This file tracks planned features.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Custom editor for Intel HEX (.hex) and Motorola SREC (.srec/.mot/.s19) files — memory grid, byte inspector with bit view and multi-byte interpreter, hex/ASCII/address search, record table, syntax-highlighted raw view, CRC and checksum analysis, segment labels, and in-place byte patching with checksum recomputation",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -22,13 +22,27 @@
     "languages": [
       {
         "id": "intel-hex",
-        "aliases": ["Intel HEX", "ihex"],
-        "extensions": [".hex"]
+        "aliases": [
+          "Intel HEX",
+          "ihex"
+        ],
+        "extensions": [
+          ".hex"
+        ]
       },
       {
         "id": "srec",
-        "aliases": ["Motorola SREC", "srec"],
-        "extensions": [".srec", ".mot", ".s19", ".s28", ".s37"]
+        "aliases": [
+          "Motorola SREC",
+          "srec"
+        ],
+        "extensions": [
+          ".srec",
+          ".mot",
+          ".s19",
+          ".s28",
+          ".s37"
+        ]
       }
     ],
     "grammars": [
@@ -48,12 +62,24 @@
         "viewType": "hexScope.hexEditor",
         "displayName": "HexScope Viewer",
         "selector": [
-          { "filenamePattern": "*.hex" },
-          { "filenamePattern": "*.srec" },
-          { "filenamePattern": "*.mot" },
-          { "filenamePattern": "*.s19" },
-          { "filenamePattern": "*.s28" },
-          { "filenamePattern": "*.s37" }
+          {
+            "filenamePattern": "*.hex"
+          },
+          {
+            "filenamePattern": "*.srec"
+          },
+          {
+            "filenamePattern": "*.mot"
+          },
+          {
+            "filenamePattern": "*.s19"
+          },
+          {
+            "filenamePattern": "*.s28"
+          },
+          {
+            "filenamePattern": "*.s37"
+          }
         ],
         "priority": "option"
       }
@@ -113,83 +139,132 @@
         "textMateRules": [
           {
             "scope": "punctuation.ihex.start-code",
-            "settings": { "foreground": "#6a6a6a" }
+            "settings": {
+              "foreground": "#6a6a6a"
+            }
           },
           {
             "scope": "meta.ihex.byte-count",
-            "settings": { "foreground": "#858585" }
+            "settings": {
+              "foreground": "#858585"
+            }
           },
           {
             "scope": "meta.ihex.address",
-            "settings": { "foreground": "#c6c6c6", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#c6c6c6",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.ihex.record-type.data",
-            "settings": { "foreground": "#4ec9a0", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#4ec9a0",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.ihex.record-type.eof",
-            "settings": { "foreground": "#ce9178", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#ce9178",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.ihex.record-type.extended-address",
-            "settings": { "foreground": "#9cdcfe", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#9cdcfe",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.ihex.record-type.start-address",
-            "settings": { "foreground": "#9cdcfe", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#9cdcfe",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.ihex.data",
-            "settings": { "foreground": "#ce9178" }
+            "settings": {
+              "foreground": "#ce9178"
+            }
           },
           {
             "scope": "meta.ihex.extended-address-value",
-            "settings": { "foreground": "#9cdcfe" }
+            "settings": {
+              "foreground": "#9cdcfe"
+            }
           },
           {
             "scope": "meta.ihex.checksum",
-            "settings": { "foreground": "#858585" }
+            "settings": {
+              "foreground": "#858585"
+            }
           },
           {
             "scope": "invalid.illegal.ihex",
-            "settings": { "foreground": "#f48771" }
+            "settings": {
+              "foreground": "#f48771"
+            }
           },
           {
             "scope": "punctuation.srec.start-code",
-            "settings": { "foreground": "#6a6a6a" }
+            "settings": {
+              "foreground": "#6a6a6a"
+            }
           },
           {
             "scope": "meta.srec.byte-count",
-            "settings": { "foreground": "#858585" }
+            "settings": {
+              "foreground": "#858585"
+            }
           },
           {
             "scope": "meta.srec.address",
-            "settings": { "foreground": "#c6c6c6", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#c6c6c6",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.srec.record-type.data",
-            "settings": { "foreground": "#4ec9a0", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#4ec9a0",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.srec.record-type.eof",
-            "settings": { "foreground": "#ce9178", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#ce9178",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.srec.record-type.extended-address",
-            "settings": { "foreground": "#9cdcfe", "fontStyle": "bold" }
+            "settings": {
+              "foreground": "#9cdcfe",
+              "fontStyle": "bold"
+            }
           },
           {
             "scope": "meta.srec.data",
-            "settings": { "foreground": "#ce9178" }
+            "settings": {
+              "foreground": "#ce9178"
+            }
           },
           {
             "scope": "meta.srec.checksum",
-            "settings": { "foreground": "#858585" }
+            "settings": {
+              "foreground": "#858585"
+            }
           },
           {
             "scope": "invalid.illegal.srec",
-            "settings": { "foreground": "#f48771" }
+            "settings": {
+              "foreground": "#f48771"
+            }
           }
         ]
       }

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -35,7 +35,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         _openContext: vscode.CustomDocumentOpenContext,
         _token: vscode.CancellationToken
     ): Promise<vscode.CustomDocument> {
-        return { uri, dispose: () => { /* nothing to dispose */ } };
+        return { uri, dispose: () => {} };
     }
 
     async resolveCustomEditor(
@@ -51,11 +51,8 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
         webviewPanel.webview.html = this._getHtml(webviewPanel.webview, document.uri, parseResult);
 
-        // Load segment labels from workspace state
         const labelKey = `hexScope.labels.${document.uri.toString()}`;
-        const storedLabels: SegmentLabel[] = this._context.workspaceState.get(labelKey, []);
 
-        // Load struct definitions from workspace state
         const structKey = `hexScope.structs.${document.uri.toString()}`;
         const structPinKey = `hexScope.structPins.${document.uri.toString()}`;
 
@@ -147,7 +144,6 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                     break;
                 }
                 case 'saveEdits': {
-                    // msg.edits: Array<[addr: number, value: number]>
                     const edits = msg.edits as Array<[number, number]>;
                     const editMap = new Map<number, number>(edits);
                     const newHex = format === 'srec'
@@ -155,7 +151,6 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                         : serializeIntelHex(raw, parseResult, editMap);
                     suppressReload = true;
                     await vscode.workspace.fs.writeFile(document.uri, new TextEncoder().encode(newHex));
-                    // Update in-memory state to the saved content
                     raw = newHex;
                     parseResult = format === 'srec' ? parseSRec(raw) : parseIntelHex(raw);
                     webviewPanel.webview.postMessage({ type: 'savedEdits' });
@@ -167,7 +162,6 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                     suppressReload = true;
                     await vscode.workspace.fs.writeFile(document.uri, new TextEncoder().encode(repairedRaw));
                     const fixedCount = parseResult.checksumErrors;
-                    // Update in-memory state to the repaired content
                     raw = repairedRaw;
                     parseResult = format === 'srec' ? parseSRec(raw) : parseIntelHex(raw);
                     postInit();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,19 +3,16 @@ import * as vscode from 'vscode';
 import { HexEditorProvider } from './HexEditorProvider';
 
 export function activate(context: vscode.ExtensionContext) {
-    // Register the custom editor provider for .hex files
     context.subscriptions.push(
         HexEditorProvider.register(context)
     );
 
-    // Command: Add Segment Label
     context.subscriptions.push(
         vscode.commands.registerCommand('hexScope.addSegmentLabel', () => {
             vscode.commands.executeCommand('hexScope.addSegmentLabelInternal');
         })
     );
 
-    // Command: Open current .hex file in the HexScope custom editor
     context.subscriptions.push(
         vscode.commands.registerCommand('hexScope.openInHexScope', (uri?: vscode.Uri) => {
             const target = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -41,5 +38,5 @@ export function activate(context: vscode.ExtensionContext) {
     }
 }
 
-export function deactivate() { /* nothing */ }
+export function deactivate() {}
 

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -9,7 +9,6 @@ import type { StructDef, StructField } from '../webview/types';
 
 function resetStructState(): void {
     S.structs           = [];
-    S.activeStructId    = null;
     S.activeStructAddr  = null;
     S.flatBytes.clear();
     S.sortedAddrs       = [];
@@ -44,13 +43,31 @@ suite('structByteSize()', () => {
         assert.strictEqual(structByteSize(def), 4);
     });
 
-    test('mixed field types sum correctly', () => {
-        const def: StructDef = { id: 'x', name: 'S', fields: [
+    test('mixed field types packed: no padding (7 bytes)', () => {
+        const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
             { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // 1
             { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },  // 2
             { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },  // 4
         ]};
         assert.strictEqual(structByteSize(def), 7);
+    });
+
+    test('mixed field types aligned: uint8+uint16+uint32 = 8 bytes', () => {
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0
+            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },  // +2 (1B pad)
+            { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },  // +4
+        ]};
+        assert.strictEqual(structByteSize(def), 8);
+    });
+
+    test('aligned struct has trailing padding to max alignment', () => {
+        // uint32 then uint8: size = 4+1 padded to 8 (align=4)
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },  // +0
+            { name: 'b', type: 'uint8',  count: 1, endian: 'inherit' },  // +4
+        ]};
+        assert.strictEqual(structByteSize(def), 8);
     });
 
     test('array field multiplies by count', () => {
@@ -130,7 +147,7 @@ suite('decodeStruct()', () => {
     setup(() => resetStructState());
 
     test('produces one row per scalar field', () => {
-        const def: StructDef = { id: 'x', name: 'S', fields: [
+        const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
             { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },
             { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
         ]};
@@ -145,6 +162,16 @@ suite('decodeStruct()', () => {
         assert.strictEqual(rows[0].byteOffset, 0);
         assert.strictEqual(rows[1].fieldName, 'b');
         assert.strictEqual(rows[1].byteOffset, 1);
+    });
+
+    test('aligned struct: uint8 then uint16 at offset 2', () => {
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },
+            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+        ]};
+        const rows = decodeStruct(def, 0, new Map(), 'le');
+        assert.strictEqual(rows[0].byteOffset, 0);
+        assert.strictEqual(rows[1].byteOffset, 2);
     });
 
     test('array field expands to count rows named field[0], field[1]...', () => {
@@ -190,8 +217,8 @@ suite('decodeStruct()', () => {
         assert.ok(rows[0].decoded.startsWith('1'), rows[0].decoded);
     });
 
-    test('byte offsets accumulate correctly across mixed-width fields', () => {
-        const def: StructDef = { id: 'x', name: 'S', fields: [
+    test('byte offsets accumulate correctly (packed)', () => {
+        const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
             { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0, 1 B
             { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },  // +1, 4 B
             { name: 'c', type: 'uint16', count: 1, endian: 'inherit' },  // +5, 2 B
@@ -200,6 +227,18 @@ suite('decodeStruct()', () => {
         assert.strictEqual(rows[0].byteOffset, 0);
         assert.strictEqual(rows[1].byteOffset, 1);
         assert.strictEqual(rows[2].byteOffset, 5);
+    });
+
+    test('byte offsets with alignment (not packed)', () => {
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0
+            { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },  // +4 (3B pad)
+            { name: 'c', type: 'uint16', count: 1, endian: 'inherit' },  // +8
+        ]};
+        const rows = decodeStruct(def, 0, new Map(), 'le');
+        assert.strictEqual(rows[0].byteOffset, 0);
+        assert.strictEqual(rows[1].byteOffset, 4);
+        assert.strictEqual(rows[2].byteOffset, 8);
     });
 
     test('bytesHex shows ?? for missing bytes', () => {

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -19,7 +19,7 @@ function resetState(): void {
     S.edits.clear();
     S.undoStack.length = 0;
     S.structs          = [];
-    S.activeStructId   = null;
+
     S.activeStructAddr = null;
     S.structPins       = [];
     S.sidebarTab       = 'inspector';

--- a/src/webview/base.css
+++ b/src/webview/base.css
@@ -40,7 +40,7 @@
     --print-color: #ce9178;
     --high-color:  #9cdcfe;
     --zero-color:  rgba(212,212,212,.20);
-    --sidebar-w:   400px;
+    --sidebar-w:   360px;
 }
 
 html, body {

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -123,13 +123,12 @@ function render(): void {
                     <div class="sb-section" id="s-labels"></div>
                 </div>
                 <div class="sb-tab-panel ${S.sidebarTab === 'struct' ? 'active' : ''}" id="sbp-struct">
-                    <div class="sb-section" id="s-struct"></div>
                     <div class="sb-section" id="s-struct-pins"></div>
                 </div>
             </div>
             <div id="side-tabs">
                 <button class="stab${S.sidebarTab === 'inspector' ? ' active' : ''}" id="stab-insp">Inspector</button>
-                <button class="stab${S.sidebarTab === 'struct'    ? ' active' : ''}" id="stab-struct">Struct</button>
+                <button class="stab${S.sidebarTab === 'struct'    ? ' active' : ''}" id="stab-struct">Struct Overlay</button>
             </div>
         </div>
         <div id="ctx-menu" style="display:none"></div>`;
@@ -199,6 +198,7 @@ function render(): void {
     rerender.memory   = () => memRerender();
     rerender.labels   = () => renderLabels();
     rerender.toMemory = () => switchView('memory');
+    rerender.jumpTo   = (addr: number) => { switchView('memory'); scrollTo(addr); };
 
     // Wire search module
     initSearch(() => switchView('memory'));
@@ -229,9 +229,6 @@ function render(): void {
         updateInspector();
     });
     document.addEventListener('mouseup', () => { dragAnchor = null; });
-
-    // Wire search module
-    initSearch(() => switchView('memory'));
 
     // Side tabs
     function applySidebarState(): void {

--- a/src/webview/layout.css
+++ b/src/webview/layout.css
@@ -8,7 +8,6 @@
     background: var(--panel-bg); border-left: 1px solid var(--border);
     display: flex; flex-direction: column; overflow: hidden;
 }
-.sb-scroll  { flex: 1; overflow-y: auto; overflow-x: hidden; }
 .sb-section { padding: 10px 12px; border-bottom: 1px solid var(--border); }
 
 .sb-hdr {

--- a/src/webview/memory-view.css
+++ b/src/webview/memory-view.css
@@ -86,6 +86,9 @@
     background: rgba(255,200,60,.18) !important;
     outline: 1px solid rgba(255,200,60,.5);
 }
+/* Array element boundary separator */
+.data-cell.struct-arr-sep { border-left: 2px solid rgba(255,200,60,.8); }
+.char-cell.struct-arr-sep { border-left: 2px solid rgba(255,200,60,.8); }
 
 /* ── Gap row ─────────────────────────────────────────────────── */
 .gap-row {

--- a/src/webview/render.ts
+++ b/src/webview/render.ts
@@ -11,4 +11,7 @@ export const rerender = {
 
     /** Switch to memory view (and re-render). */
     toMemory: () => { /* wired by hexViewer.ts */ },
+
+    /** Switch to memory view and scroll to address. */
+    jumpTo: (_addr: number) => { /* wired by hexViewer.ts */ },
 };

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -106,7 +106,7 @@
 /* Collapsible section support: hide body when collapsed */
 .sb-section.collapsed .sb-body { display: none; }
 .sb-section .sb-hdr {
-    cursor: pointer; user-select: none;
+    cursor: pointer; -webkit-user-select: none; user-select: none;
     position: relative;
 }
 .sb-section .sb-hdr::before {

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -122,8 +122,7 @@
 }
 
 /* ── Multi-byte interpreter ──────────────────────────────────── */
-.mi-endian     { display: flex; align-items: center; justify-content: flex-end; gap: 4px; margin-bottom: 10px; flex-wrap: wrap; }
-.mi-endian-lbl { font-size: 10px; color: var(--addr-fg); text-transform: uppercase; letter-spacing: .06em; margin-right: auto; }.endian-tabs {
+.endian-tabs {
     display: flex; gap: 2px;
     background: rgba(0,0,0,.2); border-radius: 3px; padding: 2px;
 }
@@ -146,8 +145,6 @@
 
 /* group — shared 2-col grid so type names and values align across all rows */
 .mi-group     { display: grid; grid-template-columns: auto 1fr; gap: 1px 0; }
-.mi-group-sep { height: 1px; background: rgba(255,255,255,.06); margin: 8px 0; grid-column: 1 / -1; }
-.mi-group-dim { opacity: .3; pointer-events: none; }
 
 /* individual card — spans both grid columns internally */
 .mi-card      { display: contents; }
@@ -170,10 +167,6 @@
 .mi-hex           { font-size: 10px; color: var(--addr-fg); opacity: .65; line-height: 1.2; }
 .mi-hex[data-copy]{ cursor: pointer; }
 .mi-hex[data-copy]:hover { opacity: 1; color: var(--fg); }
-.mi-na   { font-size: 11px; color: var(--addr-fg); opacity: .35; }
-
-/* keep for any remaining references */
-.mt-special { color: var(--non-graphic); font-style: italic; }
 
 /* ── Segment labels ──────────────────────────────────────────── */
 .label-item {

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -7,8 +7,12 @@
     border-left: 2px solid var(--addr-active-fg); border-radius: 2px;
     display: flex; align-items: baseline; flex-wrap: wrap; gap: 3px;
 }
-.insp-addr-single { font-size: 13px; }
-.insp-addr-range  { font-size: 12px; }
+.insp-addr-value  {
+    font-size: 12px;
+    min-height: 22px;
+    display: inline-flex;
+    align-items: center;
+}
 .insp-addr-sep    { color: var(--addr-fg); font-size: 11px; margin: 0 1px; }
 .insp-addr-len    {
     margin-left: auto; font-size: 10px; font-weight: 400;
@@ -56,38 +60,66 @@
 #insp-multi { margin-top: 10px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,.08); }
 #insp-multi:empty { display: none; }
 
-.bitgrid-wrap { display: flex; flex-direction: column; gap: 2px; }
+.bitgrid-wrap {
+    --bit-size: 14px;
+    display: flex; flex-direction: column; gap: 6px;
+    align-items: center;
+}
 
 /* One row: optional byte label + 8 bit cells */
-.bit-row  { display: grid; grid-template-columns: 3.8em repeat(8, 1fr); gap: 2px; align-items: center; min-height: 22px; }
+.bit-row  {
+    display: grid;
+    grid-template-columns: 3.2em repeat(8, var(--bit-size));
+    gap: 6px; align-items: center; min-height: 18px;
+    width: max-content; align-self: center;
+}
 
 /* Bit index header row */
-.bit-idx  { text-align: center; font-size: 9px; color: var(--non-graphic); font-family: var(--font-editor); }
+.bit-idx  { text-align: center; font-size: 11px; color: var(--addr-fg); font-family: var(--font-editor); font-weight: 600; }
 
 /* Byte label (B0, B1 …) — stacked: index on top, hex below */
 .bit-lbl  { display: flex; flex-direction: column; align-items: flex-end;
-            padding-right: 4px; gap: 0; justify-content: center; }
-.bit-lbl-idx { font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor); line-height: 1.3; }
+            padding-right: 6px; gap: 0; justify-content: center; }
+.bit-lbl-idx { font-size: 10px; color: var(--addr-fg); font-family: var(--font-editor); line-height: 1.2; }
 /* header variant — dimmer */
-.bit-lbl-hdr { opacity: .4; }
+.bit-lbl-hdr { opacity: .6; }
 
 .bit-v {
-    aspect-ratio: 1;
+    width: var(--bit-size);
+    height: var(--bit-size);
     display: flex; align-items: center; justify-content: center;
     border: 1px solid var(--border); border-radius: 2px;
-    background: rgba(0,0,0,.18);
+    background: rgba(0,0,0,.12);
+    transition: background .08s, border-color .08s;
+    font-size: 10px; box-sizing: border-box;
 }
-.bit-v.on { background: rgba(79,195,247,.25); border-color: rgba(79,195,247,.55); }
-.bit-v.bit-col-hi            { border-color: rgba(79,195,247,.25); background: rgba(79,195,247,.05); }
-.bit-v.on.bit-col-hi         { background: rgba(79,195,247,.3);  border-color: rgba(79,195,247,.7); }
+.bit-v.on { background: rgba(79,195,247,.28); border-color: rgba(79,195,247,.65); }
+.bit-v.bit-col-hi            { border-color: rgba(79,195,247,.35); background: rgba(79,195,247,.06); }
+.bit-v.on.bit-col-hi         { background: rgba(79,195,247,.34);  border-color: rgba(79,195,247,.8); }
 
 /* hex value in byte-row label */
-.bit-hex { color: var(--high-color); opacity: .7; font-size: 9px;
-            font-family: var(--font-editor); line-height: 1.3; }
+.bit-hex { color: var(--high-color); opacity: .9; font-size: 11px; font-family: var(--font-editor); line-height: 1.2; }
 
 /* popcount footer */
-.bit-pc  { display: block; text-align: right; font-size: 9px; color: var(--addr-fg);
-           opacity: .5; margin-top: 2px; font-family: var(--font-editor); }
+.bit-pc  { display: block; text-align: right; font-size: 11px; color: var(--fg); opacity: .9; margin-top: 4px; font-family: var(--font-editor); font-weight: 600; }
+
+/* Collapsible section support: hide body when collapsed */
+.sb-section.collapsed .sb-body { display: none; }
+.sb-section .sb-hdr {
+    cursor: pointer; user-select: none;
+    position: relative;
+}
+.sb-section .sb-hdr::before {
+    content: '\25B6'; /* right-pointing triangle */
+    display: inline-block;
+    margin-right: 6px;
+    font-size: 12px;
+    transition: transform .15s;
+    color: var(--addr-fg);
+}
+.sb-section:not(.collapsed) .sb-hdr::before {
+    transform: rotate(90deg);
+}
 
 /* ── Multi-byte interpreter ──────────────────────────────────── */
 .mi-endian     { display: flex; align-items: center; justify-content: flex-end; gap: 4px; margin-bottom: 10px; flex-wrap: wrap; }

--- a/src/webview/sidebar.ts
+++ b/src/webview/sidebar.ts
@@ -10,11 +10,28 @@ import { buildMemRows } from './data';
 // ── Inspector ────────────────────────────────────────────────────
 
 export function renderInspector(): void {
-    document.getElementById('s-insp')!.innerHTML =
+    const sec = document.getElementById('s-insp')!;
+    sec.innerHTML =
         `<div class="sb-hdr">Inspector</div>
-         <div id="insp-addr" style="display:none"></div>
-         <div id="insp-vals"><div class="sb-empty">Click a byte to inspect</div></div>
-         <div id="insp-multi"></div>`;
+         <div class="sb-body">
+           <div id="insp-addr" style="display:none"></div>
+           <div id="insp-vals"><div class="sb-empty">Click a byte to inspect</div></div>
+           <div id="insp-multi"></div>
+         </div>`;
+
+    // Collapsible: expanded by default
+    if (sec.dataset.collapsed === undefined) { sec.dataset.collapsed = 'false'; }
+    sec.classList.toggle('collapsed', sec.dataset.collapsed === 'true');
+
+    // Header toggles collapse state
+    const hdr = sec.querySelector<HTMLElement>('.sb-hdr');
+    if (hdr) {
+        hdr.addEventListener('click', () => {
+            const now = sec.dataset.collapsed === 'true' ? 'false' : 'true';
+            sec.dataset.collapsed = now;
+            sec.classList.toggle('collapsed', now === 'true');
+        });
+    }
 }
 
 export function updateInspector(): void {
@@ -35,14 +52,14 @@ export function updateInspector(): void {
     const ah = S.selStart.toString(16).toUpperCase().padStart(8, '0');
     addrEl.style.display = '';
     if (len === 1) {
-        addrEl.innerHTML = `<span class="insp-addr-single">0x${ah}</span>`;
+        addrEl.innerHTML = `<span class=\"insp-addr-value\">0x${ah}</span>`;
     } else {
         const endH = S.selEnd!.toString(16).toUpperCase().padStart(8, '0');
         addrEl.innerHTML =
-            `<span class="insp-addr-range">0x${ah}</span>` +
-            `<span class="insp-addr-sep">–</span>` +
-            `<span class="insp-addr-range">0x${endH}</span>` +
-            `<span class="insp-addr-len">${len} bytes</span>`;
+            `<span class=\"insp-addr-value\">0x${ah}</span>` +
+            `<span class=\"insp-addr-sep\">–</span>` +
+            `<span class=\"insp-addr-value\">0x${endH}</span>` +
+            `<span class=\"insp-addr-len\">${len} bytes</span>`;
     }
 
     if (val === undefined) {
@@ -114,6 +131,21 @@ export function renderBits(val?: number): void {
             `<div class="bitgrid-wrap">${bitIndexRow()}${byteRow(val, null)}</div>` +
             `<span class="bit-pc">${pc}/8 bits set</span></div>`;
     }
+
+    // Persist collapsed state on the section element; default collapsed
+    if (sec.dataset.collapsed === undefined) { sec.dataset.collapsed = 'true'; }
+    sec.classList.toggle('collapsed', sec.dataset.collapsed === 'true');
+
+    // Header toggles collapse state
+    const hdr = sec.querySelector<HTMLElement>('.sb-hdr');
+    if (hdr) {
+        hdr.addEventListener('click', () => {
+            const now = sec.dataset.collapsed === 'true' ? 'false' : 'true';
+            sec.dataset.collapsed = now;
+            sec.classList.toggle('collapsed', now === 'true');
+        });
+    }
+
     wireBitColHover();
 }
 
@@ -128,6 +160,21 @@ function renderBitsMulti(bytes: number[]): void {
         `<div class="sb-body">` +
         `<div class="bitgrid-wrap">${bitIndexRow()}${rows}</div>` +
         `<span class="bit-pc">${total}/${bytes.length * 8} bits set</span></div>`;
+
+    // Persist collapsed state on the section element; default collapsed
+    if (sec.dataset.collapsed === undefined) { sec.dataset.collapsed = 'true'; }
+    sec.classList.toggle('collapsed', sec.dataset.collapsed === 'true');
+
+    // Header toggles collapse state
+    const hdrm = sec.querySelector<HTMLElement>('.sb-hdr');
+    if (hdrm) {
+        hdrm.addEventListener('click', () => {
+            const now = sec.dataset.collapsed === 'true' ? 'false' : 'true';
+            sec.dataset.collapsed = now;
+            sec.classList.toggle('collapsed', now === 'true');
+        });
+    }
+
     wireBitColHover();
 }
 
@@ -317,8 +364,23 @@ export function renderLabels(): void {
 
     sec.innerHTML = `
         <div class="sb-hdr">Labels ${badge}</div>
-        ${items}
-        <button class="add-lbl-btn" id="btn-add-lbl">+ Add Segment Label</button>`;
+        <div class="sb-body">${items}
+        <button class="add-lbl-btn" id="btn-add-lbl">+ Add Segment Label</button>
+        </div>`;
+
+    // Persist collapsed state on the section element; default collapsed
+    if (sec.dataset.collapsed === undefined) { sec.dataset.collapsed = 'true'; }
+    sec.classList.toggle('collapsed', sec.dataset.collapsed === 'true');
+
+    // Header toggles collapse state
+    const lh = sec.querySelector<HTMLElement>('.sb-hdr');
+    if (lh) {
+        lh.addEventListener('click', () => {
+            const now = sec.dataset.collapsed === 'true' ? 'false' : 'true';
+            sec.dataset.collapsed = now;
+            sec.classList.toggle('collapsed', now === 'true');
+        });
+    }
 
     // Delete
     sec.querySelectorAll<HTMLElement>('.label-del').forEach(el => {
@@ -388,6 +450,10 @@ export function renderLabels(): void {
 function renderLabelForm(editId?: string): void {
     const sec     = document.getElementById('s-labels')!;
     const editing = editId ? S.labels.find(l => l.id === editId) : undefined;
+
+    // Ensure the labels section is expanded while editing
+    sec.dataset.collapsed = 'false';
+    sec.classList.remove('collapsed');
 
     const COLORS = [
         { name: 'Sky Blue', v: '#4fc3f7' }, { name: 'Green',  v: '#81c784' },

--- a/src/webview/sidebar.ts
+++ b/src/webview/sidebar.ts
@@ -441,6 +441,17 @@ export function renderLabels(): void {
         });
     });
 
+    // Jump to label address on row click (but not when clicking action buttons)
+    sec.querySelectorAll<HTMLElement>('.label-item').forEach(item => {
+        item.style.cursor = 'pointer';
+        item.addEventListener('click', e => {
+            if ((e.target as HTMLElement).closest('.label-act')) { return; }
+            const id  = item.dataset.id!;
+            const lbl = S.labels.find(l => l.id === id);
+            if (lbl) { rerender.jumpTo(lbl.startAddress); }
+        });
+    });
+
     // Add — open inline form
     document.getElementById('btn-add-lbl')?.addEventListener('click', () => renderLabelForm());
 }

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -23,7 +23,6 @@ export const S = {
     edits:        new Map<number, number>(),   // addr → new value (pending saves)
     undoStack:    [] as Array<Array<[number, number]>>,  // stack of [addr, prevVal] transactions
     structs:      [] as StructDef[],           // user-defined struct definitions
-    activeStructId:   null as string | null,   // id of currently selected struct
     activeStructAddr: null as number | null,   // base address for struct decode
     structPins:   [] as StructPin[],           // saved (structId, addr) overlay instances
     sidebarTab:     'inspector' as 'inspector' | 'struct',  // active sidebar tab

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -26,8 +26,34 @@ export function fieldByteSize(type: StructFieldType): number {
     }
 }
 
+/** Natural alignment for a field type (C ABI, 32-bit target). */
+export function fieldAlignment(type: StructFieldType): number {
+    return fieldByteSize(type); // for all supported types, align == size (max 8)
+}
+
+function alignUp(offset: number, align: number): number {
+    return align <= 1 ? offset : (offset + align - 1) & ~(align - 1);
+}
+
+/**
+ * Compute byte size of a struct, respecting alignment padding unless packed.
+ * Includes trailing padding so that arrays of the struct are correctly aligned.
+ */
 export function structByteSize(def: StructDef): number {
-    return def.fields.reduce((s, f) => s + fieldByteSize(f.type) * f.count, 0);
+    if (def.packed) {
+        return def.fields.reduce((s, f) => s + fieldByteSize(f.type) * f.count, 0);
+    }
+    let offset = 0;
+    let maxAlign = 1;
+    for (const f of def.fields) {
+        const sz    = fieldByteSize(f.type);
+        const align = fieldAlignment(f.type);
+        if (align > maxAlign) { maxAlign = align; }
+        offset = alignUp(offset, align);
+        offset += sz * f.count;
+    }
+    // Trailing padding: round up to struct's own alignment
+    return alignUp(offset, maxAlign);
 }
 
 // ── Decode logic ──────────────────────────────────────────────────
@@ -87,8 +113,10 @@ export function decodeStruct(
     const rows: DecodedField[] = [];
     let offset = 0;
     for (const field of def.fields) {
-        const sz = fieldByteSize(field.type);
+        const sz     = fieldByteSize(field.type);
+        const align  = def.packed ? 1 : fieldAlignment(field.type);
         const endian = field.endian === 'inherit' ? globalEndian : field.endian;
+        offset = alignUp(offset, align);
         for (let idx = 0; idx < field.count; idx++) {
             const raw: number[] = [];
             for (let b = 0; b < sz; b++) {
@@ -96,7 +124,7 @@ export function decodeStruct(
                 raw.push(v !== undefined ? v : -1);
             }
             const hasData = raw.every(v => v >= 0);
-            const bytesHex = raw.map(v => v >= 0 ? v.toString(16).toUpperCase().padStart(2, '0') : '??').join(' ');
+            const bytesHex = raw.map(v => v >= 0 ? v.toString(16).toUpperCase().padStart(2, '00') : '??').join(' ');
             const decoded = hasData ? decodeField(raw, field.type, endian) : '??';
             const name = field.count > 1 ? `${field.name}[${idx}]` : field.name;
             rows.push({ fieldName: name, type: field.type, arrayIdx: idx, byteOffset: offset, bytesHex, decoded, hasData });
@@ -253,4 +281,59 @@ export function fieldsToText(fields: StructField[]): string {
         const hint  = f.endian !== 'inherit' ? `  // ${f.endian}` : '';
         return `${cType} ${f.name}${arr};${hint}`;
     }).join('\n');
+}
+
+/**
+ * Render a StructDef as a C typedef, with per-field offset comments.
+ * Includes padding pseudo-fields when the struct is not packed.
+ * Output is plain text (no HTML escaping).
+ */
+export function structToC(def: StructDef): string {
+    const attr = def.packed ? ' __attribute__((packed))' : '';
+    const lines: string[] = [];
+    lines.push(`typedef struct${attr} {`);
+
+    const maxTypeLen = def.fields.length
+        ? Math.max(...def.fields.map(f => TYPE_TO_C[f.type].length))
+        : 8;
+
+    let offset = 0;
+    let maxAlign = 1;
+
+    for (const f of def.fields) {
+        const sz    = fieldByteSize(f.type);
+        const align = def.packed ? 1 : fieldAlignment(f.type);
+        if (align > maxAlign) { maxAlign = align; }
+        const aligned = alignUp(offset, align);
+
+        if (!def.packed && aligned > offset) {
+            // Emit padding pseudo-field
+            const padBytes = aligned - offset;
+            lines.push(`    uint8_t  _pad${offset}[${padBytes}];`.padEnd(44) +
+                `/* +${offset.toString().padStart(3)}  ${padBytes}B padding */`);
+        }
+
+        offset = aligned;
+        const cType = TYPE_TO_C[f.type].padEnd(maxTypeLen);
+        const arr   = f.count > 1 ? `[${f.count}]` : '';
+        const fieldBytes = sz * f.count;
+        const endianHint = f.endian !== 'inherit' ? `  /* ${f.endian} */` : '';
+        lines.push(`    ${cType} ${f.name}${arr};`.padEnd(44) +
+            `/* +${offset.toString().padStart(3)}  ${fieldBytes}B${endianHint} */`);
+        offset += fieldBytes;
+    }
+
+    // Trailing padding
+    const totalUnpadded = offset;
+    const totalPadded   = alignUp(offset, maxAlign);
+    if (!def.packed && totalPadded > totalUnpadded) {
+        const padBytes = totalPadded - totalUnpadded;
+        lines.push(`    uint8_t  _pad${offset}[${padBytes}];`.padEnd(44) +
+            `/* +${offset.toString().padStart(3)}  ${padBytes}B padding */`);
+    }
+
+    const totalBytes = def.packed ? totalUnpadded : totalPadded;
+    const alignNote  = def.packed ? 'packed' : `align=${maxAlign}`;
+    lines.push(`} ${def.name};`.padEnd(44) + `/* ${totalBytes}B, ${alignNote} */`);
+    return lines.join('\n');
 }

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -48,6 +48,11 @@
     color: var(--addr-fg);
 }
 .struct-btn-secondary:hover { background: rgba(255,255,255,.12); border-color: var(--fg); }
+.struct-btn-danger {
+    background: rgba(255,80,80,.08); border: 1px solid rgba(255,80,80,.35);
+    color: rgba(255,120,120,1); margin-left: auto;
+}
+.struct-btn-danger:hover { background: rgba(255,80,80,.18); border-color: rgba(255,80,80,.7); }
 
 /* sb-hdr with inline button */
 .sb-hdr-row {
@@ -103,7 +108,7 @@
 /* Field header + rows */
 .se-field-hdr {
     display: grid;
-    grid-template-columns: 64px 1fr 72px 18px;
+    grid-template-columns: 64px 1fr 72px 30px 18px;
     gap: 3px; align-items: center;
     font-size: 9px; font-weight: 700; text-transform: uppercase;
     letter-spacing: .04em; color: var(--addr-fg); font-family: var(--font-ui);
@@ -113,7 +118,7 @@
 
 .struct-field-row {
     display: grid;
-    grid-template-columns: 64px 1fr 72px 18px;
+    grid-template-columns: 64px 1fr 72px 30px 18px;
     gap: 3px; align-items: center; padding: 1px 0;
 }
 
@@ -168,6 +173,20 @@
 .sfe-del-btn:hover { color: var(--err); }
 .sfe-del-placeholder { display: block; width: 18px; }
 
+.sfe-move-btns {
+    display: flex; flex-direction: row; align-items: center; justify-content: center; gap: 1px;
+}
+.sfe-move-btn {
+    background: transparent; border: none; color: var(--addr-fg);
+    font-size: 11px; line-height: 1; padding: 0 1px; cursor: pointer;
+    transition: color .1s;
+    display: inline-block;
+}
+.sfe-move-up { transform: rotate(-90deg); }
+.sfe-move-dn { transform: rotate(90deg); }
+.sfe-move-btn:hover:not(:disabled) { color: var(--fg); }
+.sfe-move-btn:disabled { opacity: .2; cursor: default; }
+
 .struct-add-field-btn {
     background: transparent; border: 1px dashed var(--border);
     border-radius: 3px; color: var(--addr-fg); font-size: 10px;
@@ -180,7 +199,7 @@
 
 /* ══ Instances panel (#s-struct-pins) ════════════════════════════ */
 
-/* Header row: title + badge + LE/BE tabs + ＋ Add */
+/* Header row: title + badge + ⚙ Types + LE/BE tabs + ＋ Add */
 .si-hdr-row {
     display: flex; align-items: center; gap: 6px;
     margin-bottom: 6px;
@@ -217,22 +236,24 @@
 }
 .struct-btn-cancel:hover { border-color: var(--fg); color: var(--fg); }
 
-/* Field preview */
+/* C-code type preview (used in add-form and card type-preview) */
 .sa-preview {
     background: rgba(0,0,0,.18); border: 1px solid var(--border);
-    border-radius: 3px; padding: 4px 6px;
-    display: flex; flex-direction: column; gap: 1px;
-    max-height: 96px; overflow-y: auto;
+    border-radius: 3px; padding: 0;
+    max-height: 160px; overflow-y: auto;
 }
-.sa-preview-empty {
-    font-size: 10px; color: var(--non-graphic); font-style: italic;
-    font-family: var(--font-ui);
+.si-c-preview {
+    margin: 0; padding: 5px 7px;
+    font-family: var(--font-editor); font-size: 10px; line-height: 1.5;
+    color: var(--fg); white-space: pre; tab-size: 4;
+    background: transparent; border: none;
+    overflow-x: auto;
 }
-.sa-pf {
-    font-size: 10px; line-height: 1.4; font-family: var(--font-editor);
-}
-.sa-pf-type { color: var(--print-color); margin-right: 4px; }
-.sa-pf-name { color: var(--fg); }
+/* C syntax token colors */
+.sc-kw        { color: #569cd6; }          /* typedef struct */
+.sc-attr      { color: #c586c0; }          /* __attribute__((packed)) */
+.sc-type      { color: #4ec9b0; }          /* uint8_t uint32_t float … */
+.sc-cmt       { color: #6a9955; }          /* /* … */ */
 
 .sa-addr-inp { flex: 0 0 90px; }
 
@@ -253,6 +274,7 @@
 }
 .si-card:hover { border-color: rgba(255,255,255,.2); }
 .si-card.si-expanded { border-color: rgba(79,195,247,.35); }
+.si-card.si-card-selected { border-color: rgba(79,195,247,.6); background: rgba(79,195,247,.05); }
 
 .si-card-hdr {
     display: flex; align-items: center; gap: 4px;
@@ -266,17 +288,27 @@
     display: flex; align-items: center; justify-content: center;
     background: transparent; border: none; padding: 0;
     color: var(--addr-fg); font-size: 12px; cursor: pointer;
-    line-height: 1;
+    line-height: 1; align-self: flex-start; margin-top: 2px;
 }
 
+.si-card-info {
+    flex: 1; min-width: 0;
+    display: flex; flex-direction: column; gap: 2px;
+}
 .si-cname {
-    flex: 0 1 auto; min-width: 0;
     font-size: 11px; font-weight: 600; color: var(--fg);
     font-family: var(--font-ui);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.si-cmeta {
-    flex: 1 1 0; min-width: 0;
+.si-cmeta-row {
+    display: flex; align-items: baseline; gap: 5px;
+}
+.si-ctype {
+    font-size: 9px; color: var(--high-color); opacity: .65;
+    font-family: var(--font-editor); white-space: nowrap;
+    flex-shrink: 0;
+}
+.si-caddr {
     font-size: 9px; color: var(--addr-fg);
     font-family: var(--font-editor); white-space: nowrap;
     overflow: hidden; text-overflow: ellipsis;
@@ -291,44 +323,135 @@
 .si-card:hover .si-del-btn { opacity: 1; }
 .si-del-btn:hover { color: var(--err); }
 
+/* Type-definition preview toggle button (in si-cmeta-row) */
+.si-type-btn {
+    flex-shrink: 0; padding: 0 3px;
+    background: transparent; border: none;
+    color: var(--addr-fg); font-family: var(--font-editor);
+    font-size: 8px; cursor: pointer; border-radius: 2px;
+    opacity: 0; transition: opacity .1s, color .1s; line-height: 1;
+}
+.si-card:hover .si-type-btn { opacity: 1; }
+.si-type-btn:hover { color: var(--high-color); }
+.si-type-btn.active { opacity: 1; color: var(--high-color); }
+
+/* Edit-type button on card (✎) */
+.si-edit-type-btn {
+    flex-shrink: 0; padding: 0 3px;
+    background: transparent; border: none;
+    color: var(--addr-fg); font-size: 10px; cursor: pointer;
+    border-radius: 2px; opacity: 0; transition: opacity .1s, color .1s;
+}
+.si-card:hover .si-edit-type-btn { opacity: 1; }
+.si-edit-type-btn:hover { color: var(--high-color); }
+
+/* ＋ new-type button in add form type row */
+.si-add-type-btn {
+    flex-shrink: 0;
+    background: transparent; border: 1px solid var(--border);
+    border-radius: 3px; color: var(--addr-fg);
+    font-size: 11px; padding: 1px 5px; cursor: pointer; line-height: 1.4;
+    transition: background .1s, border-color .1s, color .1s;
+}
+.si-add-type-btn:hover { background: rgba(255,255,255,.08); border-color: var(--fg); color: var(--fg); }
+
+/* "No types yet" row in add form */
+.sa-no-types-row { gap: 8px; }
+.sa-no-types-msg { flex: 1; font-size: 10px; color: var(--addr-fg); opacity: .7; }
+
+/* Editor header row */
+.si-editor-hdr-row {
+    display: flex; align-items: center;
+    margin-bottom: 8px;
+}
+
+/* Inline struct type definition preview */
+.si-type-preview {
+    border-top: 1px dashed rgba(255,255,255,.1);
+    background: rgba(0,0,0,.15);
+    overflow-x: auto;
+}
+.si-type-preview .si-c-preview {
+    padding: 4px 8px 5px;
+    max-height: 180px; overflow-y: auto;
+}
+
+/* Packed toggle button in struct editor */
+.se-packed-btn {
+    display: inline-block; align-self: start; margin: 2px 0 4px;
+    padding: 2px 7px; border-radius: 3px;
+    font-size: 10px; font-family: var(--font-editor);
+    color: var(--addr-fg); background: transparent;
+    border: 1px solid var(--border);
+    cursor: pointer; opacity: .55; transition: opacity .1s, border-color .1s, color .1s;
+    user-select: none;
+}
+.se-packed-btn:hover { opacity: .8; border-color: var(--addr-active-fg); }
+.se-packed-btn.active {
+    opacity: 1; color: #569cd6;
+    border-color: #569cd6; background: rgba(86,156,214,.12);
+}
+
+/* Live C preview inside the struct editor */
+.se-preview {
+    border: 1px solid var(--border); border-radius: 3px;
+    background: rgba(0,0,0,.18); overflow: hidden;
+    margin-top: 2px;
+}
+.se-preview .si-c-preview { max-height: 160px; overflow-y: auto; }
+
 /* Expanded field rows */
 .si-fields {
     border-top: 1px solid var(--border);
     padding: 3px 0;
 }
-/* 5-col grid: [offset 40px] [exp-btn 16px] [name 1fr] [col1 auto] [col2 auto] */
+/* Grid: [offset 40px] [type 28px] [body flex 1fr] */
 .si-field {
     display: grid;
-    grid-template-columns: 40px 16px 1fr auto;
+    grid-template-columns: 40px 28px 1fr;
     gap: 3px; align-items: baseline;
     padding: 2px 8px;
     cursor: pointer;
     transition: background .1s;
 }
-.si-field:hover { background: var(--hover-bg); }
+.si-field:hover    { background: var(--hover-bg); }
+.si-field.si-selected { background: rgba(79,195,247,.12) !important; }
 
 .si-f-off  { font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor); }
+.si-f-type { font-size: 8px; color: var(--addr-fg); opacity: .55; font-family: var(--font-editor); white-space: nowrap; }
+
+/* name + dotted leader + value */
+.si-f-body {
+    display: flex; align-items: baseline; gap: 3px;
+    min-width: 0; overflow: hidden;
+}
 .si-f-name {
     font-size: 10px; color: var(--fg); font-family: var(--font-editor);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    flex-shrink: 1; min-width: 0;
 }
-.si-f-pri { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; text-align: right; }
-.si-f-val { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; text-align: right; }
+.si-f-lead {
+    flex: 1; min-width: 8px;
+    border-bottom: 1px dotted rgba(255,255,255,.2);
+    margin-bottom: 2px; align-self: flex-end;
+}
+.si-f-pri { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; flex-shrink: 0; }
+.si-f-val { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; flex-shrink: 0; }
 .si-f-val[data-val-type="ascii"] { color: var(--print-color); }
-.si-f-val[data-val-type="bin"]   { color: var(--fg); white-space: normal; text-align: left; }
+.si-f-val[data-val-type="bin"]   { color: var(--fg); white-space: normal; }
 .si-bit { font-family: var(--font-editor); display: inline-block; letter-spacing: 0; padding: 0 .25ch; }
 .si-bit.one  { color: var(--fg); font-weight: 700; }
 .si-bit.zero { color: var(--fg); opacity: .70; }
 .si-bin-wrap { display: inline-block; max-width: 100%; white-space: normal; }
 .si-bin-wrap br { display: block; line-height: 1.1; }
-.si-f-sec { font-size: 9px;  color: var(--addr-fg);   font-family: var(--font-editor); white-space: nowrap; text-align: right; opacity: .75; }
 .si-f-ptr { color: #e8a020 !important; font-style: italic; }
+.si-f-ptr-sym { color: var(--addr-fg); font-style: normal; opacity: .8; }
 .si-no-data { opacity: .4; }
 
-/* Array field group — same 5-col grid for alignment */
+/* Array field group — same grid for alignment */
 .si-arr-grp-hdr {
     display: grid;
-    grid-template-columns: 40px 16px 1fr auto;
+    grid-template-columns: 40px 28px 1fr;
     gap: 3px; align-items: center;
     padding: 2px 8px;
     cursor: pointer;
@@ -357,7 +480,8 @@
 .si-val-row { padding: 6px 10px; cursor: pointer; font-size: 12px; color: var(--fg); }
 .si-val-row:hover { background: var(--hover-bg); }
 .si-val-row.active { font-weight: 700; color: var(--high-color); }
-.si-arr-grp-hdr:hover { background: var(--hover-bg); }
+.si-arr-grp-hdr:hover      { background: var(--hover-bg); }
+.si-arr-grp-hdr.si-selected { background: rgba(79,195,247,.12) !important; }
 .si-arr-exp-btn {
     width: 16px; height: 16px;
     display: flex; align-items: center; justify-content: center;
@@ -366,21 +490,6 @@
 }
 .si-arr-addr {
     font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor);
-    white-space: nowrap; text-align: right;
+    white-space: nowrap; flex-shrink: 0;
 }
 .si-arr-grp-body .si-field { padding-left: 16px; }
-
-/* Column type config row */
-.si-colcfg {
-    display: flex; align-items: center; gap: 4px;
-    padding: 3px 8px 4px;
-    border-bottom: 1px solid var(--border);
-}
-.si-colcfg-lbl {
-    font-size: 9px; color: var(--addr-fg); white-space: nowrap;
-}
-.si-colcfg-sel {
-    font-size: 9px; background: var(--input-bg); color: var(--fg);
-    border: 1px solid var(--border); border-radius: 2px;
-    padding: 1px 2px; cursor: pointer; flex: 1; min-width: 0;
-}

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -384,6 +384,7 @@
     color: var(--addr-fg); background: transparent;
     border: 1px solid var(--border);
     cursor: pointer; opacity: .55; transition: opacity .1s, border-color .1s, color .1s;
+    -webkit-user-select: none;
     user-select: none;
 }
 .se-packed-btn:hover { opacity: .8; border-color: var(--addr-active-fg); }

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -1,4 +1,13 @@
-﻿/* ── Struct Overlay sidebar panel ────────────────────────────── */
+﻿.ctx-array-note {
+    padding: 6px 12px 0 12px;
+    font-size: 12px;
+    color: var(--addr-fg);
+    white-space: nowrap;
+    line-height: 1.4;
+    font-family: var(--font-ui);
+    font-style: italic;
+}
+/* ── Struct Overlay sidebar panel ────────────────────────────── */
 
 /* Shared layout tokens */
 .struct-addr-pfx {
@@ -290,7 +299,7 @@
 /* 5-col grid: [offset 40px] [exp-btn 16px] [name 1fr] [col1 auto] [col2 auto] */
 .si-field {
     display: grid;
-    grid-template-columns: 40px 16px 1fr auto auto;
+    grid-template-columns: 40px 16px 1fr auto;
     gap: 3px; align-items: baseline;
     padding: 2px 8px;
     cursor: pointer;
@@ -304,6 +313,14 @@
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .si-f-pri { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; text-align: right; }
+.si-f-val { font-size: 10px; color: var(--high-color); font-family: var(--font-editor); white-space: nowrap; text-align: right; }
+.si-f-val[data-val-type="ascii"] { color: var(--print-color); }
+.si-f-val[data-val-type="bin"]   { color: var(--fg); white-space: normal; text-align: left; }
+.si-bit { font-family: var(--font-editor); display: inline-block; letter-spacing: 0; padding: 0 .25ch; }
+.si-bit.one  { color: var(--fg); font-weight: 700; }
+.si-bit.zero { color: var(--fg); opacity: .70; }
+.si-bin-wrap { display: inline-block; max-width: 100%; white-space: normal; }
+.si-bin-wrap br { display: block; line-height: 1.1; }
 .si-f-sec { font-size: 9px;  color: var(--addr-fg);   font-family: var(--font-editor); white-space: nowrap; text-align: right; opacity: .75; }
 .si-f-ptr { color: #e8a020 !important; font-style: italic; }
 .si-no-data { opacity: .4; }
@@ -311,13 +328,35 @@
 /* Array field group — same 5-col grid for alignment */
 .si-arr-grp-hdr {
     display: grid;
-    grid-template-columns: 40px 16px 1fr auto auto;
+    grid-template-columns: 40px 16px 1fr auto;
     gap: 3px; align-items: center;
     padding: 2px 8px;
     cursor: pointer;
     transition: background .1s;
     border-top: 1px solid rgba(255,255,255,.05);
 }
+
+/* per-field value-type menu */
+.si-val-menu {
+    position: fixed; z-index: 9999; background: var(--panel-bg);
+    border: 1px solid var(--border); border-radius: 4px; padding: 4px;
+    box-shadow: 0 6px 18px rgba(0,0,0,.6);
+    min-width: 260px;
+    max-width: 340px;
+    word-break: break-word;
+}
+.si-val-menu .ctx-hint {
+    display: block;
+    padding: 6px 12px 0 12px;
+    font-size: 12px;
+    color: var(--addr-fg);
+    white-space: normal;
+    line-height: 1.4;
+    word-break: break-word;
+}
+.si-val-row { padding: 6px 10px; cursor: pointer; font-size: 12px; color: var(--fg); }
+.si-val-row:hover { background: var(--hover-bg); }
+.si-val-row.active { font-weight: 700; color: var(--high-color); }
 .si-arr-grp-hdr:hover { background: var(--hover-bg); }
 .si-arr-exp-btn {
     width: 16px; height: 16px;
@@ -325,7 +364,7 @@
     background: transparent; border: none; padding: 0;
     color: var(--addr-fg); font-size: 12px; cursor: pointer; line-height: 1;
 }
-.si-arr-count {
+.si-arr-addr {
     font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor);
     white-space: nowrap; text-align: right;
 }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -33,11 +33,11 @@ const _expanded = new Set<string>();
 /** Array field groups that are expanded. Key: `${pinId}::${baseName}`. Collapsed by default. */
 const _expandedArrayFields = new Set<string>();
 
-type ColType = 'hex' | 'dec' | 'ascii';
-/** Display type for value column 1 (always shown). Default: hex. */
-let _col1Type: ColType = 'hex';
-/** Display type for value column 2. 'none' means hidden. Default: none. */
-let _col2Type: ColType | 'none' = 'none';
+type ColType = 'hex' | 'dec' | 'ascii' | 'bin';
+/** Default display type for value cells (per-field default). */
+let _defaultValType: ColType = 'hex';
+/** Per-field display override keyed by absolute byte-start address. */
+const _fieldValTypes = new Map<number, ColType>();
 /** Whether the inline add-instance form is open. */
 let _addingPin = false;
 
@@ -311,21 +311,6 @@ export function renderStructPins(): void {
         `<button id="si-add-btn" class="si-add-btn"${!hasStructs || _addingPin ? ' disabled' : ''}>＋ Add</button>` +
         `</div>` +
         addFormHtml +
-        `<div class="si-colcfg">` +
-        `<span class="si-colcfg-lbl">Col 1</span>` +
-        `<select id="si-col1-sel" class="si-colcfg-sel">` +
-        `<option value="hex"${_col1Type==='hex'?' selected':''}>hex</option>` +
-        `<option value="dec"${_col1Type==='dec'?' selected':''}>dec</option>` +
-        `<option value="ascii"${_col1Type==='ascii'?' selected':''}>ascii</option>` +
-        `</select>` +
-        `<span class="si-colcfg-lbl">Col 2</span>` +
-        `<select id="si-col2-sel" class="si-colcfg-sel">` +
-        `<option value="none"${_col2Type==='none'?' selected':''}>—</option>` +
-        `<option value="hex"${_col2Type==='hex'?' selected':''}>hex</option>` +
-        `<option value="dec"${_col2Type==='dec'?' selected':''}>dec</option>` +
-        `<option value="ascii"${_col2Type==='ascii'?' selected':''}>ascii</option>` +
-        `</select>` +
-        `</div>` +
         `<div id="si-list">${instHtml}</div>`;
 
     // ── ＋ Add button ──
@@ -380,14 +365,7 @@ export function renderStructPins(): void {
         if (_expanded.size > 0) { renderStructPins(); }
     });
 
-    document.getElementById('si-col1-sel')?.addEventListener('change', e => {
-        _col1Type = (e.target as HTMLSelectElement).value as ColType;
-        renderStructPins();
-    });
-    document.getElementById('si-col2-sel')?.addEventListener('change', e => {
-        _col2Type = (e.target as HTMLSelectElement).value as ColType | 'none';
-        renderStructPins();
-    });
+    // Per-field value type is handled via right-click menu on individual values.
 
     wireInstanceCards(sec);
 }
@@ -401,13 +379,34 @@ function getValForType(r: DecodedField, valType: ColType): string {
     bytes.forEach((b, i) => dv.setUint8(i, b));
     const le    = S.endian === 'le';
     const hexFn = (v: number, pad: number) => `0x${(v >>> 0).toString(16).toUpperCase().padStart(pad, '0')}`;
+    const binFn = () => {
+        // Continuous bit string (MSB-first per byte), grouped into 4-bit nibbles.
+        const bitSeq = bytes.map(b => b.toString(2).padStart(8, '0')).join('');
+        const groups = bitSeq.match(/.{1,4}/g) || [];
+        const renderGroups = (grps: string[]) => grps.map(g =>
+            [...g].map(bit => `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}">${bit}</span>`).join('')
+        ).join(' ');
+
+        // Full HTML broken into lines of max 16 bits (4 nibbles) per line.
+        const groupsPerLine = 4; // 4 nibbles = 16 bits
+        const lines: string[] = [];
+        for (let i = 0; i < groups.length; i += groupsPerLine) {
+            lines.push(renderGroups(groups.slice(i, i + groupsPerLine)));
+        }
+        const fullHtml = lines.join('<br>');
+
+        // Always return the full, multi-line binary HTML.
+        return `<span class="si-bin-wrap">${fullHtml}</span>`;
+    };
     // Pointer always renders as arrow + hex address regardless of valType
     if (r.type === 'pointer') {
         const v = dv.getUint32(0, le) >>> 0;
-        return `\u2192 0x${v.toString(16).toUpperCase().padStart(8, '0')}`;
+        return `0x${v.toString(16).toUpperCase().padStart(8, '0')} \u2192`;
     }
+    if (valType === 'bin') { return binFn(); }
     if (valType === 'ascii') {
-        return bytes.map(b => b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : '.').join('');
+        const s = bytes.map(b => b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : '.').join('');
+        return `'${s}'`;
     }
     switch (r.type) {
         case 'uint8':  { const v = dv.getUint8(0);              return valType === 'hex' ? hexFn(v, 2) : String(v); }
@@ -432,20 +431,67 @@ function getValForType(r: DecodedField, valType: ColType): string {
     }
 }
 
+/** Get a plain-text representation suitable for copying. */
+function getCopyText(r: DecodedField, valType: ColType): string {
+    if (!r.hasData) { return '??'; }
+    const bytes = r.bytesHex.split(' ').map(h => parseInt(h, 16));
+    const le    = S.endian === 'le';
+    const hexPad = (v: number, pad: number) => `0x${(v >>> 0).toString(16).toUpperCase().padStart(pad, '0')}`;
+    if (r.type === 'pointer') {
+        const buf = new ArrayBuffer(bytes.length);
+        const dv = new DataView(buf);
+        bytes.forEach((b, i) => dv.setUint8(i, b));
+        const v = dv.getUint32(0, le) >>> 0;
+        return hexPad(v, 8);
+    }
+    if (valType === 'bin') {
+        const bitSeq = bytes.map(b => b.toString(2).padStart(8, '0')).join('');
+        const groups = bitSeq.match(/.{1,4}/g) || [];
+        return groups.join(' ');
+    }
+    if (valType === 'ascii') {
+        return bytes.map(b => (b >= 0x20 && b < 0x7f) ? String.fromCharCode(b) : '.').join('');
+    }
+    const buf = new ArrayBuffer(bytes.length);
+    const dv = new DataView(buf);
+    bytes.forEach((b, i) => dv.setUint8(i, b));
+    switch (r.type) {
+        case 'uint8':  { const v = dv.getUint8(0);              return valType === 'hex' ? hexPad(v, 2) : String(v); }
+        case 'int8':   { const v = dv.getInt8(0);               return valType === 'hex' ? hexPad(dv.getUint8(0), 2) : String(v); }
+        case 'uint16': { const v = dv.getUint16(0, le);         return valType === 'hex' ? hexPad(v, 4) : String(v); }
+        case 'int16':  { const v = dv.getInt16(0, le);          return valType === 'hex' ? hexPad(dv.getUint16(0, le), 4) : String(v); }
+        case 'uint32': { const v = dv.getUint32(0, le) >>> 0;   return valType === 'hex' ? hexPad(v, 8) : String(v); }
+        case 'int32':  { const v = dv.getInt32(0, le);          return valType === 'hex' ? hexPad(dv.getUint32(0, le), 8) : String(v); }
+        case 'float32': {
+            const v = dv.getFloat32(0, le);
+            return valType === 'hex'
+                ? bytes.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join('')
+                : isNaN(v) ? 'NaN' : !isFinite(v) ? String(v) : parseFloat(v.toPrecision(7)).toString();
+        }
+        case 'float64': {
+            const v = dv.getFloat64(0, le);
+            return valType === 'hex'
+                ? bytes.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join('')
+                : isNaN(v) ? 'NaN' : !isFinite(v) ? String(v) : parseFloat(v.toPrecision(10)).toString();
+        }
+        default: return r.decoded;
+    }
+}
+
 /** Build a single field row (5-col grid) for scalar fields and array elements. */
 function mkFieldRow(r: DecodedField, bs: number, bc: number): string {
     const nd  = !r.hasData ? ' si-no-data' : '';
     const ptr = r.type === 'pointer';
-    const v1  = getValForType(r, _col1Type);
-    const v2  = _col2Type !== 'none' ? getValForType(r, _col2Type) : '';
+    const t   = _fieldValTypes.get(bs) ?? _defaultValType;
+    const v   = getValForType(r, t);
+    const valHtml = t === 'bin' ? v : esc(v);
     return (
         `<div class="si-field${nd}${ptr ? ' si-ptr-field' : ''}" ` +
         `data-byte-start="${bs}" data-byte-cnt="${bc}">` +
         `<span class="si-f-off">+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
         `<span></span>` +
         `<span class="si-f-name">${esc(r.fieldName)}</span>` +
-        `<span class="si-f-pri${ptr ? ' si-f-ptr' : ''}">${esc(v1)}</span>` +
-        `<span class="si-f-sec">${esc(v2)}</span>` +
+        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${bs}">${valHtml}</span>` +
         `</div>`
     );
 }
@@ -483,6 +529,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const byteStart = pin.addr + r0.byteOffset;
                 const totalCnt  = g.rows.reduce((s, r) => s + fieldByteSize(r.type), 0);
                 const elHtml  = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, fieldByteSize(r.type))).join('');
+                // Show address of first element like a pointer (0xXXXXXXXX)
+                const addrHex = byteStart.toString(16).toUpperCase().padStart(8, '0');
                 return (
                     `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
                     `<div class="si-arr-grp-hdr" ` +
@@ -490,10 +538,10 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                     `<span class="si-f-off">+${r0.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
                     `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
                     `<span class="si-f-name">${esc(g.baseName)}</span>` +
-                    `<span class="si-arr-count">[${g.rows.length}]</span>` +
+                    `<span class="si-arr-addr">0x${addrHex}</span>` +
                     `<span></span>` +
                     `</div>` +
-                    `<div class="si-arr-grp-body"${isOpen ? '' : ' style="display:none"'}>${elHtml}</div>` +
+                    `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
                     `</div>`
                 );
             }
@@ -617,6 +665,264 @@ function wireInstanceCards(sec: HTMLElement): void {
             S.selEnd   = start + cnt - 1;
             import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
             import('./sidebar.js').then(m => m.updateInspector());
+        });
+    });
+
+    // Right-click on a field row to open the value menu. Pass the pin index
+    // so the menu can decode values when performing copy actions.
+    sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
+        row.addEventListener('contextmenu', ev => {
+            ev.preventDefault(); ev.stopPropagation();
+            const start = parseInt(row.dataset.byteStart!);
+            const card = row.closest<HTMLElement>('.si-card');
+            const pinIdx = card ? parseInt(card.dataset.idx!) : -1;
+            // Determine if this is a pointer field
+            const valCell = row.querySelector<HTMLElement>('.si-f-val');
+            const isPointer = valCell?.classList.contains('si-f-ptr');
+            // Only allow per-element change, not group, for array elements
+            showFieldValMenu(ev.clientX, ev.clientY, start, undefined, pinIdx, { isPointer });
+        });
+    });
+
+    // Right-click on an array group header should allow actions on the
+    // entire group (child elements).
+    sec.querySelectorAll<HTMLElement>('.si-arr-grp-hdr').forEach(hdr => {
+        hdr.addEventListener('contextmenu', ev => {
+            ev.preventDefault(); ev.stopPropagation();
+            const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
+            const bsList = Array.from(grp.querySelectorAll<HTMLElement>('.si-field'))
+                .map(r => parseInt(r.dataset.byteStart!));
+            const card = hdr.closest<HTMLElement>('.si-card');
+            const pinIdx = card ? parseInt(card.dataset.idx!) : -1;
+            const start = bsList[0];
+            showFieldValMenu(ev.clientX, ev.clientY, start, bsList, pinIdx, { isArrayHeader: true });
+        });
+    });
+}
+
+// Floating per-field value-type menu
+let _valMenuEl: HTMLElement | null = null;
+function hideFieldValMenu(): void {
+    if (_valMenuEl) { _valMenuEl.remove(); _valMenuEl = null; }
+    document.removeEventListener('click', hideFieldValMenu);
+}
+function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], pinIdx?: number, opts?: { isPointer?: boolean, isArrayHeader?: boolean }): void {
+    hideFieldValMenu();
+    const types: ColType[] = ['hex', 'dec', 'bin', 'ascii'];
+    let cur: ColType | null = null;
+    if (bsList && bsList.length > 0) {
+        const vals = bsList.map(b => _fieldValTypes.get(b) ?? _defaultValType);
+        const allSame = vals.every(v => v === vals[0]);
+        cur = allSame ? (vals[0] as ColType) : null;
+    } else {
+        cur = _fieldValTypes.get(bs) ?? _defaultValType;
+    }
+
+    // Helpers for menu
+    const item = (cmd: string, label: string, hint = '') =>
+        `<div class="ctx-row" data-cmd="${cmd}">` +
+        `<span class="ctx-label">${esc(label)}</span>` +
+        (hint ? `<span class="ctx-hint">${esc(hint)}</span>` : '') +
+        `</div>`;
+    const sep = `<div class="ctx-sep"></div>`;
+    const sub = (label: string, id: string, body: string) =>
+        `<div class="ctx-row ctx-has-sub" data-sub="${id}">` +
+        `<span class="ctx-label">${esc(label)}</span>` +
+        `<div class="ctx-submenu">${body}</div>` +
+        `</div>`;
+
+    // Pointer: only allow copy address value
+    if (opts?.isPointer) {
+        const el = document.createElement('div');
+        el.id = 'si-val-menu'; el.className = 'si-val-menu ctx-menu';
+        el.innerHTML = item('copy-hex', 'Copy value');
+        document.body.appendChild(el);
+        const mw = el.offsetWidth || 180; const mh = el.offsetHeight || 60;
+        el.style.left = `${Math.min(x, window.innerWidth - mw - 8)}px`;
+        el.style.top  = `${Math.min(y, window.innerHeight - mh - 8)}px`;
+        el.querySelectorAll<HTMLElement>('.ctx-row[data-cmd]').forEach(row => {
+            row.addEventListener('click', ev => {
+                ev.stopPropagation();
+                // Always copy as hex address
+                let pin: StructPin | undefined;
+                const all = allStructs();
+                if (typeof pinIdx === 'number' && pinIdx >= 0) {
+                    pin = S.structPins[pinIdx];
+                } else {
+                    pin = S.structPins.find(p => {
+                        const def = all.find(d => d.id === p.structId);
+                        if (!def) { return false; }
+                        const size = structByteSize(def);
+                        return bs >= p.addr && bs < p.addr + size;
+                    });
+                }
+                if (!pin) { hideFieldValMenu(); return; }
+                const def = all.find(d => d.id === pin!.structId);
+                if (!def) { hideFieldValMenu(); return; }
+                const rows = decodeStruct(def, pin.addr, S.flatBytes, S.endian);
+                const r = rows.find(rr => pin!.addr + rr.byteOffset === bs);
+                const toCopy = r ? getCopyText(r, 'hex') : '??';
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(toCopy).catch(() => {
+                        const ta = document.createElement('textarea');
+                        ta.value = toCopy; document.body.appendChild(ta); ta.select();
+                        document.execCommand('copy'); ta.remove();
+                    });
+                } else {
+                    const ta = document.createElement('textarea');
+                    ta.value = toCopy; document.body.appendChild(ta); ta.select();
+                    document.execCommand('copy'); ta.remove();
+                }
+                hideFieldValMenu();
+                return;
+            });
+        });
+        setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+        _valMenuEl = el;
+        return;
+    }
+
+    // Copy submenu
+    const copyMenu =
+        item('copy-hex',   'Hex',   '') +
+        item('copy-dec',   'Decimal', '') +
+        item('copy-bin',   'Binary', '') +
+        item('copy-ascii', 'ASCII',  '');
+
+    // Display type submenu
+    const dispMenu = types.map(t =>
+        `<div class="ctx-row${t===cur ? ' active' : ''}" data-cmd="disp-${t}">` +
+        `<span class="ctx-label">${t}</span>` +
+        `</div>`
+    ).join('');
+    // For array header, show a different note (single line, no wrap, custom class)
+    const note = opts?.isArrayHeader
+        ? `<div class="ctx-array-note">apply to all array elements</div>`
+        : '';
+
+    // Compose menu
+    const el = document.createElement('div');
+    el.id = 'si-val-menu'; el.className = 'si-val-menu ctx-menu';
+    el.innerHTML =
+        sub('Copy', 'copy', copyMenu) +
+        sep +
+        sub('Change display type', 'disp', dispMenu) +
+        note;
+
+    document.body.appendChild(el);
+    const mw = el.offsetWidth || 220; const mh = el.offsetHeight || 120;
+    el.style.left = `${Math.min(x, window.innerWidth - mw - 8)}px`;
+    el.style.top  = `${Math.min(y, window.innerHeight - mh - 8)}px`;
+
+    // Wire leaf-item clicks
+    el.querySelectorAll<HTMLElement>('.ctx-row[data-cmd]').forEach(row => {
+        row.addEventListener('click', ev => {
+            ev.stopPropagation();
+            const cmd = row.dataset.cmd!;
+            // Copy actions
+            if (cmd.startsWith('copy-')) {
+                const t = cmd.replace('copy-', '') as ColType;
+                let pin: StructPin | undefined;
+                const all = allStructs();
+                if (typeof pinIdx === 'number' && pinIdx >= 0) {
+                    pin = S.structPins[pinIdx];
+                } else {
+                    pin = S.structPins.find(p => {
+                        const def = all.find(d => d.id === p.structId);
+                        if (!def) { return false; }
+                        const size = structByteSize(def);
+                        return bs >= p.addr && bs < p.addr + size;
+                    });
+                }
+                if (!pin) { hideFieldValMenu(); return; }
+                const def = all.find(d => d.id === pin!.structId);
+                if (!def) { hideFieldValMenu(); return; }
+                const rows = decodeStruct(def, pin.addr, S.flatBytes, S.endian);
+                const toCopy = (bsList && bsList.length > 0)
+                    ? bsList.map(b => {
+                        const r = rows.find(rr => pin!.addr + rr.byteOffset === b);
+                        return r ? getCopyText(r, t) : '??';
+                      }).join('\n')
+                    : (() => {
+                        const r = rows.find(rr => pin!.addr + rr.byteOffset === bs);
+                        return r ? getCopyText(r, t) : '??';
+                      })();
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(toCopy).catch(() => {
+                        const ta = document.createElement('textarea');
+                        ta.value = toCopy; document.body.appendChild(ta); ta.select();
+                        document.execCommand('copy'); ta.remove();
+                    });
+                } else {
+                    const ta = document.createElement('textarea');
+                    ta.value = toCopy; document.body.appendChild(ta); ta.select();
+                    document.execCommand('copy'); ta.remove();
+                }
+                hideFieldValMenu();
+                return;
+            }
+            // Display type actions
+            if (cmd.startsWith('disp-')) {
+                const t = cmd.replace('disp-', '') as ColType;
+                // Only allow group change from array header, not from element
+                if (opts?.isArrayHeader && bsList && bsList.length > 0) {
+                    bsList.forEach(b => {
+                        if (t === _defaultValType) { _fieldValTypes.delete(b); }
+                        else { _fieldValTypes.set(b, t); }
+                    });
+                } else {
+                    if (t === _defaultValType) { _fieldValTypes.delete(bs); }
+                    else { _fieldValTypes.set(bs, t); }
+                }
+                hideFieldValMenu();
+                renderStructPins();
+                return;
+            }
+        });
+    });
+
+    // Wire submenus (hover logic)
+    wireStructSubmenus(el);
+
+    // Hide when clicking outside
+    setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+    _valMenuEl = el;
+}
+function wireStructSubmenus(menuEl: HTMLElement): void {
+    let closeTimer: ReturnType<typeof setTimeout> | null = null;
+    let activeSub: HTMLElement | null = null;
+    const openSub = (sub: HTMLElement, row: HTMLElement) => {
+        if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+        if (activeSub && activeSub !== sub) { activeSub.style.display = 'none'; }
+        activeSub = sub;
+        sub.style.display = 'block';
+        // Viewport edge: flip left if no room on right
+        const rr = row.getBoundingClientRect();
+        const sw = sub.offsetWidth || 220;
+        if (rr.right + sw > window.innerWidth - 8) {
+            sub.style.left = 'auto'; sub.style.right = '100%';
+        } else {
+            sub.style.left = '100%'; sub.style.right = 'auto';
+        }
+    };
+    const scheduledClose = (sub: HTMLElement) => {
+        closeTimer = setTimeout(() => {
+            sub.style.display = 'none';
+            if (activeSub === sub) { activeSub = null; }
+        }, 100);
+    };
+    menuEl.querySelectorAll<HTMLElement>('.ctx-has-sub').forEach(row => {
+        const sub = row.querySelector<HTMLElement>('.ctx-submenu');
+        if (!sub) { return; }
+        row.addEventListener('mouseenter', () => openSub(sub, row));
+        row.addEventListener('mouseleave', e => {
+            if (!sub.contains(e.relatedTarget as Node)) { scheduledClose(sub); }
+        });
+        sub.addEventListener('mouseenter', () => {
+            if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+        });
+        sub.addEventListener('mouseleave', e => {
+            if (!row.contains(e.relatedTarget as Node)) { scheduledClose(sub); }
         });
     });
 }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1,7 +1,6 @@
 ﻿// ── Struct Overlay — UI layer ─────────────────────────────────────
-// Two sections rendered into separate DOM containers:
-//   #s-struct      — struct type definitions (create / edit / delete)
-//   #s-struct-pins — apply panel + saved instances (expandable decoded cards)
+// Single section rendered into #s-struct-pins.
+// Type management (create / edit / delete) is inline within that section.
 // Pure codec logic lives in struct-codec.ts.
 
 import { S }        from './state';
@@ -11,7 +10,7 @@ import { rerender } from './render';
 import {
     FIELD_TYPES,
     fieldByteSize, structByteSize, decodeStruct, allStructs,
-    parseStructText, fieldsToText,
+    parseStructText, fieldsToText, structToC,
 } from './struct-codec.js';
 import type { DecodedField } from './struct-codec.js';
 import type { StructDef, StructFieldType, StructPin } from './types';
@@ -19,14 +18,14 @@ import type { StructDef, StructFieldType, StructPin } from './types';
 // Re-export codec symbols so callers can import from a single path.
 export {
     FIELD_TYPES, TYPE_TO_C,
-    fieldByteSize, structByteSize, decodeStruct, allStructs,
-    parseStructText, fieldsToText,
+    fieldByteSize, fieldAlignment, structByteSize, decodeStruct, allStructs,
+    parseStructText, fieldsToText, structToC,
 } from './struct-codec.js';
 export type { DecodedField, ParseStructTextResult } from './struct-codec.js';
 
 // ── Module state ──────────────────────────────────────────────────
 
-/** Struct id currently selected in the apply panel. */
+/** Struct id currently selected in the add form. */
 let _applyStructId: string | null = null;
 /** Set of instance card ids that are expanded. */
 const _expanded = new Set<string>();
@@ -40,107 +39,118 @@ let _defaultValType: ColType = 'hex';
 const _fieldValTypes = new Map<number, ColType>();
 /** Whether the inline add-instance form is open. */
 let _addingPin = false;
+/** Byte start address of the currently highlighted field row. */
+let _selectedFieldAddr: number | null = null;
+/** Array group key of the currently highlighted array header. */
+let _selectedArrKey: string | null = null;
+/** Byte start addresses marked with struct-arr-sep in the hex view. */
+const _arrSepAddrs: number[] = [];
+/** Pin id of the currently selected instance card. */
+let _selectedPinId: string | null = null;
+/** Pins whose type-definition preview is open inside the card. */
+const _previewedPins = new Set<string>();
+/**
+ * When non-null the section is in "type editor" mode.
+ * `existing` is null for new types, or the original def being edited.
+ * `draft`    holds the working copy being modified.
+ * `fromAdd`  is true when the editor was opened from the add-instance form.
+ */
+let _editingType: { draft: StructDef; existing: StructDef | null; fromAdd: boolean } | null = null;
 
-// ══════════════════════════════════════════════════════════════════
-// SECTION 1 — Struct Type Definitions  (#s-struct)
-// ══════════════════════════════════════════════════════════════════
+// ── Inline type editor helpers ────────────────────────────────────
 
-export function renderStructPanel(): void {
-    const sec = document.getElementById('s-struct');
-    if (!sec) { return; }
-
-    const badge = S.structs.length > 0
-        ? `<span class="sb-badge">${S.structs.length}</span>` : '';
-
-    const listHtml = S.structs.length === 0
-        ? `<div class="sb-empty sd-empty">No struct types yet.</div>`
-        : S.structs.map(def => {
-            const sz = structByteSize(def);
-            return (
-                `<div class="sd-row">` +
-                `<span class="sd-name">${esc(def.name)}</span>` +
-                `<span class="sd-meta">${def.fields.length}f · ${sz}B</span>` +
-                `<button class="sd-btn sd-edit" data-id="${esc(def.id)}" title="Edit">✎</button>` +
-                `<button class="sd-btn sd-del"  data-id="${esc(def.id)}" title="Delete">✕</button>` +
-                `</div>`
-            );
-        }).join('');
-
-    sec.innerHTML =
-        `<div class="sb-hdr-row">` +
-        `<span class="sb-hdr">Struct Types ${badge}</span>` +
-        `<button id="sd-new" class="struct-btn struct-btn-secondary">+ New</button>` +
-        `</div>` +
-        `<div id="sd-list">${listHtml}</div>`;
-
-    document.getElementById('sd-new')!.addEventListener('click', () => {
-        renderStructEditor(null);
-    });
-
-    sec.querySelectorAll<HTMLElement>('.sd-edit').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const def = S.structs.find(d => d.id === btn.dataset.id) ?? null;
-            renderStructEditor(def);
-        });
-    });
-
-    sec.querySelectorAll<HTMLElement>('.sd-del').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const id = btn.dataset.id!;
-            S.structs    = S.structs.filter(d => d.id !== id);
-            S.structPins = S.structPins.filter(p => p.structId !== id);
-            if (_applyStructId === id) { _applyStructId = null; }
-            vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
-            vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
-            renderStructPanel();
-            renderStructPins();
-        });
-    });
+function sanitizeCIdent(raw: string): string {
+    return raw.replace(/[^A-Za-z0-9_]/g, '').replace(/^(\d)/, '_$1');
 }
 
-// ── Struct form editor (form-only) ────────────────────────────────
-
-export function renderStructEditor(existing: StructDef | null): void {
-    const sec = document.getElementById('s-struct');
-    if (!sec) { return; }
-
-    const draftId = existing?.id ?? `user_${Date.now()}`;
-    const draft: StructDef = existing
-        ? { id: draftId, name: existing.name, fields: existing.fields.map(f => ({ ...f })) }
-        : { id: draftId, name: '', fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] };
-
-    renderEditorInto(sec, draft, existing);
-}
-
-function fieldRowHtml(f: import('./types').StructField, i: number, isOnly: boolean): string {
+function fieldRowHtml(f: import('./types').StructField, i: number, isOnly: boolean, total: number): string {
     const typeOpts = FIELD_TYPES.map(t =>
-        `<option value="${t}" ${f.type === t ? 'selected' : ''}>${t}</option>`
+        `<option value="${t}"${f.type === t ? ' selected' : ''}>${t}</option>`
     ).join('');
     const isArr = f.count > 1;
     const delCell = isOnly
         ? `<span class="sfe-del-placeholder"></span>`
-        : `<button class="sfe-del-btn" title="Remove field">✕</button>`;
+        : `<button class="sfe-del-btn" title="Remove field">\u2715</button>`;
+    const upDis  = i === 0         ? ' disabled' : '';
+    const dnDis  = i === total - 1 ? ' disabled' : '';
     return (
         `<div class="struct-field-row" data-idx="${i}">` +
         `<select class="sfe-type-sel">${typeOpts}</select>` +
-        `<input  class="sfe-name-inp" type="text" value="${esc(f.name)}" maxlength="64" ` +
-                `placeholder="fieldName" spellcheck="false" autocomplete="off">` +
+        `<input class="sfe-name-inp" type="text" value="${esc(f.name)}" maxlength="64" ` +
+               `placeholder="fieldName" spellcheck="false" autocomplete="off">` +
         `<div class="sfe-arr-cell${isArr ? ' is-array' : ''}">` +
         `<button class="sfe-arr-toggle${isArr ? ' active' : ''}" title="${isArr ? 'Remove array' : 'Make array'}">[ ]</button>` +
-        `<input  class="sfe-count-inp" type="text" inputmode="numeric" ` +
-                `value="${isArr ? f.count : ''}" placeholder="N" maxlength="3">` +
+        `<input class="sfe-count-inp" type="text" inputmode="numeric" ` +
+               `value="${isArr ? f.count : ''}" placeholder="N" maxlength="3">` +
+        `</div>` +
+        `<div class="sfe-move-btns">` +
+        `<button class="sfe-move-btn sfe-move-up" title="Move up"${upDis}>&#x2192;</button>` +
+        `<button class="sfe-move-btn sfe-move-dn" title="Move down"${dnDis}>&#x2192;</button>` +
         `</div>` +
         delCell +
         `</div>`
     );
 }
 
-function sanitizeCIdent(raw: string): string {
-    return raw.replace(/[^A-Za-z0-9_]/g, '').replace(/^(\d)/, '_$1');
+// ── C syntax-highlighted HTML from a struct definition ──────────────────────
+
+const SC_KW   = /\b(typedef|struct)\b/g;
+const SC_ATTR = /__attribute__\(\(packed\)\)/g;
+
+function structToCHtml(def: StructDef): string {
+    const nameEscRe = def.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const scTyp = new RegExp(
+        `\\b(uint8_t|uint16_t|uint32_t|uint64_t|int8_t|int16_t|int32_t|int64_t|float|double|${nameEscRe})\\b`,
+        'g'
+    );
+    return structToC(def).split('\n').map(line => {
+        const ci = line.indexOf('/*');
+        const code = ci >= 0 ? line.slice(0, ci) : line;
+        const cmt  = ci >= 0 ? line.slice(ci) : '';
+        const isPad = /\b_pad\w+/.test(code);
+        let h = esc(code);
+        if (isPad) {
+            const n = code.match(/_pad\w+\[(\d+)\]/)?.[1] ?? '?';
+            const indent = esc(line.slice(0, line.length - line.trimStart().length));
+            return `${indent}<span class="sc-cmt">/* ${n} byte${n === '1' ? '' : 's'} padding */</span>`;
+        }
+        h = h.replace(SC_KW,   '<span class="sc-kw">$&</span>');
+        h = h.replace(SC_ATTR, '<span class="sc-attr">$&</span>');
+        h = h.replace(scTyp,   '<span class="sc-type">$&</span>');
+        return h + (cmt ? `<span class="sc-cmt">${esc(cmt)}</span>` : '');
+    }).join('\n');
 }
 
-function syncDraftFields(sec: HTMLElement, draft: StructDef): void {
-    draft.name = (document.getElementById('se-name') as HTMLInputElement)?.value.trim() || draft.name;
+function editorHtml(draft: StructDef, existing: StructDef | null): string {
+    const n = draft.fields.length;
+    const fieldRows = draft.fields.map((f, i) => fieldRowHtml(f, i, n === 1, n)).join('');
+    return (
+        `<div class="si-editor-wrap">` +
+        `<div class="si-editor-hdr-row">` +
+        `<span class="sb-hdr" style="margin:0">${existing ? 'Edit Type' : 'New Type'}</span>` +
+        `</div>` +
+        `<div class="se-form">` +
+        `<input id="se-name" class="se-name-inp" type="text" value="${esc(draft.name)}" ` +
+               `maxlength="64" placeholder="TypeName" spellcheck="false" autocomplete="off">` +
+        `<button id="se-packed" class="se-packed-btn${draft.packed ? ' active' : ''}" ` +
+               `title="Toggle packed struct">__attribute__((packed))</button>` +
+        `<div class="se-field-hdr"><span>Type</span><span>Name</span><span>[ ]</span><span></span></div>` +
+        `<div id="se-fields">${fieldRows}</div>` +
+        `<button id="se-add" class="struct-add-field-btn">+ Add Field</button>` +
+        `<div class="se-btns">` +
+        `<button id="se-save" class="struct-btn struct-btn-apply">Save</button>` +
+        `<button id="se-cancel" class="struct-btn struct-btn-secondary">Cancel</button>` +
+        (existing ? `<button id="se-delete" class="struct-btn struct-btn-danger">Delete type</button>` : '') +
+        `</div>` +
+        `<div id="se-preview" class="se-preview"><pre class="si-c-preview">${structToCHtml(draft)}</pre></div>` +
+        `</div>` +
+        `</div>`
+    );
+}
+
+function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
+    draft.name   = (sec.querySelector<HTMLInputElement>('#se-name'))?.value.trim() || draft.name;
+    draft.packed = sec.querySelector('#se-packed')?.classList.contains('active') ?? false;
     const rows = sec.querySelectorAll<HTMLElement>('.struct-field-row');
     draft.fields = Array.from(rows).map(row => ({
         name:   sanitizeCIdent((row.querySelector('.sfe-name-inp') as HTMLInputElement).value) || 'field',
@@ -155,43 +165,58 @@ function syncDraftFields(sec: HTMLElement, draft: StructDef): void {
     }));
 }
 
-function renderEditorInto(sec: HTMLElement, draft: StructDef, existing: StructDef | null): void {
-    const n = draft.fields.length;
-    const fieldRows = draft.fields.map((f, i) => fieldRowHtml(f, i, n === 1)).join('');
+function wireEditorInSec(sec: HTMLElement): void {
+    if (!_editingType) { return; }
+    const { draft, existing } = _editingType;
 
-    sec.innerHTML =
-        `<div class="sb-hdr">${existing ? 'Edit Struct' : 'New Struct'}</div>` +
-        `<div class="se-form">` +
-        `<input id="se-name" class="se-name-inp" type="text" value="${esc(draft.name)}" ` +
-               `maxlength="64" placeholder="StructName" spellcheck="false" autocomplete="off">` +
-        `<div class="se-field-hdr">` +
-        `<span>Type</span><span>Name</span><span>[ ]</span><span></span>` +
-        `</div>` +
-        `<div id="se-fields">${fieldRows}</div>` +
-        `<button id="se-add" class="struct-add-field-btn">+ Add Field</button>` +
-        `<div class="se-btns">` +
-        `<button id="se-save"   class="struct-btn struct-btn-apply">Save</button>` +
-        `<button id="se-cancel" class="struct-btn struct-btn-secondary">Cancel</button>` +
-        `</div>` +
-        `</div>`;
+    sec.querySelector('#se-packed')!.addEventListener('click', () => {
+        const btn = sec.querySelector('#se-packed')!;
+        const nowPacked = !btn.classList.contains('active');
+        btn.classList.toggle('active', nowPacked);
+        draft.packed = nowPacked;
+        refreshEditorPreview(sec, draft);
+    });
 
-    wireEditorEvents(sec, draft, existing);
-}
+    function refreshEditorPreview(s: HTMLElement, d: StructDef): void {
+        syncEditorDraft(s, d);
+        const pre = s.querySelector<HTMLElement>('#se-preview pre');
+        if (pre) { pre.innerHTML = structToCHtml(d); }
+    }
 
-function wireEditorEvents(sec: HTMLElement, draft: StructDef, existing: StructDef | null): void {
-    document.getElementById('se-add')!.addEventListener('click', () => {
-        syncDraftFields(sec, draft);
+    sec.querySelector('#se-add')!.addEventListener('click', () => {
+        syncEditorDraft(sec, draft);
         draft.fields.push({ name: `field${draft.fields.length}`, type: 'uint8', count: 1, endian: 'inherit' });
-        renderEditorInto(sec, draft, existing);
+        renderStructPins();
     });
 
     sec.querySelectorAll<HTMLElement>('.sfe-del-btn').forEach(btn => {
         btn.addEventListener('click', () => {
-            syncDraftFields(sec, draft);
+            syncEditorDraft(sec, draft);
             const row = btn.closest<HTMLElement>('.struct-field-row')!;
-            const idx = parseInt(row.dataset.idx!);
-            draft.fields.splice(idx, 1);
-            renderEditorInto(sec, draft, existing);
+            draft.fields.splice(parseInt(row.dataset.idx!), 1);
+            renderStructPins();
+        });
+    });
+
+    sec.querySelectorAll<HTMLElement>('.sfe-move-up').forEach(btn => {
+        btn.addEventListener('click', () => {
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(btn.closest<HTMLElement>('.struct-field-row')!.dataset.idx!);
+            if (idx > 0) {
+                [draft.fields[idx - 1], draft.fields[idx]] = [draft.fields[idx], draft.fields[idx - 1]];
+                renderStructPins();
+            }
+        });
+    });
+
+    sec.querySelectorAll<HTMLElement>('.sfe-move-dn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(btn.closest<HTMLElement>('.struct-field-row')!.dataset.idx!);
+            if (idx < draft.fields.length - 1) {
+                [draft.fields[idx], draft.fields[idx + 1]] = [draft.fields[idx + 1], draft.fields[idx]];
+                renderStructPins();
+            }
         });
     });
 
@@ -207,40 +232,77 @@ function wireEditorEvents(sec: HTMLElement, draft: StructDef, existing: StructDe
                 if (!inp.value) { inp.value = '2'; }
                 inp.focus(); inp.select();
             }
+            refreshEditorPreview(sec, draft);
         });
     });
 
     sec.querySelectorAll<HTMLInputElement>('.sfe-count-inp').forEach(inp => {
         inp.addEventListener('input', () => {
             inp.value = inp.value.replace(/\D/g, '').slice(0, 3);
+            refreshEditorPreview(sec, draft);
         });
     });
 
     sec.querySelectorAll<HTMLInputElement>('.sfe-name-inp').forEach(inp => {
+        inp.addEventListener('input', () => { refreshEditorPreview(sec, draft); });
         inp.addEventListener('blur', () => {
             const clean = sanitizeCIdent(inp.value);
             if (clean !== inp.value) { inp.value = clean || 'field'; }
+            refreshEditorPreview(sec, draft);
         });
     });
 
-    document.getElementById('se-save')!.addEventListener('click', () => {
-        syncDraftFields(sec, draft);
-        const nameInp = document.getElementById('se-name') as HTMLInputElement;
+    sec.querySelectorAll<HTMLSelectElement>('.sfe-type-sel').forEach(sel => {
+        sel.addEventListener('change', () => { refreshEditorPreview(sec, draft); });
+    });
+
+    sec.querySelector<HTMLInputElement>('#se-name')!.addEventListener('input', () => {
+        refreshEditorPreview(sec, draft);
+    });
+
+    sec.querySelector('#se-save')!.addEventListener('click', () => {
+        syncEditorDraft(sec, draft);
+        const nameInp = sec.querySelector<HTMLInputElement>('#se-name')!;
         const name = nameInp.value.trim();
         if (!name) { nameInp.style.borderColor = 'var(--err)'; return; }
         if (draft.fields.length === 0) { return; }
-        const def: StructDef = { id: draft.id, name, fields: draft.fields };
+        const def: StructDef = { id: draft.id, name, packed: draft.packed ?? false, fields: draft.fields };
         const idx = S.structs.findIndex(d => d.id === def.id);
         if (idx >= 0) { S.structs[idx] = def; } else { S.structs.push(def); }
         vscode.postMessage({ type: 'saveStructs', structs: S.structs });
-        renderStructPanel();
+        const wasFromAdd = _editingType!.fromAdd;
+        _editingType = null;
+        if (wasFromAdd) {
+            _applyStructId = def.id;
+            _addingPin = true;
+        }
         renderStructPins();
     });
 
-    document.getElementById('se-cancel')!.addEventListener('click', () => {
-        renderStructPanel();
+    sec.querySelector('#se-cancel')!.addEventListener('click', () => {
+        const wasFromAdd = _editingType!.fromAdd;
+        _editingType = null;
+        if (wasFromAdd) { _addingPin = true; }
+        renderStructPins();
+    });
+
+    sec.querySelector<HTMLElement>('#se-delete')?.addEventListener('click', () => {
+        const id = _editingType!.draft.id;
+        S.structs    = S.structs.filter(d => d.id !== id);
+        S.structPins = S.structPins.filter(p => p.structId !== id);
+        if (_applyStructId === id) { _applyStructId = null; }
+        vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
+        vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
+        _editingType = null;
+        renderStructPins();
     });
 }
+
+// ── No longer exported — type management is fully internal ─────────
+/** @deprecated Use inline editing via renderStructPins */
+export function renderStructPanel(): void { /* no-op: removed */ }
+/** @deprecated Use inline editing via renderStructPins */
+export function renderStructEditor(_existing: StructDef | null, _inEl?: HTMLElement): void { /* no-op: removed */ }
 
 // ══════════════════════════════════════════════════════════════════
 // SECTION 2 — Apply Panel + Saved Instances  (#s-struct-pins)
@@ -259,30 +321,48 @@ export function renderStructPins(): void {
         _applyStructId = all[0].id;
     }
 
-    const hasStructs  = all.length > 0;
-    const instBadge   = S.structPins.length > 0 ? `<span class="sb-badge">${S.structPins.length}</span>` : '';
+    // ── Editor mode: replace section content with the type editor ──
+    if (_editingType) {
+        sec.innerHTML = editorHtml(_editingType.draft, _editingType.existing);
+        wireEditorInSec(sec);
+        sec.querySelector<HTMLInputElement>('#se-name')?.focus();
+        return;
+    }
+
+    const instBadge = S.structPins.length > 0 ? `<span class="sb-badge">${S.structPins.length}</span>` : '';
 
     // ── Inline add form ──
     let addFormHtml = '';
     if (_addingPin) {
-        const applyDef   = all.find(d => d.id === _applyStructId) ?? null;
-        const structOpts = hasStructs
-            ? all.map(d => `<option value="${esc(d.id)}"${d.id === _applyStructId ? ' selected' : ''}>${esc(d.name)}</option>`).join('')
-            : `<option value="">— no struct types —</option>`;
-        const previewHtml = applyDef
-            ? `<div class="sa-preview">${applyDef.fields.map(f =>
-                `<div class="sa-pf"><span class="sa-pf-type">${esc(f.type)}</span> ` +
-                `<span class="sa-pf-name">${esc(f.name)}${f.count > 1 ? `[${f.count}]` : ''}</span></div>`
-              ).join('')}</div>`
-            : `<div class="sa-preview sa-preview-empty">No struct types defined yet.</div>`;
-        const addrVal = S.activeStructAddr !== null
+        const applyDef = all.find(d => d.id === _applyStructId) ?? null;
+        const addrVal  = S.activeStructAddr !== null
             ? S.activeStructAddr.toString(16).toUpperCase().padStart(8, '0') : '';
+
+        let typeRowHtml: string;
+        if (all.length === 0) {
+            typeRowHtml =
+                `<div class="sa-row sa-no-types-row">` +
+                `<span class="sa-no-types-msg">No types yet.</span>` +
+                `<button id="sa-new-type-btn" class="struct-btn struct-btn-secondary">New type</button>` +
+                `</div>`;
+        } else {
+            const structOpts = all.map(d =>
+                `<option value="${esc(d.id)}"${d.id === _applyStructId ? ' selected' : ''}>${esc(d.name)}</option>`
+            ).join('');
+            const previewHtml = applyDef
+                ? `<pre class="si-c-preview">${structToCHtml(applyDef)}</pre>`
+                : '';
+            typeRowHtml =
+                `<div class="sa-row">` +
+                `<select id="sa-struct-sel" class="struct-sel">${structOpts}</select>` +
+                `<button id="sa-new-type-btn" class="si-add-type-btn" title="New type">\uff0b</button>` +
+                `</div>` +
+                previewHtml;
+        }
+
         addFormHtml =
             `<div id="si-add-form" class="si-add-form">` +
-            `<div class="sa-row">` +
-            `<select id="sa-struct-sel" class="struct-sel" style="flex:1">${structOpts}</select>` +
-            `</div>` +
-            previewHtml +
+            typeRowHtml +
             `<div class="sa-row">` +
             `<span class="struct-addr-pfx">0x</span>` +
             `<input id="sa-addr" class="struct-addr-inp sa-addr-inp" type="text" maxlength="8" ` +
@@ -291,24 +371,24 @@ export function renderStructPins(): void {
                    `placeholder="instance name" spellcheck="false" autocomplete="off">` +
             `</div>` +
             `<div class="sa-row sa-btn-row">` +
-            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${!hasStructs ? ' disabled' : ''}>Confirm</button>` +
+            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${!_applyStructId ? ' disabled' : ''}>Confirm</button>` +
             `<button id="sa-cancel" class="struct-btn struct-btn-cancel">Cancel</button>` +
             `</div>` +
             `</div>`;
     }
 
     const instHtml = S.structPins.length === 0
-        ? `<div class="sb-empty">No instances yet. Click ＋ Add to create one.</div>`
+        ? `<div class="sb-empty">No instances yet. Click \uff0b Add to create one.</div>`
         : S.structPins.map((pin, i) => buildInstanceCard(pin, i)).join('');
 
     sec.innerHTML =
         `<div class="si-hdr-row">` +
-        `<span class="sb-hdr" style="margin:0">Instances ${instBadge}</span>` +
+        `<span class="sb-hdr" style="margin:0">Struct Instances ${instBadge}</span>` +
         `<div class="endian-tabs sa-endian-tabs">` +
         `<button id="sa-btn-le" class="${S.endian === 'le' ? 'active' : ''}">LE</button>` +
         `<button id="sa-btn-be" class="${S.endian === 'be' ? 'active' : ''}">BE</button>` +
         `</div>` +
-        `<button id="si-add-btn" class="si-add-btn"${!hasStructs || _addingPin ? ' disabled' : ''}>＋ Add</button>` +
+        `<button id="si-add-btn" class="si-add-btn"${_addingPin ? ' disabled' : ''}>\uff0b Add</button>` +
         `</div>` +
         addFormHtml +
         `<div id="si-list">${instHtml}</div>`;
@@ -322,12 +402,22 @@ export function renderStructPins(): void {
 
     // ── Add-form wiring ──
     if (_addingPin) {
-        document.getElementById('sa-struct-sel')!.addEventListener('change', e => {
+        document.getElementById('sa-struct-sel')?.addEventListener('change', e => {
             _applyStructId = (e.target as HTMLSelectElement).value || null;
             renderStructPins();
         });
+        document.getElementById('sa-new-type-btn')?.addEventListener('click', () => {
+            _addingPin = false;
+            const draftId = `user_${Date.now()}`;
+            _editingType = {
+                draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
+                existing: null,
+                fromAdd: true,
+            };
+            renderStructPins();
+        });
         document.getElementById('sa-confirm')!.addEventListener('click', () => {
-            if (!hasStructs || !_applyStructId) { return; }
+            if (!_applyStructId) { return; }
             const addrInp = document.getElementById('sa-addr') as HTMLInputElement;
             const nameInp = document.getElementById('sa-name') as HTMLInputElement;
             const addr    = parseInt(addrInp.value.replace(/^0x/i, ''), 16);
@@ -365,11 +455,8 @@ export function renderStructPins(): void {
         if (_expanded.size > 0) { renderStructPins(); }
     });
 
-    // Per-field value type is handled via right-click menu on individual values.
-
     wireInstanceCards(sec);
 }
-
 /** Get a display string for a field given the requested column display type. */
 function getValForType(r: DecodedField, valType: ColType): string {
     if (!r.hasData) { return '??'; }
@@ -398,10 +485,11 @@ function getValForType(r: DecodedField, valType: ColType): string {
         // Always return the full, multi-line binary HTML.
         return `<span class="si-bin-wrap">${fullHtml}</span>`;
     };
-    // Pointer always renders as arrow + hex address regardless of valType
+    // Pointer always renders as arrow → hex address regardless of valType
     if (r.type === 'pointer') {
         const v = dv.getUint32(0, le) >>> 0;
-        return `0x${v.toString(16).toUpperCase().padStart(8, '0')} \u2192`;
+        return `<span class="si-f-ptr-sym">\u2192</span>\u2009` +
+               `0x${v.toString(16).toUpperCase().padStart(8, '0')}`;
     }
     if (valType === 'bin') { return binFn(); }
     if (valType === 'ascii') {
@@ -478,20 +566,29 @@ function getCopyText(r: DecodedField, valType: ColType): string {
     }
 }
 
-/** Build a single field row (5-col grid) for scalar fields and array elements. */
+const TYPE_ABBREV: Record<string, string> = {
+    uint8: 'u8',  uint16: 'u16', uint32: 'u32',
+    int8:  'i8',  int16:  'i16', int32:  'i32',
+    float32: 'f32', float64: 'f64', pointer: 'ptr',
+};
+
 function mkFieldRow(r: DecodedField, bs: number, bc: number): string {
     const nd  = !r.hasData ? ' si-no-data' : '';
     const ptr = r.type === 'pointer';
     const t   = _fieldValTypes.get(bs) ?? _defaultValType;
     const v   = getValForType(r, t);
-    const valHtml = t === 'bin' ? v : esc(v);
+    const valHtml = (t === 'bin' || ptr) ? v : esc(v);
+    const abbrev  = TYPE_ABBREV[r.type] ?? r.type;
     return (
         `<div class="si-field${nd}${ptr ? ' si-ptr-field' : ''}" ` +
         `data-byte-start="${bs}" data-byte-cnt="${bc}">` +
         `<span class="si-f-off">+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
-        `<span></span>` +
+        `<span class="si-f-type">${abbrev}</span>` +
+        `<span class="si-f-body">` +
         `<span class="si-f-name">${esc(r.fieldName)}</span>` +
+        `<span class="si-f-lead"></span>` +
         `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${bs}">${valHtml}</span>` +
+        `</span>` +
         `</div>`
     );
 }
@@ -528,18 +625,20 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const r0      = g.rows[0];
                 const byteStart = pin.addr + r0.byteOffset;
                 const totalCnt  = g.rows.reduce((s, r) => s + fieldByteSize(r.type), 0);
-                const elHtml  = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, fieldByteSize(r.type))).join('');
-                // Show address of first element like a pointer (0xXXXXXXXX)
-                const addrHex = byteStart.toString(16).toUpperCase().padStart(8, '0');
+                const elHtml     = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, fieldByteSize(r.type))).join('');
+                const arrAbbrev  = TYPE_ABBREV[r0.type] ?? r0.type;
+                const arrSummary = `[${g.rows.length}]\u202f\u00b7\u202f${arrAbbrev}`;
                 return (
                     `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
                     `<div class="si-arr-grp-hdr" ` +
                     `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
                     `<span class="si-f-off">+${r0.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
                     `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+                    `<span class="si-f-body">` +
                     `<span class="si-f-name">${esc(g.baseName)}</span>` +
-                    `<span class="si-arr-addr">0x${addrHex}</span>` +
-                    `<span></span>` +
+                    `<span class="si-f-lead"></span>` +
+                    `<span class="si-arr-addr">${esc(arrSummary)}</span>` +
+                    `</span>` +
                     `</div>` +
                     `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
                     `</div>`
@@ -550,17 +649,46 @@ function buildInstanceCard(pin: StructPin, i: number): string {
         bodyHtml = `<div class="si-fields">${fieldHtml}</div>`;
     }
 
+    const typePreviewHtml = def
+        ? `<div class="si-type-preview"${_previewedPins.has(pin.id) ? '' : ' style="display:none"'}>` +
+          `<pre class="si-c-preview">${structToCHtml(def)}</pre>` +
+          `</div>`
+        : '';
+
     return (
         `<div class="si-card${expanded ? ' si-expanded' : ''}" data-pin-id="${esc(pin.id)}" data-idx="${i}">` +
         `<div class="si-card-hdr">` +
-        `<button class="si-expand-btn" data-pin-id="${esc(pin.id)}">${expanded ? '▾' : '▸'}</button>` +
+        `<button class="si-expand-btn" data-pin-id="${esc(pin.id)}">${expanded ? '\u25be' : '\u25b8'}</button>` +
+        `<div class="si-card-info">` +
         `<span class="si-cname">${esc(pin.name)}</span>` +
-        `<span class="si-cmeta">${esc(defName)} · 0x${addrHex} · ${totalBytes}B</span>` +
-        `<button class="si-del-btn" data-idx="${i}" title="Remove">✕</button>` +
+        `<div class="si-cmeta-row">` +
+        `<span class="si-ctype">${esc(defName)}</span>` +
+        `<button class="si-type-btn${_previewedPins.has(pin.id) ? ' active' : ''}" ` +
+        `data-pin-id="${esc(pin.id)}" title="View type definition">&#x29C9;</button>` +
+        (def ? `<button class="si-edit-type-btn" data-struct-id="${esc(def.id)}" title="Edit type">✎</button>` : '') +
+        `<span class="si-caddr">0x${addrHex}\u202f\u00b7\u202f${totalBytes}B</span>` +
         `</div>` +
+        `</div>` +
+        `<button class="si-del-btn" data-idx="${i}" title="Remove">\u2715</button>` +
+        `</div>` +
+        typePreviewHtml +
         bodyHtml +
         `</div>`
     );
+}
+
+function clearArrSep(): void {
+    for (const addr of _arrSepAddrs) {
+        const ah = addr.toString(16).toUpperCase().padStart(8, '0');
+        document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
+            .forEach(el => el.classList.remove('struct-arr-sep'));
+    }
+    _arrSepAddrs.length = 0;
+}
+
+function clearSelRow(): void {
+    document.querySelectorAll<HTMLElement>('.si-selected')
+        .forEach(el => el.classList.remove('si-selected'));
 }
 
 function wireInstanceCards(sec: HTMLElement): void {
@@ -572,33 +700,31 @@ function wireInstanceCards(sec: HTMLElement): void {
         });
     });
 
-    // Array group toggle — DOM-only, no full re-render
+    // Array group: arrow button toggles expand; rest of row selects in hex view
     sec.querySelectorAll<HTMLElement>('.si-arr-grp-hdr').forEach(hdr => {
-        hdr.addEventListener('click', e => {
-            if ((e.target as HTMLElement).closest('.si-field')) { return; }
+        const expBtn = hdr.querySelector<HTMLElement>('.si-arr-exp-btn')!;
+        const start  = parseInt(hdr.dataset.byteStart!);
+        const cnt    = parseInt(hdr.dataset.byteCnt!);
+
+        expBtn.addEventListener('click', e => {
+            e.stopPropagation();
             const grp  = hdr.closest<HTMLElement>('.si-arr-grp')!;
             const key  = grp.dataset.arrKey!;
             const body = grp.querySelector<HTMLElement>('.si-arr-grp-body')!;
-            const btn  = hdr.querySelector<HTMLElement>('.si-arr-exp-btn')!;
             const isOpen = _expandedArrayFields.has(key);
             if (isOpen) {
                 _expandedArrayFields.delete(key);
                 grp.classList.remove('open');
                 body.style.display = 'none';
-                btn.textContent = '▸';
+                expBtn.textContent = '▸';
             } else {
                 _expandedArrayFields.add(key);
                 grp.classList.add('open');
                 body.style.display = '';
-                btn.textContent = '▾';
+                expBtn.textContent = '▾';
             }
         });
-    });
 
-    // Array group header hover → highlight all its bytes
-    sec.querySelectorAll<HTMLElement>('.si-arr-grp-hdr').forEach(hdr => {
-        const start = parseInt(hdr.dataset.byteStart!);
-        const cnt   = parseInt(hdr.dataset.byteCnt!);
         hdr.addEventListener('mouseenter', () => {
             for (let i = 0; i < cnt; i++) {
                 const ah = (start + i).toString(16).toUpperCase().padStart(8, '0');
@@ -610,11 +736,40 @@ function wireInstanceCards(sec: HTMLElement): void {
             document.querySelectorAll<HTMLElement>('.struct-h')
                 .forEach(el => el.classList.remove('struct-h'));
         });
+
+        hdr.addEventListener('click', e => {
+            if ((e.target as HTMLElement).closest('.si-arr-exp-btn')) { return; }
+            clearArrSep();
+            clearSelRow();
+            if (isNaN(start) || isNaN(cnt)) { return; }
+            const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
+            _selectedArrKey    = grp.dataset.arrKey!;
+            _selectedFieldAddr = null;
+            // Mark each element's first byte (except element 0) for visual separation
+            grp.querySelectorAll<HTMLElement>('.si-field').forEach((row, i) => {
+                if (i === 0) { return; }
+                const bs = parseInt(row.dataset.byteStart!);
+                if (isNaN(bs)) { return; }
+                _arrSepAddrs.push(bs);
+                const ah = bs.toString(16).toUpperCase().padStart(8, '0');
+                document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
+                    .forEach(el => el.classList.add('struct-arr-sep'));
+            });
+            S.selStart = start;
+            S.selEnd   = start + cnt - 1;
+            hdr.classList.add('si-selected');
+            import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
+            import('./sidebar.js').then(m => m.updateInspector());
+        });
     });
 
     sec.querySelectorAll<HTMLElement>('.si-card-hdr').forEach(hdr => {
         hdr.addEventListener('click', e => {
             if ((e.target as HTMLElement).closest('.si-expand-btn, .si-del-btn')) { return; }
+            clearArrSep();
+            clearSelRow();
+            _selectedFieldAddr = null;
+            _selectedArrKey    = null;
             const card = hdr.closest<HTMLElement>('.si-card')!;
             const idx  = parseInt(card.dataset.idx!);
             const pin  = S.structPins[idx];
@@ -625,6 +780,9 @@ function wireInstanceCards(sec: HTMLElement): void {
             S.selStart = pin.addr;
             S.selEnd   = pin.addr + size - 1;
             S.activeStructAddr = pin.addr;
+            _selectedPinId = pin.id;
+            sec.querySelectorAll<HTMLElement>('.si-card').forEach(c => c.classList.remove('si-card-selected'));
+            card.classList.add('si-card-selected');
             rerender.toMemory();
             import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(pin.addr); });
             import('./sidebar.js').then(m => m.updateInspector());
@@ -661,8 +819,13 @@ function wireInstanceCards(sec: HTMLElement): void {
 
         row.addEventListener('click', () => {
             if (isNaN(start) || isNaN(cnt)) { return; }
+            clearArrSep();
+            clearSelRow();
             S.selStart = start;
             S.selEnd   = start + cnt - 1;
+            row.classList.add('si-selected');
+            _selectedFieldAddr = start;
+            _selectedArrKey    = null;
             import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
             import('./sidebar.js').then(m => m.updateInspector());
         });
@@ -698,6 +861,64 @@ function wireInstanceCards(sec: HTMLElement): void {
             showFieldValMenu(ev.clientX, ev.clientY, start, bsList, pinIdx, { isArrayHeader: true });
         });
     });
+
+    // Type-definition preview toggle inside card header
+    sec.querySelectorAll<HTMLElement>('.si-type-btn').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.stopPropagation();
+            const id = btn.dataset.pinId!;
+            const card = btn.closest<HTMLElement>('.si-card')!;
+            const preview = card.querySelector<HTMLElement>('.si-type-preview');
+            if (_previewedPins.has(id)) {
+                _previewedPins.delete(id);
+                btn.classList.remove('active');
+                if (preview) { preview.style.display = 'none'; }
+            } else {
+                _previewedPins.add(id);
+                btn.classList.add('active');
+                if (preview) { preview.style.display = ''; }
+            }
+        });
+    });
+
+    // Edit-type button on card
+    sec.querySelectorAll<HTMLElement>('.si-edit-type-btn').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.stopPropagation();
+            const structId = btn.dataset.structId!;
+            const existing = S.structs.find(d => d.id === structId) ?? null;
+            if (!existing) { return; }
+            _editingType = {
+                draft: { id: existing.id, name: existing.name, packed: existing.packed ?? false, fields: existing.fields.map(f => ({ ...f })) },
+                existing,
+                fromAdd: false,
+            };
+            renderStructPins();
+        });
+    });
+
+    // Re-apply selection highlight after DOM rebuild
+    if (_selectedPinId !== null) {
+        sec.querySelectorAll<HTMLElement>('.si-card').forEach(card => {
+            if (card.dataset.pinId === _selectedPinId) {
+                card.classList.add('si-card-selected');
+            }
+        });
+    }
+    if (_selectedFieldAddr !== null) {
+        sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
+            if (parseInt(row.dataset.byteStart!) === _selectedFieldAddr) {
+                row.classList.add('si-selected');
+            }
+        });
+    } else if (_selectedArrKey !== null) {
+        sec.querySelectorAll<HTMLElement>('.si-arr-grp-hdr').forEach(hdr => {
+            const grp = hdr.closest<HTMLElement>('.si-arr-grp');
+            if (grp?.dataset.arrKey === _selectedArrKey) {
+                hdr.classList.add('si-selected');
+            }
+        });
+    }
 }
 
 // Floating per-field value-type menu
@@ -730,6 +951,61 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
         `<span class="ctx-label">${esc(label)}</span>` +
         `<div class="ctx-submenu">${body}</div>` +
         `</div>`;
+
+    // Array header: copy start address + view-as for all elements
+    if (opts?.isArrayHeader) {
+        const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', ascii: 'ASCII' };
+        const dispMenu = types.map(t =>
+            `<div class="ctx-row${t === cur ? ' active' : ''}" data-cmd="disp-${t}">` +
+            `<span class="ctx-label">${TYPE_LABELS[t]}</span>` +
+            `</div>`
+        ).join('');
+        const el = document.createElement('div');
+        el.id = 'si-val-menu'; el.className = 'si-val-menu ctx-menu';
+        el.innerHTML =
+            item('copy-addr', 'Copy address') +
+            sep +
+            sub('View as', 'disp', dispMenu);
+        document.body.appendChild(el);
+        const mw = el.offsetWidth || 200; const mh = el.offsetHeight || 80;
+        el.style.left = `${Math.min(x, window.innerWidth - mw - 8)}px`;
+        el.style.top  = `${Math.min(y, window.innerHeight - mh - 8)}px`;
+        el.querySelectorAll<HTMLElement>('.ctx-row[data-cmd]').forEach(row => {
+            row.addEventListener('click', ev => {
+                ev.stopPropagation();
+                const cmd = row.dataset.cmd!;
+                if (cmd === 'copy-addr') {
+                    const addrStr = `0x${bs.toString(16).toUpperCase().padStart(8, '0')}`;
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(addrStr).catch(() => {
+                            const ta = document.createElement('textarea');
+                            ta.value = addrStr; document.body.appendChild(ta); ta.select();
+                            document.execCommand('copy'); ta.remove();
+                        });
+                    } else {
+                        const ta = document.createElement('textarea');
+                        ta.value = addrStr; document.body.appendChild(ta); ta.select();
+                        document.execCommand('copy'); ta.remove();
+                    }
+                    hideFieldValMenu();
+                    return;
+                }
+                if (cmd.startsWith('disp-') && bsList && bsList.length > 0) {
+                    const t = cmd.replace('disp-', '') as ColType;
+                    bsList.forEach(b => {
+                        if (t === _defaultValType) { _fieldValTypes.delete(b); }
+                        else { _fieldValTypes.set(b, t); }
+                    });
+                    hideFieldValMenu();
+                    renderStructPins();
+                }
+            });
+        });
+        wireStructSubmenus(el);
+        setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+        _valMenuEl = el;
+        return;
+    }
 
     // Pointer: only allow copy address value
     if (opts?.isPointer) {
@@ -782,32 +1058,26 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
         return;
     }
 
+    const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', ascii: 'ASCII' };
+
     // Copy submenu
-    const copyMenu =
-        item('copy-hex',   'Hex',   '') +
-        item('copy-dec',   'Decimal', '') +
-        item('copy-bin',   'Binary', '') +
-        item('copy-ascii', 'ASCII',  '');
+    const copyMenu = types.map(t =>
+        item(`copy-${t}`, TYPE_LABELS[t], '')
+    ).join('');
 
     // Display type submenu
     const dispMenu = types.map(t =>
         `<div class="ctx-row${t===cur ? ' active' : ''}" data-cmd="disp-${t}">` +
-        `<span class="ctx-label">${t}</span>` +
+        `<span class="ctx-label">${TYPE_LABELS[t]}</span>` +
         `</div>`
     ).join('');
-    // For array header, show a different note (single line, no wrap, custom class)
-    const note = opts?.isArrayHeader
-        ? `<div class="ctx-array-note">apply to all array elements</div>`
-        : '';
-
     // Compose menu
     const el = document.createElement('div');
     el.id = 'si-val-menu'; el.className = 'si-val-menu ctx-menu';
     el.innerHTML =
         sub('Copy', 'copy', copyMenu) +
         sep +
-        sub('Change display type', 'disp', dispMenu) +
-        note;
+        sub('View as', 'disp', dispMenu);
 
     document.body.appendChild(el);
     const mw = el.offsetWidth || 220; const mh = el.offsetHeight || 120;
@@ -864,16 +1134,8 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
             // Display type actions
             if (cmd.startsWith('disp-')) {
                 const t = cmd.replace('disp-', '') as ColType;
-                // Only allow group change from array header, not from element
-                if (opts?.isArrayHeader && bsList && bsList.length > 0) {
-                    bsList.forEach(b => {
-                        if (t === _defaultValType) { _fieldValTypes.delete(b); }
-                        else { _fieldValTypes.set(b, t); }
-                    });
-                } else {
-                    if (t === _defaultValType) { _fieldValTypes.delete(bs); }
-                    else { _fieldValTypes.set(bs, t); }
-                }
+                if (t === _defaultValType) { _fieldValTypes.delete(bs); }
+                else { _fieldValTypes.set(bs, t); }
                 hideFieldValMenu();
                 renderStructPins();
                 return;
@@ -931,6 +1193,11 @@ function wireStructSubmenus(menuEl: HTMLElement): void {
 
 /** Called when the user's byte selection changes. Fills the add-form address if open. */
 export function onSelectionChangeForStruct(): void {
+    clearArrSep();
+    clearSelRow();
+    _selectedFieldAddr = null;
+    _selectedArrKey    = null;
+    _selectedPinId     = null;
     if (S.selStart === null) { return; }
     S.activeStructAddr = S.selStart;
     if (S.sidebarTab === 'struct' && _addingPin) {

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -65,6 +65,9 @@ export interface StructDef {
     id: string;
     name: string;
     fields: StructField[];
+    /** When true: no padding between fields (GCC __attribute__((packed))).
+     *  When false/absent: fields are naturally aligned (default). */
+    packed?: boolean;
 }
 
 /** A saved struct overlay instance: one struct definition applied to one address with a user label. */


### PR DESCRIPTION
## Struct Overlay Enhancement

This PR completes the struct overlay feature with proper C layout semantics, a fully inline type editor, and a live C code preview.

### Struct layout
- Fields are now naturally aligned by default (C standard rules). Each field is padded to its own alignment, and the struct gets trailing padding to round its size up to the largest field's alignment.
- New `__attribute__((packed))` toggle button disables all padding for packed structs.
- `structToC()` renders a `typedef struct` with per-field offset comments and padding annotated as `/* N bytes padding */`.

### Type editor
- All type management is now inline within the Struct Overlay panel — no separate types panel.
- Live C code preview updates in real time as you edit name, fields, types, array counts, and the packed toggle.
- Per-field move up/down arrow buttons to reorder fields.
- Syntax-highlighted C preview: keywords in blue, types/struct name in teal, `__attribute__((packed))` in purple, comments in green.

### Other improvements
- Click any label row in the Labels panel to switch to the Memory view and scroll to that label's address.
- Sidebar sections are collapsible and persist their state.
- Binary display format added to field value options.

### Tests
- Existing tests updated to use `packed: true` where they assumed packed layout.
- New tests covering aligned layout, trailing padding, and `structToC` output.