### PR TITLE
feat(sidebar): sidebar UX rework — slide-in types panel, inline type editor, tab state reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.1.0] — 2026-05-01
+
+### Added
+
+- **Slide-in Struct Types panel** — a dedicated types panel now slides in from the right of the Struct Overlay section, opened via a hamburger button (☰) in the Struct Instances header; lists all defined types with edit and delete action buttons
+- **Inline confirm popover** for destructive actions — deleting a struct type or a segment label now shows a small "Delete?" popover anchored above the button instead of deleting immediately
+- **`updateLabelFormSel`** — the Add/Edit Label form auto-fills its address and range fields when the byte selection changes while the form is open
+- **Auto-fill for empty names** — saving a struct type with a blank name generates a unique `MyStruct` / `MyStruct1` … name automatically; saving a label with a blank name generates `Label_0` / `Label_1` …; empty struct field names fall back to `field0`, `field1` …
+- **`actionBtnsHtml` / `wireActionBtns` / `inlineConfirm`** helper functions extracted to `utils.ts` and shared across the Labels and Struct Types panels
+
+### Changed
+
+- Struct type editor no longer replaces the full section — it now renders inside the types slide-in panel; the separate "Edit Type" / "New Type" header row inside the editor form has been removed
+- "Delete type" button removed from inside the type editor; deletion is now done from the types list with an inline confirm
+- Add-Instance form reordered: instance name field now appears before the address field
+- Switching away from the Struct Overlay sidebar tab resets the panel view state (slide-in panel closes, editing cancelled)
+- Segment label delete action now uses the shared inline confirm popover instead of deleting on first click
+- `struct-btn-danger` "Delete type" button removed from the editor toolbar
+
 ## [2.0.0] — 2026-05-01
 
 ### Added

