### PR TITLE
fix: shorten package description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.1] — 2026-05-01
+
+### Changed
+
+- Shortened extension description
+
 ## [2.1.0] — 2026-05-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-hex-scope",
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
-  "description": "Custom editor for Intel HEX (.hex) and Motorola SREC (.srec/.mot/.s19) files — memory grid, byte inspector with bit view and multi-byte interpreter, hex/ASCII/address search, record table, syntax-highlighted raw view, CRC and checksum analysis, segment labels, and in-place byte patching with checksum recomputation",
+  "description": "Custom editor for Intel HEX (.hex) and Motorola SREC (.srec/.mot/.s19) files with memory grid, byte inspector, hex search, record table, and checksum tools.",
   "version": "2.1.0",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Custom editor for Intel HEX (.hex) and Motorola SREC (.srec/.mot/.s19) files with memory grid, byte inspector, hex search, record table, and checksum tools.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The extension description was too long in VS Code. Shortened it.