--- a/src/webview/base.css
+++ b/src/webview/base.css
@@ -56,3 +56,76 @@ html, body {
 ::-webkit-scrollbar-thumb { background: rgba(121,121,121,.4); border-radius: 5px; border: 2px solid var(--bg); }
 ::-webkit-scrollbar-thumb:hover { background: rgba(121,121,121,.7); }
 ::-webkit-scrollbar-corner { background: transparent; }
+
+/* ── Shared action buttons (edit ✎ / delete 🗑) ────────────────── */
+/* Used in labels, struct instance cards, and manage-types rows.    */
+.act-btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 18px; height: 18px; padding: 0; flex-shrink: 0;
+    background: transparent; border: none; border-radius: 2px;
+    cursor: pointer; color: var(--non-graphic); font-size: 11px; line-height: 1;
+    transition: color .1s, background .1s; -webkit-user-select: none; user-select: none;
+    opacity: 0; transition: opacity .1s, color .1s, background .1s;
+}
+/* Parent hover reveals the buttons */
+[data-act-host]:hover .act-btn,
+.label-item:hover    .act-btn,
+.sd-row:hover        .act-btn,
+.si-card:hover       .act-btn { opacity: 1; }
+
+.act-btn:hover       { background: rgba(255,255,255,.08); color: var(--fg); }
+.act-btn-edit:hover  { color: var(--high-color); background: rgba(134,180,212,.1); }
+.act-btn-del:hover   { color: var(--err);         background: rgba(244,135,113,.1); }
+
+/* ── Delete-confirm popover ─────────────────────────────────────── */
+.del-confirm-pop {
+    z-index: 9999;
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 5px 7px;
+    background: var(--panel-bg, #252526);
+    border: 1px solid var(--border, #454545);
+    border-radius: 5px;
+    box-shadow: 0 4px 12px rgba(0,0,0,.45);
+    white-space: nowrap;
+    font-family: var(--font-ui); font-size: 11px;
+    /* small drop-shadow arrow pointing down */
+    filter: drop-shadow(0 2px 4px rgba(0,0,0,.35));
+}
+/* Caret arrow pointing downward */
+.del-confirm-pop::after {
+    content: '';
+    position: absolute; bottom: -5px; left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: var(--border, #454545);
+    border-bottom: none;
+}
+.del-confirm-pop::before {
+    content: '';
+    position: absolute; bottom: -4px; left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: var(--panel-bg, #252526);
+    border-bottom: none;
+    z-index: 1;
+}
+.dcp-msg {
+    color: var(--fg); font-weight: 600;
+    -webkit-user-select: none; user-select: none;
+    margin-right: 2px;
+}
+.dcp-yes, .dcp-no {
+    border-radius: 3px; padding: 2px 8px; cursor: pointer;
+    font-size: 11px; font-family: var(--font-ui); font-weight: 600;
+    border: 1px solid transparent; transition: background .1s, border-color .1s;
+}
+.dcp-yes {
+    background: rgba(255,80,80,.14); border-color: rgba(255,80,80,.45);
+    color: rgba(255,120,120,1);
+}
+.dcp-yes:hover { background: rgba(255,80,80,.28); border-color: rgba(255,80,80,.8); }
+.dcp-no {
+    background: rgba(255,255,255,.06); border-color: var(--border);
+    color: var(--addr-fg);
+}
+.dcp-no:hover { background: rgba(255,255,255,.14); color: var(--fg); border-color: var(--fg); }

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -7,7 +7,7 @@ import { esc, fmtB }                                  from './utils';
 import { rerender }                                   from './render';
 import { renderMemHeader, renderMemBody, applySel, scrollTo } from './memoryView';
 import { renderInspector, renderBits, renderLabels, updateInspector, updateLabelFormSel } from './sidebar';
-import { renderStructPanel, renderStructPins, onSelectionChangeForStruct }              from './struct';
+import { renderStructPanel, renderStructPins, onSelectionChangeForStruct, resetStructViewState } from './struct';
 import { initSearch, runSearch, clearSearch, nextMatch, prevMatch } from './search';
 import { initFlatBytes, buildMemRows }                from './data';
 
@@ -123,7 +123,7 @@ function render(): void {
                     <div class="sb-section" id="s-labels"></div>
                 </div>
                 <div class="sb-tab-panel ${S.sidebarTab === 'struct' ? 'active' : ''}" id="sbp-struct">
-                    <div class="sb-section" id="s-struct-pins"></div>
+                    <div id="s-struct-pins"></div>
                 </div>
             </div>
             <div id="side-tabs">
@@ -239,10 +239,12 @@ function render(): void {
         document.getElementById('stab-struct')!.classList.toggle('active', S.sidebarTab === 'struct');
     }
     document.getElementById('stab-insp')!.addEventListener('click', () => {
+        resetStructViewState();
         S.sidebarTab = 'inspector';
         applySidebarState();
     });
     document.getElementById('stab-struct')!.addEventListener('click', () => {
+        renderLabels();
         S.sidebarTab = 'struct';
         applySidebarState();
     });

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -6,7 +6,7 @@ import { vscode }                                     from './api';
 import { esc, fmtB }                                  from './utils';
 import { rerender }                                   from './render';
 import { renderMemHeader, renderMemBody, applySel, scrollTo } from './memoryView';
-import { renderInspector, renderBits, renderLabels, updateInspector } from './sidebar';
+import { renderInspector, renderBits, renderLabels, updateInspector, updateLabelFormSel } from './sidebar';
 import { renderStructPanel, renderStructPins, onSelectionChangeForStruct }              from './struct';
 import { initSearch, runSearch, clearSearch, nextMatch, prevMatch } from './search';
 import { initFlatBytes, buildMemRows }                from './data';
@@ -227,6 +227,7 @@ function render(): void {
         S.selEnd   = newEnd;
         applySel();
         updateInspector();
+        updateLabelFormSel();
     });
     document.addEventListener('mouseup', () => { dragAnchor = null; });
 
@@ -304,6 +305,7 @@ function onByteDown(e: MouseEvent, el: HTMLElement): void {
 
     applySel();
     updateInspector();
+    updateLabelFormSel();
     onSelectionChangeForStruct();
 
 }
@@ -320,6 +322,7 @@ function onByteCtx(e: MouseEvent, el: HTMLElement): void {
             S.selEnd   = addr;
             applySel();
             updateInspector();
+            updateLabelFormSel();
             onSelectionChangeForStruct();
         }
     }

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -185,9 +185,7 @@
     padding: 2px 3px; border-radius: 2px; flex-shrink: 0;
     transition: color .1s, background .1s; -webkit-user-select: none; user-select: none;
 }
-.label-act:hover         { color: var(--fg); background: rgba(255,255,255,.08); }
-.label-del:hover         { color: var(--err); background: rgba(244,135,113,.1); }
-.label-edt:hover         { color: var(--high-color); background: rgba(134,180,212,.1); }
+.label-act:hover { color: var(--fg); background: rgba(255,255,255,.08); }
 
 .add-lbl-btn {
     width: 100%; margin-top: 8px; padding: 5px;

--- a/src/webview/sidebar.ts
+++ b/src/webview/sidebar.ts
@@ -2,7 +2,7 @@
 // Inspector · Bit View · Multi-Byte interpreter · Segment Labels
 
 import { S } from './state';
-import { esc, fmtB } from './utils';
+import { esc, fmtB, inlineConfirm, actionBtnsHtml, wireActionBtns } from './utils';
 import { vscode } from './api';
 import { rerender } from './render';
 import { buildMemRows } from './data';
@@ -358,8 +358,7 @@ export function renderLabels(): void {
                 <span class="label-act label-vis" data-id="${l.id}" data-hidden="${l.hidden ? '1' : '0'}" title="${l.hidden ? 'Show' : 'Hide'}">${l.hidden ? '&#128065;&#xFE0E;' : '&#128065;'}</span>
                 <span class="label-act label-up"  data-id="${l.id}" title="Move up"   ${i === 0 ? 'style="opacity:.3;pointer-events:none"' : ''}>&#8593;</span>
                 <span class="label-act label-dn"  data-id="${l.id}" title="Move down" ${i === S.labels.length - 1 ? 'style="opacity:.3;pointer-events:none"' : ''}>&#8595;</span>
-                <span class="label-act label-edt" data-id="${l.id}" title="Edit">&#9998;</span>
-                <span class="label-act label-del" data-id="${l.id}" title="Remove">&#10005;</span>
+                ${actionBtnsHtml(`data-id="${l.id}"`, `data-id="${l.id}"`)}
             </div>`).join('');
 
     sec.innerHTML = `
@@ -382,21 +381,19 @@ export function renderLabels(): void {
         });
     }
 
-    // Delete
-    sec.querySelectorAll<HTMLElement>('.label-del').forEach(el => {
-        el.addEventListener('click', () => {
+    wireActionBtns(
+        sec,
+        '.act-btn-edit',
+        '.act-btn-del',
+        el => renderLabelForm(el.dataset.id),
+        el => {
             S.labels = S.labels.filter(l => l.id !== el.dataset.id);
             vscode.postMessage({ type: 'saveLabels', labels: S.labels });
             buildMemRows();
             rerender.labels();
             if (S.currentView === 'memory') { rerender.memory(); }
-        });
-    });
-
-    // Edit — open inline form
-    sec.querySelectorAll<HTMLElement>('.label-edt').forEach(el => {
-        el.addEventListener('click', () => renderLabelForm(el.dataset.id));
-    });
+        },
+    );
 
     // Toggle visibility
     sec.querySelectorAll<HTMLElement>('.label-vis').forEach(el => {
@@ -572,7 +569,13 @@ function renderLabelForm(editId?: string): void {
     document.getElementById('lf-save')?.addEventListener('click', () => {
         warnEl().textContent = '';
 
-        const name = nameEl().value.trim();
+        const name = nameEl().value.trim() || (() => {
+            const taken = new Set(S.labels.map(l => l.name));
+            let candidate = 'Label_0';
+            let n = 1;
+            while (taken.has(candidate)) { candidate = `Label_${n++}`; }
+            return candidate;
+        })();
         if (!name) { warnEl().textContent = 'Name is required.'; return; }
 
         const startAddress = parseInt(startEl().value.replace(/^0x/i, ''), 16);
@@ -620,4 +623,21 @@ function renderLabelForm(editId?: string): void {
         rerender.labels();
         if (S.currentView === 'memory') { rerender.memory(); }
     });
+}
+
+/**
+ * Called whenever the hex-view selection changes.
+ * If the label form (#lf-start) is currently open, updates its address
+ * (and range) fields to reflect the newly selected byte(s).
+ */
+export function updateLabelFormSel(): void {
+    if (S.selStart === null) { return; }
+    const startEl = document.getElementById('lf-start') as HTMLInputElement | null;
+    if (!startEl) { return; }
+    const fh = (n: number) => `0x${n.toString(16).toUpperCase().padStart(8, '0')}`;
+    startEl.value = fh(S.selStart);
+    const rangeEl = document.getElementById('lf-range') as HTMLInputElement | null;
+    if (rangeEl && S.selEnd !== null && S.selEnd >= S.selStart) {
+        rangeEl.value = String(S.selEnd - S.selStart + 1);
+    }
 }

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -300,7 +300,7 @@ export function structToC(def: StructDef): string {
     let offset = 0;
     let maxAlign = 1;
 
-    for (const f of def.fields) {
+    def.fields.forEach((f, fi) => {
         const sz    = fieldByteSize(f.type);
         const align = def.packed ? 1 : fieldAlignment(f.type);
         if (align > maxAlign) { maxAlign = align; }
@@ -315,13 +315,14 @@ export function structToC(def: StructDef): string {
 
         offset = aligned;
         const cType = TYPE_TO_C[f.type].padEnd(maxTypeLen);
+        const displayFieldName = f.name || `field${fi}`;
         const arr   = f.count > 1 ? `[${f.count}]` : '';
         const fieldBytes = sz * f.count;
         const endianHint = f.endian !== 'inherit' ? `  /* ${f.endian} */` : '';
-        lines.push(`    ${cType} ${f.name}${arr};`.padEnd(44) +
+        lines.push(`    ${cType} ${displayFieldName}${arr};`.padEnd(44) +
             `/* +${offset.toString().padStart(3)}  ${fieldBytes}B${endianHint} */`);
         offset += fieldBytes;
-    }
+    });
 
     // Trailing padding
     const totalUnpadded = offset;
@@ -334,6 +335,7 @@ export function structToC(def: StructDef): string {
 
     const totalBytes = def.packed ? totalUnpadded : totalPadded;
     const alignNote  = def.packed ? 'packed' : `align=${maxAlign}`;
-    lines.push(`} ${def.name};`.padEnd(44) + `/* ${totalBytes}B, ${alignNote} */`);
+    const displayName = def.name || 'MyStruct';
+    lines.push(`} ${displayName};`.padEnd(44) + `/* ${totalBytes}B, ${alignNote} */`);
     return lines.join('\n');
 }

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -188,6 +188,29 @@
 .se-btns { display: flex; gap: 6px; margin-top: 2px; }
 
 /* ══ Instances panel (#s-struct-pins) ════════════════════════════ */
+#s-struct-pins { padding: 10px 12px; }
+
+/* Sliding two-panel track: main (instances) ←→ types */
+.si-panel-clip {
+    overflow: hidden; /* clips the off-screen panel */
+}
+.si-panel-track {
+    display: flex;
+    width: 200%;
+    transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.si-panel-track.si-showing-types {
+    transform: translateX(-50%);
+}
+.si-main-panel,
+.si-types-panel {
+    width: 50%; /* 50% of 200% = 100% of actual panel width */
+    min-width: 0;
+    flex-shrink: 0;
+}
+.si-types-panel {
+    padding-left: 1px; /* prevent border clipping on slide edge */
+}
 
 /* Header row: title + badge + ⚙ Types + LE/BE tabs + ＋ Add */
 .si-hdr-row {

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -82,16 +82,6 @@
     flex-shrink: 0; font-size: 9px; color: var(--addr-fg);
     font-family: var(--font-editor); white-space: nowrap;
 }
-.sd-btn {
-    flex-shrink: 0; width: 18px; height: 18px; padding: 0;
-    display: flex; align-items: center; justify-content: center;
-    background: transparent; border: none;
-    color: var(--addr-fg); font-size: 10px; cursor: pointer;
-    border-radius: 2px; opacity: 0; transition: opacity .1s, color .1s;
-}
-.sd-row:hover .sd-btn { opacity: 1; }
-.sd-edit:hover { color: var(--high-color); }
-.sd-del:hover  { color: var(--err); }
 
 /* ══ Struct form editor (#s-struct when editing) ═════════════════ */
 
@@ -217,6 +207,17 @@
 .si-add-btn:hover:not([disabled]) { background: rgba(79,195,247,.22); border-color: rgba(79,195,247,.6); }
 .si-add-btn[disabled] { opacity: .35; cursor: not-allowed; }
 
+/* Muted icon button (e.g. manage-types, edit-pin) */
+.si-icon-btn {
+    flex-shrink: 0;
+    background: transparent; border: 1px solid transparent;
+    border-radius: 3px; color: var(--addr-fg);
+    font-size: 11px; font-family: var(--font-ui);
+    padding: 2px 5px; cursor: pointer;
+    transition: background .1s, border-color .1s, color .1s;
+}
+.si-icon-btn:hover { background: rgba(255,255,255,.08); border-color: var(--border); color: var(--fg); }
+
 /* Inline add form */
 .si-add-form {
     display: flex; flex-direction: column; gap: 5px;
@@ -224,9 +225,27 @@
     border-radius: 4px; padding: 8px; margin-bottom: 8px;
 }
 
+/* Form mode header (＋ New Instance / ✎ Edit Instance) */
+.sa-form-hdr {
+    font-size: 10px; font-weight: 600; font-family: var(--font-ui);
+    padding-bottom: 5px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 1px;
+    -webkit-user-select: none; user-select: none;
+}
+.sa-form-hdr-new  { color: var(--high-color); }
+.sa-form-hdr-edit { color: var(--addr-fg); }
+
 .sa-row { display: flex; align-items: center; gap: 4px; }
 .sa-btn-row { gap: 6px; }
 .sa-endian-tabs { flex-shrink: 0; }
+
+/* Inline instance-edit form inside a card */
+.si-pin-edit-form {
+    display: flex; flex-direction: column; gap: 5px;
+    background: rgba(0,0,0,.18); border-top: 1px solid var(--border);
+    padding: 8px;
+}
 
 .struct-btn-cancel {
     background: transparent; border: 1px solid var(--border);
@@ -313,15 +332,12 @@
     font-family: var(--font-editor); white-space: nowrap;
     overflow: hidden; text-overflow: ellipsis;
 }
-.si-del-btn {
-    flex-shrink: 0; width: 16px; height: 16px; padding: 0;
-    display: flex; align-items: center; justify-content: center;
-    background: transparent; border: none;
-    color: var(--addr-fg); font-size: 10px; cursor: pointer;
-    border-radius: 2px; opacity: 0; transition: opacity .1s, color .1s;
+.si-del-btn { display: none; } /* superseded by .act-btn — kept to avoid selector errors */
+
+/* Action buttons group (edit + delete) at top-right of card */
+.si-card-actions {
+    flex-shrink: 0; display: flex; align-items: center; gap: 0;
 }
-.si-card:hover .si-del-btn { opacity: 1; }
-.si-del-btn:hover { color: var(--err); }
 
 /* Type-definition preview toggle button (in si-cmeta-row) */
 .si-type-btn {

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -4,7 +4,7 @@
 // Pure codec logic lives in struct-codec.ts.
 
 import { S }        from './state';
-import { esc }      from './utils';
+import { esc, actionBtnsHtml, wireActionBtns } from './utils';
 import { vscode }   from './api';
 import { rerender } from './render';
 import {
@@ -49,13 +49,20 @@ const _arrSepAddrs: number[] = [];
 let _selectedPinId: string | null = null;
 /** Pins whose type-definition preview is open inside the card. */
 const _previewedPins = new Set<string>();
+/** Whether the manage-types list view is open. */
+let _managingTypes = false;
+/** Pin id currently being edited inline (name/addr/type). */
+let _editingPinId: string | null = null;
+/** Struct type id selected in the inline instance-edit form (may differ from the saved pin). */
+let _editingPinDraftStructId: string | null = null;
 /**
  * When non-null the section is in "type editor" mode.
  * `existing` is null for new types, or the original def being edited.
  * `draft`    holds the working copy being modified.
  * `fromAdd`  is true when the editor was opened from the add-instance form.
+ * `fromManage` is true when opened from the manage-types list.
  */
-let _editingType: { draft: StructDef; existing: StructDef | null; fromAdd: boolean } | null = null;
+let _editingType: { draft: StructDef; existing: StructDef | null; fromAdd: boolean; fromManage: boolean } | null = null;
 
 // ── Inline type editor helpers ────────────────────────────────────
 
@@ -98,7 +105,7 @@ const SC_KW   = /\b(typedef|struct)\b/g;
 const SC_ATTR = /__attribute__\(\(packed\)\)/g;
 
 function structToCHtml(def: StructDef): string {
-    const nameEscRe = def.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const nameEscRe = (def.name || 'MyStruct').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const scTyp = new RegExp(
         `\\b(uint8_t|uint16_t|uint32_t|uint64_t|int8_t|int16_t|int32_t|int64_t|float|double|${nameEscRe})\\b`,
         'g'
@@ -140,7 +147,6 @@ function editorHtml(draft: StructDef, existing: StructDef | null): string {
         `<div class="se-btns">` +
         `<button id="se-save" class="struct-btn struct-btn-apply">Save</button>` +
         `<button id="se-cancel" class="struct-btn struct-btn-secondary">Cancel</button>` +
-        (existing ? `<button id="se-delete" class="struct-btn struct-btn-danger">Delete type</button>` : '') +
         `</div>` +
         `<div id="se-preview" class="se-preview"><pre class="si-c-preview">${structToCHtml(draft)}</pre></div>` +
         `</div>` +
@@ -149,11 +155,11 @@ function editorHtml(draft: StructDef, existing: StructDef | null): string {
 }
 
 function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
-    draft.name   = (sec.querySelector<HTMLInputElement>('#se-name'))?.value.trim() || draft.name;
+    draft.name   = (sec.querySelector<HTMLInputElement>('#se-name'))?.value.trim() ?? '';
     draft.packed = sec.querySelector('#se-packed')?.classList.contains('active') ?? false;
     const rows = sec.querySelectorAll<HTMLElement>('.struct-field-row');
     draft.fields = Array.from(rows).map(row => ({
-        name:   sanitizeCIdent((row.querySelector('.sfe-name-inp') as HTMLInputElement).value) || 'field',
+        name:   sanitizeCIdent((row.querySelector('.sfe-name-inp') as HTMLInputElement).value), 
         type:   (row.querySelector('.sfe-type-sel') as HTMLSelectElement).value as StructFieldType,
         count: (() => {
             const cell = row.querySelector<HTMLElement>('.sfe-arr-cell')!;
@@ -262,38 +268,49 @@ function wireEditorInSec(sec: HTMLElement): void {
 
     sec.querySelector('#se-save')!.addEventListener('click', () => {
         syncEditorDraft(sec, draft);
-        const nameInp = sec.querySelector<HTMLInputElement>('#se-name')!;
-        const name = nameInp.value.trim();
-        if (!name) { nameInp.style.borderColor = 'var(--err)'; return; }
         if (draft.fields.length === 0) { return; }
-        const def: StructDef = { id: draft.id, name, packed: draft.packed ?? false, fields: draft.fields };
+
+        // Auto-fill struct name if empty, ensuring uniqueness across existing structs
+        const nameInp = sec.querySelector<HTMLInputElement>('#se-name')!;
+        let name = nameInp.value.trim();
+        if (!name) {
+            const otherNames = new Set(S.structs.filter(d => d.id !== draft.id).map(d => d.name));
+            let candidate = 'MyStruct';
+            let n = 1;
+            while (otherNames.has(candidate)) { candidate = `MyStruct${n++}`; }
+            name = candidate;
+        }
+
+        // Auto-fill empty field names, ensuring uniqueness within the field list
+        const takenNames = new Set(draft.fields.map(f => f.name).filter(Boolean));
+        const savedFields = draft.fields.map((f, fi) => {
+            if (f.name) { return { ...f }; }
+            let candidate = `field${fi}`;
+            let n = 0;
+            while (takenNames.has(candidate)) { candidate = `field${fi}_${n++}`; }
+            takenNames.add(candidate);
+            return { ...f, name: candidate };
+        });
+
+        const def: StructDef = { id: draft.id, name, packed: draft.packed ?? false, fields: savedFields };
         const idx = S.structs.findIndex(d => d.id === def.id);
         if (idx >= 0) { S.structs[idx] = def; } else { S.structs.push(def); }
         vscode.postMessage({ type: 'saveStructs', structs: S.structs });
-        const wasFromAdd = _editingType!.fromAdd;
+        const { fromAdd, fromManage } = _editingType!;
         _editingType = null;
-        if (wasFromAdd) {
+        if (fromAdd) {
             _applyStructId = def.id;
             _addingPin = true;
         }
+        if (fromManage) { _managingTypes = true; }
         renderStructPins();
     });
 
     sec.querySelector('#se-cancel')!.addEventListener('click', () => {
-        const wasFromAdd = _editingType!.fromAdd;
+        const { fromAdd, fromManage } = _editingType!;
         _editingType = null;
-        if (wasFromAdd) { _addingPin = true; }
-        renderStructPins();
-    });
-
-    sec.querySelector<HTMLElement>('#se-delete')?.addEventListener('click', () => {
-        const id = _editingType!.draft.id;
-        S.structs    = S.structs.filter(d => d.id !== id);
-        S.structPins = S.structPins.filter(p => p.structId !== id);
-        if (_applyStructId === id) { _applyStructId = null; }
-        vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
-        vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
-        _editingType = null;
+        if (fromAdd)    { _addingPin = true; }
+        if (fromManage) { _managingTypes = true; }
         renderStructPins();
     });
 }
@@ -329,6 +346,74 @@ export function renderStructPins(): void {
         return;
     }
 
+    // ── Manage-types mode ──
+    if (_managingTypes) {
+        const typeRows = all.length === 0
+            ? `<div class="sb-empty">No types defined yet.</div>`
+            : all.map(d => {
+                const fieldCount = d.fields.length;
+                const meta = `${fieldCount} field${fieldCount !== 1 ? 's' : ''}`;
+                return (
+                    `<div class="sd-row">` +
+                    `<span class="sd-name">${esc(d.name)}</span>` +
+                    `<span class="sd-meta">${meta}</span>` +
+                    actionBtnsHtml(`data-struct-id="${esc(d.id)}"`, `data-struct-id="${esc(d.id)}"`) +
+                    `</div>`
+                );
+            }).join('');
+
+        sec.innerHTML =
+            `<div class="si-hdr-row">` +
+            `<span class="sb-hdr" style="margin:0">Struct Types</span>` +
+            `<button id="sm-new-btn" class="struct-btn struct-btn-secondary">New type</button>` +
+            `<button id="sm-close-btn" class="si-add-btn" title="Back">✕</button>` +
+            `</div>` +
+            `<div id="sm-list">${typeRows}</div>`;
+
+        document.getElementById('sm-close-btn')?.addEventListener('click', () => {
+            _managingTypes = false;
+            renderStructPins();
+        });
+        document.getElementById('sm-new-btn')?.addEventListener('click', () => {
+            _managingTypes = false;
+            const draftId = `user_${Date.now()}`;
+            _editingType = {
+                draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
+                existing: null,
+                fromAdd: false,
+                fromManage: true,
+            };
+            renderStructPins();
+        });
+        wireActionBtns(
+            sec,
+            '.act-btn-edit',
+            '.act-btn-del',
+            btn => {
+                const existing = S.structs.find(d => d.id === btn.dataset.structId) ?? null;
+                if (!existing) { return; }
+                _managingTypes = false;
+                _editingType = {
+                    draft: { id: existing.id, name: existing.name, packed: existing.packed ?? false, fields: existing.fields.map(f => ({ ...f })) },
+                    existing,
+                    fromAdd: false,
+                    fromManage: true,
+                };
+                renderStructPins();
+            },
+            btn => {
+                const id = btn.dataset.structId!;
+                S.structs    = S.structs.filter(d => d.id !== id);
+                S.structPins = S.structPins.filter(p => p.structId !== id);
+                if (_applyStructId === id) { _applyStructId = null; }
+                vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
+                vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
+                renderStructPins();
+            },
+        );
+        return;
+    }
+
     const instBadge = S.structPins.length > 0 ? `<span class="sb-badge">${S.structPins.length}</span>` : '';
 
     // ── Inline add form ──
@@ -342,7 +427,7 @@ export function renderStructPins(): void {
         if (all.length === 0) {
             typeRowHtml =
                 `<div class="sa-row sa-no-types-row">` +
-                `<span class="sa-no-types-msg">No types yet.</span>` +
+                `<span class="sa-no-types-msg">No struct types yet — create one first.</span>` +
                 `<button id="sa-new-type-btn" class="struct-btn struct-btn-secondary">New type</button>` +
                 `</div>`;
         } else {
@@ -362,23 +447,26 @@ export function renderStructPins(): void {
 
         addFormHtml =
             `<div id="si-add-form" class="si-add-form">` +
-            typeRowHtml +
+            `<div class="sa-form-hdr sa-form-hdr-new">\uff0b New Instance</div>` +
+            `<div class="sa-row">` +
+            `<input id="sa-name" class="sa-name-inp" type="text" maxlength="40" ` +
+                   `placeholder="instance name" spellcheck="false" autocomplete="off">` +
+            `</div>` +
             `<div class="sa-row">` +
             `<span class="struct-addr-pfx">0x</span>` +
             `<input id="sa-addr" class="struct-addr-inp sa-addr-inp" type="text" maxlength="8" ` +
                    `placeholder="08000000" autocomplete="off" spellcheck="false" value="${esc(addrVal)}">` +
-            `<input id="sa-name" class="sa-name-inp" type="text" maxlength="40" ` +
-                   `placeholder="instance name" spellcheck="false" autocomplete="off">` +
             `</div>` +
+            typeRowHtml +
             `<div class="sa-row sa-btn-row">` +
-            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${!_applyStructId ? ' disabled' : ''}>Confirm</button>` +
+            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${(!_applyStructId || !addrVal) ? ' disabled' : ''}>Confirm</button>` +
             `<button id="sa-cancel" class="struct-btn struct-btn-cancel">Cancel</button>` +
             `</div>` +
             `</div>`;
     }
 
     const instHtml = S.structPins.length === 0
-        ? `<div class="sb-empty">No instances yet. Click \uff0b Add to create one.</div>`
+        ? `<div class="sb-empty">No instances yet. Click [\uff0b Add] to create one.</div>`
         : S.structPins.map((pin, i) => buildInstanceCard(pin, i)).join('');
 
     sec.innerHTML =
@@ -389,15 +477,23 @@ export function renderStructPins(): void {
         `<button id="sa-btn-be" class="${S.endian === 'be' ? 'active' : ''}">BE</button>` +
         `</div>` +
         `<button id="si-add-btn" class="si-add-btn"${_addingPin ? ' disabled' : ''}>\uff0b Add</button>` +
+        `<button id="si-types-btn" class="si-icon-btn" title="Manage types">&#9776;</button>` +
         `</div>` +
         addFormHtml +
         `<div id="si-list">${instHtml}</div>`;
 
     // ── ＋ Add button ──
-    document.getElementById('si-add-btn')!.addEventListener('click', () => {
+    document.getElementById('si-add-btn')?.addEventListener('click', () => {
         _addingPin = true;
         renderStructPins();
         document.getElementById('sa-name')?.focus();
+    });
+
+    // ── Types button ──
+    document.getElementById('si-types-btn')?.addEventListener('click', () => {
+        _managingTypes = true;
+        _addingPin = false;
+        renderStructPins();
     });
 
     // ── Add-form wiring ──
@@ -413,21 +509,35 @@ export function renderStructPins(): void {
                 draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
                 existing: null,
                 fromAdd: true,
+                fromManage: false,
             };
             renderStructPins();
         });
-        document.getElementById('sa-confirm')!.addEventListener('click', () => {
+        document.getElementById('sa-addr')?.addEventListener('input', () => {
+            const addrInp = document.getElementById('sa-addr') as HTMLInputElement | null;
+            const confirmBtn = document.getElementById('sa-confirm') as HTMLButtonElement | null;
+            if (!addrInp || !confirmBtn) { return; }
+            const hasAddr = addrInp.value.trim().length > 0;
+            confirmBtn.disabled = !_applyStructId || !hasAddr;
+        });
+        document.getElementById('sa-confirm')?.addEventListener('click', () => {
             if (!_applyStructId) { return; }
             const addrInp = document.getElementById('sa-addr') as HTMLInputElement;
             const nameInp = document.getElementById('sa-name') as HTMLInputElement;
             const addr    = parseInt(addrInp.value.replace(/^0x/i, ''), 16);
-            const name    = nameInp.value.trim();
-            let ok = true;
-            if (isNaN(addr)) { addrInp.style.borderColor = 'var(--err)'; ok = false; }
-            else              { addrInp.style.borderColor = ''; }
-            if (!name)        { nameInp.style.borderColor = 'var(--err)'; ok = false; }
-            else              { nameInp.style.borderColor = ''; }
-            if (!ok) { return; }
+            if (isNaN(addr)) { addrInp.style.borderColor = 'var(--err)'; return; }
+            addrInp.style.borderColor = '';
+            // Auto-fill instance name if empty, unique among existing pin names
+            let name = nameInp.value.trim();
+            if (!name) {
+                const applyDef = S.structs.find(d => d.id === _applyStructId);
+                const base = applyDef ? applyDef.name : 'inst';
+                const takenPinNames = new Set(S.structPins.map(p => p.name));
+                let candidate = `${base}_0`;
+                let n = 1;
+                while (takenPinNames.has(candidate)) { candidate = `${base}_${n++}`; }
+                name = candidate;
+            }
             const pin: StructPin = { id: `pin_${Date.now()}`, structId: _applyStructId, addr, name };
             S.structPins       = [...S.structPins, pin];
             S.activeStructAddr = addr;
@@ -435,23 +545,23 @@ export function renderStructPins(): void {
             vscode.postMessage({ type: 'saveStructPins', pins: S.structPins });
             renderStructPins();
         });
-        document.getElementById('sa-cancel')!.addEventListener('click', () => {
+        document.getElementById('sa-cancel')?.addEventListener('click', () => {
             _addingPin = false;
             renderStructPins();
         });
     }
 
     // ── Endian tabs ──
-    document.getElementById('sa-btn-le')!.addEventListener('click', () => {
+    document.getElementById('sa-btn-le')?.addEventListener('click', () => {
         S.endian = 'le';
-        document.getElementById('sa-btn-le')!.classList.add('active');
-        document.getElementById('sa-btn-be')!.classList.remove('active');
+        document.getElementById('sa-btn-le')?.classList.add('active');
+        document.getElementById('sa-btn-be')?.classList.remove('active');
         if (_expanded.size > 0) { renderStructPins(); }
     });
-    document.getElementById('sa-btn-be')!.addEventListener('click', () => {
+    document.getElementById('sa-btn-be')?.addEventListener('click', () => {
         S.endian = 'be';
-        document.getElementById('sa-btn-be')!.classList.add('active');
-        document.getElementById('sa-btn-le')!.classList.remove('active');
+        document.getElementById('sa-btn-be')?.classList.add('active');
+        document.getElementById('sa-btn-le')?.classList.remove('active');
         if (_expanded.size > 0) { renderStructPins(); }
     });
 
@@ -655,6 +765,42 @@ function buildInstanceCard(pin: StructPin, i: number): string {
           `</div>`
         : '';
 
+    const isEditingThis = _editingPinId === pin.id;
+
+    // Inline edit form replaces the card header area
+    let editFormHtml = '';
+    if (isEditingThis) {
+        const draftStructId = _editingPinDraftStructId ?? pin.structId;
+        const structOpts = allStructs().map(d =>
+            `<option value="${esc(d.id)}"${d.id === draftStructId ? ' selected' : ''}>${esc(d.name)}</option>`
+        ).join('');
+        const editDef = allStructs().find(d => d.id === draftStructId);
+        const editPreviewHtml = editDef
+            ? `<pre class="si-c-preview">${structToCHtml(editDef)}</pre>`
+            : '';
+        editFormHtml =
+            `<div class="si-pin-edit-form">` +
+            `<div class="sa-form-hdr sa-form-hdr-edit">&#9998; Edit Instance</div>` +
+            `<div class="sa-row">` +
+            `<input class="si-pe-name sa-name-inp" type="text" maxlength="40" ` +
+                   `placeholder="instance name" spellcheck="false" autocomplete="off" value="${esc(pin.name)}">` +
+            `</div>` +
+            `<div class="sa-row">` +
+            `<span class="struct-addr-pfx">0x</span>` +
+            `<input class="si-pe-addr struct-addr-inp sa-addr-inp" type="text" maxlength="8" ` +
+                   `autocomplete="off" spellcheck="false" placeholder="08000000" value="${esc(addrHex)}">` +
+            `</div>` +
+            `<div class="sa-row">` +
+            `<select class="si-pe-type struct-sel">${structOpts}</select>` +
+            `</div>` +
+            editPreviewHtml +
+            `<div class="sa-row sa-btn-row">` +
+            `<button class="si-pe-save struct-btn struct-btn-apply">Save</button>` +
+            `<button class="si-pe-cancel struct-btn struct-btn-cancel">Cancel</button>` +
+            `</div>` +
+            `</div>`;
+    }
+
     return (
         `<div class="si-card${expanded ? ' si-expanded' : ''}" data-pin-id="${esc(pin.id)}" data-idx="${i}">` +
         `<div class="si-card-hdr">` +
@@ -664,15 +810,16 @@ function buildInstanceCard(pin: StructPin, i: number): string {
         `<div class="si-cmeta-row">` +
         `<span class="si-ctype">${esc(defName)}</span>` +
         `<button class="si-type-btn${_previewedPins.has(pin.id) ? ' active' : ''}" ` +
-        `data-pin-id="${esc(pin.id)}" title="View type definition">&#x29C9;</button>` +
-        (def ? `<button class="si-edit-type-btn" data-struct-id="${esc(def.id)}" title="Edit type">✎</button>` : '') +
+        `data-pin-id="${esc(pin.id)}" title="View type definition">{&nbsp;}</button>` +
         `<span class="si-caddr">0x${addrHex}\u202f\u00b7\u202f${totalBytes}B</span>` +
         `</div>` +
         `</div>` +
-        `<button class="si-del-btn" data-idx="${i}" title="Remove">\u2715</button>` +
+        `<div class="si-card-actions">` +
+        (def ? actionBtnsHtml(`data-pin-id="${esc(pin.id)}"`, `data-idx="${i}"`) : `<span class="act-btn act-btn-del" data-idx="${i}" title="Delete">&#128465;&#xFE0E;</span>`) +
         `</div>` +
-        typePreviewHtml +
-        bodyHtml +
+        `</div>` +
+        editFormHtml +
+        (isEditingThis ? '' : typePreviewHtml + bodyHtml) +
         `</div>`
     );
 }
@@ -765,7 +912,7 @@ function wireInstanceCards(sec: HTMLElement): void {
 
     sec.querySelectorAll<HTMLElement>('.si-card-hdr').forEach(hdr => {
         hdr.addEventListener('click', e => {
-            if ((e.target as HTMLElement).closest('.si-expand-btn, .si-del-btn')) { return; }
+            if ((e.target as HTMLElement).closest('.si-expand-btn, .si-card-actions, .si-type-btn')) { return; }
             clearArrSep();
             clearSelRow();
             _selectedFieldAddr = null;
@@ -789,15 +936,30 @@ function wireInstanceCards(sec: HTMLElement): void {
         });
     });
 
-    sec.querySelectorAll<HTMLElement>('.si-del-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const idx = parseInt(btn.dataset.idx!);
-            const pin = S.structPins[idx];
-            if (pin) { _expanded.delete(pin.id); }
-            S.structPins = S.structPins.filter((_, i) => i !== idx);
-            vscode.postMessage({ type: 'saveStructPins', pins: S.structPins });
-            renderStructPins();
-        });
+    // Wire edit + delete action buttons on each instance card
+    sec.querySelectorAll<HTMLElement>('.si-card').forEach(card => {
+        const actions = card.querySelector<HTMLElement>('.si-card-actions');
+        if (!actions) { return; }
+        wireActionBtns(
+            actions,
+            '.act-btn-edit',
+            '.act-btn-del',
+            btn => {
+                _editingPinId = btn.dataset.pinId!;
+                const editedPin = S.structPins.find(p => p.id === _editingPinId);
+                _editingPinDraftStructId = editedPin?.structId ?? null;
+                _expanded.delete(_editingPinId);
+                renderStructPins();
+            },
+            btn => {
+                const idx = parseInt(btn.dataset.idx!);
+                const pin = S.structPins[idx];
+                if (pin) { _expanded.delete(pin.id); }
+                S.structPins = S.structPins.filter((_, i) => i !== idx);
+                vscode.postMessage({ type: 'saveStructPins', pins: S.structPins });
+                renderStructPins();
+            },
+        );
     });
 
     sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
@@ -881,21 +1043,49 @@ function wireInstanceCards(sec: HTMLElement): void {
         });
     });
 
-    // Edit-type button on card
-    sec.querySelectorAll<HTMLElement>('.si-edit-type-btn').forEach(btn => {
-        btn.addEventListener('click', e => {
-            e.stopPropagation();
-            const structId = btn.dataset.structId!;
-            const existing = S.structs.find(d => d.id === structId) ?? null;
-            if (!existing) { return; }
-            _editingType = {
-                draft: { id: existing.id, name: existing.name, packed: existing.packed ?? false, fields: existing.fields.map(f => ({ ...f })) },
-                existing,
-                fromAdd: false,
-            };
-            renderStructPins();
-        });
-    });
+    // Inline pin-edit form wiring
+    if (_editingPinId) {
+        const editForm = sec.querySelector<HTMLElement>('.si-pin-edit-form');
+        if (editForm) {
+            const pinId = _editingPinId;
+            editForm.querySelector<HTMLSelectElement>('.si-pe-type')?.addEventListener('change', e => {
+                _editingPinDraftStructId = (e.target as HTMLSelectElement).value || null;
+                renderStructPins();
+            });
+            editForm.querySelector<HTMLElement>('.si-pe-save')!.addEventListener('click', e => {
+                e.stopPropagation();
+                const nameVal = (editForm.querySelector('.si-pe-name') as HTMLInputElement).value.trim();
+                const addrVal = (editForm.querySelector('.si-pe-addr') as HTMLInputElement).value.trim();
+                const typeVal = (editForm.querySelector('.si-pe-type') as HTMLSelectElement).value;
+                const addr = parseInt(addrVal.replace(/^0x/i, ''), 16);
+                if (isNaN(addr)) {
+                    (editForm.querySelector('.si-pe-addr') as HTMLInputElement).style.borderColor = 'var(--err)';
+                    return;
+                }
+                const idx = S.structPins.findIndex(p => p.id === pinId);
+                if (idx >= 0) {
+                    const pin = S.structPins[idx];
+                    S.structPins[idx] = {
+                        ...pin,
+                        name: nameVal || pin.name,
+                        addr,
+                        structId: typeVal,
+                    };
+                    S.activeStructAddr = addr;
+                    vscode.postMessage({ type: 'saveStructPins', pins: S.structPins });
+                }
+                _editingPinId = null;
+                _editingPinDraftStructId = null;
+                renderStructPins();
+            });
+            editForm.querySelector<HTMLElement>('.si-pe-cancel')!.addEventListener('click', e => {
+                e.stopPropagation();
+                _editingPinId = null;
+                _editingPinDraftStructId = null;
+                renderStructPins();
+            });
+        }
+    }
 
     // Re-apply selection highlight after DOM rebuild
     if (_selectedPinId !== null) {
@@ -1200,8 +1390,14 @@ export function onSelectionChangeForStruct(): void {
     _selectedPinId     = null;
     if (S.selStart === null) { return; }
     S.activeStructAddr = S.selStart;
-    if (S.sidebarTab === 'struct' && _addingPin) {
-        const inp = document.getElementById('sa-addr') as HTMLInputElement | null;
-        if (inp) { inp.value = S.selStart.toString(16).toUpperCase().padStart(8, '0'); }
+    if (S.sidebarTab === 'struct') {
+        const addrHex = S.selStart.toString(16).toUpperCase().padStart(8, '0');
+        if (_addingPin) {
+            const inp = document.getElementById('sa-addr') as HTMLInputElement | null;
+            if (inp) { inp.value = addrHex; }
+        } else if (_editingPinId) {
+            const inp = document.querySelector<HTMLInputElement>('.si-pe-addr');
+            if (inp) { inp.value = addrHex; }
+        }
     }
 }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -133,9 +133,6 @@ function editorHtml(draft: StructDef, existing: StructDef | null): string {
     const fieldRows = draft.fields.map((f, i) => fieldRowHtml(f, i, n === 1, n)).join('');
     return (
         `<div class="si-editor-wrap">` +
-        `<div class="si-editor-hdr-row">` +
-        `<span class="sb-hdr" style="margin:0">${existing ? 'Edit Type' : 'New Type'}</span>` +
-        `</div>` +
         `<div class="se-form">` +
         `<input id="se-name" class="se-name-inp" type="text" value="${esc(draft.name)}" ` +
                `maxlength="64" placeholder="TypeName" spellcheck="false" autocomplete="off">` +
@@ -296,21 +293,24 @@ function wireEditorInSec(sec: HTMLElement): void {
         const idx = S.structs.findIndex(d => d.id === def.id);
         if (idx >= 0) { S.structs[idx] = def; } else { S.structs.push(def); }
         vscode.postMessage({ type: 'saveStructs', structs: S.structs });
-        const { fromAdd, fromManage } = _editingType!;
+        const { fromAdd } = _editingType!;
         _editingType = null;
         if (fromAdd) {
             _applyStructId = def.id;
             _addingPin = true;
+            _managingTypes = false;
         }
-        if (fromManage) { _managingTypes = true; }
+        // fromManage: _managingTypes stays true → re-render shows updated type list
         renderStructPins();
     });
 
     sec.querySelector('#se-cancel')!.addEventListener('click', () => {
-        const { fromAdd, fromManage } = _editingType!;
+        const { fromAdd } = _editingType!;
         _editingType = null;
-        if (fromAdd)    { _addingPin = true; }
-        if (fromManage) { _managingTypes = true; }
+        if (fromAdd) {
+            _addingPin = true;
+            _managingTypes = false;
+        }
         renderStructPins();
     });
 }
@@ -338,81 +338,23 @@ export function renderStructPins(): void {
         _applyStructId = all[0].id;
     }
 
-    // ── Editor mode: replace section content with the type editor ──
-    if (_editingType) {
-        sec.innerHTML = editorHtml(_editingType.draft, _editingType.existing);
-        wireEditorInSec(sec);
-        sec.querySelector<HTMLInputElement>('#se-name')?.focus();
-        return;
-    }
+    // When editing a type, ensure the types panel is visible
+    if (_editingType) { _managingTypes = true; }
 
-    // ── Manage-types mode ──
-    if (_managingTypes) {
-        const typeRows = all.length === 0
-            ? `<div class="sb-empty">No types defined yet.</div>`
-            : all.map(d => {
-                const fieldCount = d.fields.length;
-                const meta = `${fieldCount} field${fieldCount !== 1 ? 's' : ''}`;
-                return (
-                    `<div class="sd-row">` +
-                    `<span class="sd-name">${esc(d.name)}</span>` +
-                    `<span class="sd-meta">${meta}</span>` +
-                    actionBtnsHtml(`data-struct-id="${esc(d.id)}"`, `data-struct-id="${esc(d.id)}"`) +
-                    `</div>`
-                );
-            }).join('');
-
-        sec.innerHTML =
-            `<div class="si-hdr-row">` +
-            `<span class="sb-hdr" style="margin:0">Struct Types</span>` +
-            `<button id="sm-new-btn" class="struct-btn struct-btn-secondary">New type</button>` +
-            `<button id="sm-close-btn" class="si-add-btn" title="Back">✕</button>` +
-            `</div>` +
-            `<div id="sm-list">${typeRows}</div>`;
-
-        document.getElementById('sm-close-btn')?.addEventListener('click', () => {
-            _managingTypes = false;
-            renderStructPins();
-        });
-        document.getElementById('sm-new-btn')?.addEventListener('click', () => {
-            _managingTypes = false;
-            const draftId = `user_${Date.now()}`;
-            _editingType = {
-                draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
-                existing: null,
-                fromAdd: false,
-                fromManage: true,
-            };
-            renderStructPins();
-        });
-        wireActionBtns(
-            sec,
-            '.act-btn-edit',
-            '.act-btn-del',
-            btn => {
-                const existing = S.structs.find(d => d.id === btn.dataset.structId) ?? null;
-                if (!existing) { return; }
-                _managingTypes = false;
-                _editingType = {
-                    draft: { id: existing.id, name: existing.name, packed: existing.packed ?? false, fields: existing.fields.map(f => ({ ...f })) },
-                    existing,
-                    fromAdd: false,
-                    fromManage: true,
-                };
-                renderStructPins();
-            },
-            btn => {
-                const id = btn.dataset.structId!;
-                S.structs    = S.structs.filter(d => d.id !== id);
-                S.structPins = S.structPins.filter(p => p.structId !== id);
-                if (_applyStructId === id) { _applyStructId = null; }
-                vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
-                vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
-                renderStructPins();
-            },
-        );
-        return;
-    }
+    // ── Build types panel ──
+    const typeRows = all.length === 0
+        ? `<div class="sb-empty">No types defined yet.</div>`
+        : all.map(d => {
+            const fieldCount = d.fields.length;
+            const meta = `${fieldCount} field${fieldCount !== 1 ? 's' : ''}`;
+            return (
+                `<div class="sd-row">` +
+                `<span class="sd-name">${esc(d.name)}</span>` +
+                `<span class="sd-meta">${meta}</span>` +
+                actionBtnsHtml(`data-struct-id="${esc(d.id)}"`, `data-struct-id="${esc(d.id)}"`) +
+                `</div>`
+            );
+        }).join('');
 
     const instBadge = S.structPins.length > 0 ? `<span class="sb-badge">${S.structPins.length}</span>` : '';
 
@@ -459,7 +401,7 @@ export function renderStructPins(): void {
             `</div>` +
             typeRowHtml +
             `<div class="sa-row sa-btn-row">` +
-            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${(!_applyStructId || !addrVal) ? ' disabled' : ''}>Confirm</button>` +
+            `<button id="sa-confirm" class="struct-btn struct-btn-apply"${!_applyStructId ? ' disabled' : ''}>Confirm</button>` +
             `<button id="sa-cancel" class="struct-btn struct-btn-cancel">Cancel</button>` +
             `</div>` +
             `</div>`;
@@ -469,7 +411,13 @@ export function renderStructPins(): void {
         ? `<div class="sb-empty">No instances yet. Click [\uff0b Add] to create one.</div>`
         : S.structPins.map((pin, i) => buildInstanceCard(pin, i)).join('');
 
+    // ── Both panels rendered side-by-side; CSS slides between them ──
     sec.innerHTML =
+        `<div class="si-panel-clip">` +
+        `<div class="si-panel-track${_managingTypes ? ' si-showing-types' : ''}" id="si-track">` +
+
+        // ── Main panel (instances) ──
+        `<div class="si-main-panel">` +
         `<div class="si-hdr-row">` +
         `<span class="sb-hdr" style="margin:0">Struct Instances ${instBadge}</span>` +
         `<div class="endian-tabs sa-endian-tabs">` +
@@ -480,7 +428,84 @@ export function renderStructPins(): void {
         `<button id="si-types-btn" class="si-icon-btn" title="Manage types">&#9776;</button>` +
         `</div>` +
         addFormHtml +
-        `<div id="si-list">${instHtml}</div>`;
+        `<div id="si-list">${instHtml}</div>` +
+        `</div>` +
+
+        // ── Types panel ──
+        `<div class="si-types-panel">` +
+        `<div class="si-hdr-row">` +
+        `<button id="sm-close-btn" class="si-icon-btn" title="${_editingType ? 'Cancel' : 'Back'}">&#8592;</button>` +
+        `<span class="sb-hdr" style="margin:0">${_editingType ? (_editingType.existing ? 'Edit Type' : 'New Type') : 'Struct Types'}</span>` +
+        (!_editingType ? `<button id="sm-new-btn" class="struct-btn struct-btn-secondary">New type</button>` : '') +
+        `</div>` +
+        (_editingType ? editorHtml(_editingType.draft, _editingType.existing) : `<div id="sm-list">${typeRows}</div>`) +
+        `</div>` +
+
+        `</div>` + // si-panel-track
+        `</div>`; // si-panel-clip
+
+    // ── Types button: slide in (no re-render) ──
+    document.getElementById('si-types-btn')?.addEventListener('click', () => {
+        _managingTypes = true;
+        document.getElementById('si-track')?.classList.add('si-showing-types');
+    });
+
+    // ── Close/cancel: if editing a type cancel it; otherwise slide back ──
+    document.getElementById('sm-close-btn')?.addEventListener('click', () => {
+        if (_editingType) {
+            const { fromAdd } = _editingType;
+            _editingType = null;
+            if (fromAdd) {
+                _addingPin = true;
+                _managingTypes = false;
+            }
+            // fromManage: stay on types panel (re-render shows type list)
+            renderStructPins();
+        } else {
+            _managingTypes = false;
+            document.getElementById('si-track')?.classList.remove('si-showing-types');
+        }
+    });
+
+    // ── New type (from types panel) ──
+    document.getElementById('sm-new-btn')?.addEventListener('click', () => {
+        const draftId = `user_${Date.now()}`;
+        _editingType = {
+            draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
+            existing: null,
+            fromAdd: false,
+            fromManage: true,
+        };
+        renderStructPins();
+    });
+
+    // ── Edit / delete type actions ──
+    const typesPanel = sec.querySelector<HTMLElement>('.si-types-panel')!;
+    wireActionBtns(
+        typesPanel,
+        '.act-btn-edit',
+        '.act-btn-del',
+        btn => {
+            const existing = S.structs.find(d => d.id === btn.dataset.structId) ?? null;
+            if (!existing) { return; }
+            _editingType = {
+                draft: { id: existing.id, name: existing.name, packed: existing.packed ?? false, fields: existing.fields.map(f => ({ ...f })) },
+                existing,
+                fromAdd: false,
+                fromManage: true,
+            };
+            renderStructPins();
+        },
+        btn => {
+            const id = btn.dataset.structId!;
+            S.structs    = S.structs.filter(d => d.id !== id);
+            S.structPins = S.structPins.filter(p => p.structId !== id);
+            if (_applyStructId === id) { _applyStructId = null; }
+            vscode.postMessage({ type: 'saveStructs',    structs: S.structs });
+            vscode.postMessage({ type: 'saveStructPins', pins:    S.structPins });
+            renderStructPins();
+        },
+    );
 
     // ── ＋ Add button ──
     document.getElementById('si-add-btn')?.addEventListener('click', () => {
@@ -489,17 +514,16 @@ export function renderStructPins(): void {
         document.getElementById('sa-name')?.focus();
     });
 
-    // ── Types button ──
-    document.getElementById('si-types-btn')?.addEventListener('click', () => {
-        _managingTypes = true;
-        _addingPin = false;
-        renderStructPins();
-    });
-
     // ── Add-form wiring ──
     if (_addingPin) {
         document.getElementById('sa-struct-sel')?.addEventListener('change', e => {
             _applyStructId = (e.target as HTMLSelectElement).value || null;
+            // Preserve any address the user already typed before re-render
+            const curAddrInp = document.getElementById('sa-addr') as HTMLInputElement | null;
+            if (curAddrInp?.value) {
+                const v = parseInt(curAddrInp.value, 16);
+                if (!isNaN(v)) { S.activeStructAddr = v; }
+            }
             renderStructPins();
         });
         document.getElementById('sa-new-type-btn')?.addEventListener('click', () => {
@@ -527,7 +551,6 @@ export function renderStructPins(): void {
             const addr    = parseInt(addrInp.value.replace(/^0x/i, ''), 16);
             if (isNaN(addr)) { addrInp.style.borderColor = 'var(--err)'; return; }
             addrInp.style.borderColor = '';
-            // Auto-fill instance name if empty, unique among existing pin names
             let name = nameInp.value.trim();
             if (!name) {
                 const applyDef = S.structs.find(d => d.id === _applyStructId);
@@ -566,7 +589,24 @@ export function renderStructPins(): void {
     });
 
     wireInstanceCards(sec);
+
+    // ── If a type is being edited, wire up the editor inside the types panel ──
+    if (_editingType) {
+        wireEditorInSec(sec);
+        sec.querySelector<HTMLInputElement>('#se-name')?.focus();
+    }
 }
+
+/** Resets all transient view state for the struct panel and re-renders. Call when switching away and back. */
+export function resetStructViewState(): void {
+    _editingType             = null;
+    _addingPin               = false;
+    _managingTypes           = false;
+    _editingPinId            = null;
+    _editingPinDraftStructId = null;
+    renderStructPins();
+}
+
 /** Get a display string for a field given the requested column display type. */
 function getValForType(r: DecodedField, valType: ColType): string {
     if (!r.hasData) { return '??'; }
@@ -1394,7 +1434,11 @@ export function onSelectionChangeForStruct(): void {
         const addrHex = S.selStart.toString(16).toUpperCase().padStart(8, '0');
         if (_addingPin) {
             const inp = document.getElementById('sa-addr') as HTMLInputElement | null;
-            if (inp) { inp.value = addrHex; }
+            if (inp) {
+                inp.value = addrHex;
+                const confirmBtn = document.getElementById('sa-confirm') as HTMLButtonElement | null;
+                if (confirmBtn) { confirmBtn.disabled = !_applyStructId; }
+            }
         } else if (_editingPinId) {
             const inp = document.querySelector<HTMLInputElement>('.si-pe-addr');
             if (inp) { inp.value = addrHex; }

--- a/src/webview/utils.ts
+++ b/src/webview/utils.ts
@@ -21,3 +21,118 @@ export function byteClass(v: number): string {
     if (v >= 0x80)            { return 'bh'; }  // high  → cool
     return 'bn';                                 // control → default
 }
+
+/**
+ * Returns HTML for a paired edit + delete action button group.
+ * Both buttons use the shared `.act-btn` class.
+ *
+ * @param editData   - data-* attributes for the edit button, e.g. `data-id="foo"`
+ * @param deleteData - data-* attributes for the delete button
+ */
+export function actionBtnsHtml(editData: string, deleteData: string): string {
+    return (
+        `<span class="act-btn act-btn-edit" ${editData} title="Edit">&#9998;</span>` +
+        `<span class="act-btn act-btn-del"  ${deleteData} title="Delete">&#128465;&#xFE0E;</span>`
+    );
+}
+
+/**
+ * Wires edit and delete buttons produced by actionBtnsHtml inside `container`.
+ * Edit buttons are selected by `.act-btn-edit[data-key="${key}"]`,
+ * delete buttons by `.act-btn-del[data-key="${key}"]`.
+ * The delete button uses inlineConfirm before calling onDelete.
+ */
+export function wireActionBtns(
+    container: HTMLElement,
+    editSelector:   string,
+    deleteSelector: string,
+    onEdit:   (el: HTMLElement) => void,
+    onDelete: (el: HTMLElement) => void,
+): void {
+    container.querySelectorAll<HTMLElement>(editSelector).forEach(el => {
+        el.addEventListener('click', e => { e.stopPropagation(); onEdit(el); });
+    });
+    container.querySelectorAll<HTMLElement>(deleteSelector).forEach(el => {
+        el.addEventListener('click', e => {
+            e.stopPropagation();
+            inlineConfirm(el, () => onDelete(el));
+        });
+    });
+}
+
+/**
+ * Show a small "Delete?" popover anchored above `anchor`.
+ * Clicking Yes calls `onConfirm`; clicking No or outside dismisses it.
+ * Only one popover is live at a time.
+ */
+export function inlineConfirm(anchor: HTMLElement, onConfirm: () => void): void {
+    // Remove any existing popover first
+    dismissConfirmPopover();
+
+    const pop = document.createElement('div');
+    pop.id = 'del-confirm-pop';
+    pop.className = 'del-confirm-pop';
+    pop.innerHTML =
+        '<span class="dcp-msg">Delete?</span>' +
+        '<button class="dcp-yes">Yes</button>' +
+        '<button class="dcp-no">No</button>';
+
+    document.body.appendChild(pop);
+
+    // Position above the anchor
+    const r = anchor.getBoundingClientRect();
+    pop.style.position = 'fixed';
+    // Initially offscreen so we can measure size, then reposition
+    pop.style.visibility = 'hidden';
+    pop.style.left = '0';
+    pop.style.top  = '0';
+
+    // After paint, measure and place
+    requestAnimationFrame(() => {
+        const pw = pop.offsetWidth;
+        const ph = pop.offsetHeight;
+        const gap = 6;
+        let left = r.left + r.width / 2 - pw / 2;
+        let top  = r.top - ph - gap;
+
+        // Keep within viewport horizontally
+        left = Math.max(4, Math.min(left, window.innerWidth - pw - 4));
+        // If no room above, flip below
+        if (top < 4) { top = r.bottom + gap; }
+
+        pop.style.left = `${left}px`;
+        pop.style.top  = `${top}px`;
+        pop.style.visibility = '';
+    });
+
+    const cleanup = (confirmed: boolean) => {
+        pop.remove();
+        document.removeEventListener('mousedown', outsideHandler, true);
+        document.removeEventListener('keydown',   keyHandler,     true);
+        if (confirmed) { onConfirm(); }
+    };
+
+    pop.querySelector<HTMLElement>('.dcp-yes')!.addEventListener('click', e => {
+        e.stopPropagation(); cleanup(true);
+    });
+    pop.querySelector<HTMLElement>('.dcp-no')!.addEventListener('click', e => {
+        e.stopPropagation(); cleanup(false);
+    });
+
+    const outsideHandler = (e: MouseEvent) => {
+        if (!pop.contains(e.target as Node)) { cleanup(false); }
+    };
+    const keyHandler = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') { cleanup(false); }
+    };
+
+    // Delay adding outside-click so the originating click doesn't immediately close it
+    setTimeout(() => {
+        document.addEventListener('mousedown', outsideHandler, true);
+        document.addEventListener('keydown',   keyHandler,     true);
+    }, 0);
+}
+
+function dismissConfirmPopover(): void {
+    document.getElementById('del-confirm-pop')?.remove();
+}


### PR DESCRIPTION
## Summary

A series of UX improvements to the Inspector and Struct Overlay sidebar panels.

### Struct Overlay panel

- **Slide-in types panel** — clicking ☰ Manage Types slides the types list in from the right (CSS `translateX` transition) instead of replacing the entire view. Both panels live in the DOM simultaneously; toggling only flips a CSS class — no re-render.
- **Inline type editor** — creating or editing a struct type now happens inside the types panel rather than replacing the whole section. The panel header updates to "New Type" / "Edit Type" and the ← back button cancels the edit and returns to the type list.
- **Confirm button fixes** — the Confirm button in the add-instance form is no longer incorrectly disabled when no address is pre-filled. Selecting a byte in the hex view now correctly re-enables the button. Typed addresses are preserved when changing the struct type selection (preventing loss on re-render).
- **Removed spurious collapse triangle** — `#s-struct-pins` no longer carries `sb-section`, which was injecting a collapse toggle arrow on every panel header. Padding is applied directly via `#s-struct-pins`.

### Tab state reset

- Switching to **Inspector**: resets all transient struct view state (open type editor, add form, inline pin edit) and re-renders the struct panel cleanly.
- Switching to **Struct Overlay**: re-renders the labels section, closing any open label add/edit form.

### Label improvements (earlier in branch)

- Address autofills when the add-label form is open and the user clicks a byte, or pre-fills when opening the form with a selection active.
- Label name autofills with a unique `Label_0`, `Label_1`… name if left blank.
- Shared `actionBtnsHtml` / `wireActionBtns` components for edit (✎) + delete (🗑) button pairs across labels, struct instances, and struct types.
- Delete confirmation via floating popover (DOM-based — `confirm()` is blocked in VS Code webviews).
