### PR TITLE
fix: nested struct displays when defined as an array

### DIFF
--- a/.github/agents/changelog-release-writer.agent.md
+++ b/.github/agents/changelog-release-writer.agent.md
@@ -1,0 +1,77 @@
+---
+name: Changelog Release Writer
+description: "Use when updating CHANGELOG.md for a new release by comparing current code to a previous release tag (for example 1.1.0). Generates concise, user-friendly Added/Changed/Fixed notes in the existing changelog style and excludes branch-internal cleanup items that are not regressions from the previous release."
+tools: [read, search, execute, edit]
+argument-hint: "Provide baseline version/tag and optionally: explicit new version, release type (major/minor/patch), release date, or must-include user-visible highlights. If omitted, agent auto-selects best-fit version."
+user-invocable: true
+---
+You are a specialist for writing accurate, user-friendly release notes in this repository's changelog style.
+Your job is to compare current HEAD against the latest release tag on main, identify key user-visible changes, and update CHANGELOG.md with concise entries.
+
+## Scope
+- Compare current HEAD against the latest release tag on main (for example `v1.1.0` or `1.1.0`).
+- Infer the best-fit next release version when user does not provide an explicit version.
+- Extract user-visible changes from commits, diffs, tests, and relevant UI/feature files.
+- Write or update the new release section in CHANGELOG.md using the existing structure and tone.
+
+## Constraints
+- DO NOT invent changes not supported by git history or repository evidence.
+- DO NOT scan full main branch history; only inspect the delta between the selected baseline tag and HEAD.
+- DO NOT include branch-internal correction work that fixed issues introduced during feature development before release.
+- DO NOT include implementation noise (refactors, variable renames, formatting-only edits) unless user-visible behavior changed.
+- DO NOT include test-only or CI-only changes unless they are directly user-visible and materially affect release usage.
+- DO NOT write long narrative paragraphs; prefer short bullets.
+- ONLY include changes that are meaningful to end users, integrators, or maintainers.
+- ALWAYS honor explicit user input for version number or release type over auto-detection.
+
+## Version Selection Rules
+- Priority order:
+   1. If user provides explicit version number (for example `2.6.0`), use it.
+   2. Else if user provides release type (`major`, `minor`, `patch`/`bugfix`), bump from latest released version accordingly.
+   3. Else auto-detect best-fit release type from the evidence and bump from latest released version.
+- Determine latest released version from CHANGELOG headings first; use git tags as fallback.
+- Auto-detection mapping (SemVer):
+   - `major`: confirmed breaking change in user-facing behavior, compatibility, config, API/commands, file format, or migration requirement.
+   - `minor`: backward-compatible new user-facing features/capabilities.
+   - `patch`: fixes, polish, and backward-compatible behavior corrections only.
+- If evidence is ambiguous between two types, choose the lower-impact bump and list the ambiguity under `Excluded Items` or a brief note.
+
+## Classification Rules
+- `Added`: new user-facing features, views, commands, workflows, or file-format capabilities.
+- `Changed`: behavior updates, UX adjustments, performance improvements, or compatibility updates.
+- `Fixed`: regressions or defects that affected behavior compared to the previous release baseline.
+- Exclude fixes that merely corrected mistakes made during the same unreleased feature branch unless they represent a real regression from the baseline release.
+
+## Required Method
+1. Identify release inputs:
+   - previous release tag (baseline): latest release tag reachable from main unless user explicitly overrides
+   - new release version (explicit, type-derived, or auto-detected)
+   - release date (if provided)
+   - tag lookup default: try `vX.Y.Z` first, then `X.Y.Z`
+   - version precedence: explicit version > explicit release type > auto-detected best fit
+2. Gather evidence with git and repository files:
+   - resolve baseline from main (latest release tag on main)
+   - `git log --oneline <baseline>..HEAD`
+   - `git diff --name-status <baseline>..HEAD`
+   - targeted diffs for core files and tests
+   - do not run broad history scans such as full `git log main`
+3. Determine release bump level using Version Selection Rules, then compute target version.
+4. Build a candidate change list and remove low-value/internal items.
+5. Map each retained item to `Added`, `Changed`, or `Fixed` using the rules above.
+6. Produce concise bullet text in the current changelog voice.
+7. Update CHANGELOG.md in-place with a new section (or revise draft section) while preserving formatting style.
+   - if the target version section already exists, update it in place instead of creating a duplicate
+8. Validate consistency:
+   - no duplicate bullets
+   - no contradiction with code history
+   - no mention of fixes that are not baseline regressions
+
+## Output Format
+Return sections in this order:
+1. Baseline and Scope Used
+2. Version Decision (include rationale and whether explicit/type-derived/auto-detected)
+3. Proposed Changelog Entry
+4. Excluded Items (brief reason)
+5. File Updated
+
+If any required release input is missing, ask only for the missing value(s) before editing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,25 @@
 # Changelog
 
+## [2.5.1] — 2026-06-03
+
+### Changed
+
+- Struct Overlay nested field tree UI was refined with clearer indentation/alignment and guide lines for nested nodes
+- Nested group/element expand controls now have clearer visual affordances and more consistent row highlighting
+
+### Fixed
+
+- Struct Overlay now shows declared struct type names for nested struct fields and arrays (instead of generic type labels)
+- Nested struct/array rendering now uses the declared array size so element counts and summaries are accurate
+- Nested struct array elements now render as distinct expandable nodes, with selection highlighting/jump behavior aligned to each element range
+
 ## [2.5.0] — 2026-06-01
 
 ### Added
 
 - Nested struct fields in Struct Overlay, including validation for invalid references/cycles/depth
 - New ASCII struct field type for readable C-style strings (null-terminated display)
-- Resizable Struct Overlay sidebar with persistent width
+- Resizable sidebar with persistent width
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/vscode": "^1.120.0",
@@ -16,6 +17,7 @@
         "@vscode/test-electron": "^2.5.2",
         "esbuild": "^0.27.3",
         "eslint": "^9.39.3",
+        "jsdom": "^29.1.1",
         "npm-run-all": "^4.1.5",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1"
@@ -23,6 +25,57 @@
       "engines": {
         "vscode": "^1.120.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -32,6 +85,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -668,6 +874,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -815,6 +1039,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.0.tgz",
+      "integrity": "sha512-sqqlwW3zm+cE82GwKdGyn3pcze7LXlx/4jUgA0vtAf6Fa81KMrJqc3VfWmmeOTUIElW9IdPsLwMUIpiOZQgK3A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -838,6 +1082,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.120.0",
@@ -1341,6 +1592,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1709,6 +1970,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1793,6 +2082,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1888,6 +2184,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -2762,6 +3071,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3173,6 +3495,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3436,6 +3765,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3599,6 +3979,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -4260,6 +4647,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4505,6 +4905,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -4628,6 +5038,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4832,6 +5255,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -5138,6 +5571,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -5254,6 +5694,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5265,6 +5725,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5428,6 +5914,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -5476,6 +5972,54 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -5701,6 +6245,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -323,11 +323,13 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.120.0",
+    "@types/jsdom": "^28.0.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "typescript-eslint": "^8.56.1",
     "eslint": "^9.39.3",
     "esbuild": "^0.27.3",
+    "jsdom": "^29.1.1",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.9.3",
     "@vscode/test-cli": "^0.0.12",

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -1,0 +1,469 @@
+import * as assert from 'assert';
+import { JSDOM } from 'jsdom';
+
+import { S } from '../webview/state';
+import type { StructDef, StructPin } from '../webview/types';
+
+function resetStructState(): void {
+    S.structs = [];
+    S.structPins = [];
+    S.activeStructAddr = null;
+    S.parseResult = null;
+    S.segmentIndex = [];
+    S.endian = 'le';
+    S.sidebarTab = 'struct';
+}
+
+suite('struct UI array header summary', () => {
+    let dom: JSDOM;
+
+    setup(() => {
+        dom = new JSDOM('<!doctype html><html><body><div id="s-struct-pins"></div></body></html>');
+
+        const fakeVsCodeApi = {
+            postMessage: () => {},
+            getState: () => ({}),
+            setState: (_state: unknown) => {},
+        };
+
+        Object.defineProperty(globalThis, 'window', {
+            value: dom.window,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'document', {
+            value: dom.window.document,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'navigator', {
+            value: dom.window.navigator,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'acquireVsCodeApi', {
+            value: () => fakeVsCodeApi,
+            configurable: true,
+            writable: true,
+        });
+
+        resetStructState();
+    });
+
+    teardown(() => {
+        resetStructState();
+        dom.window.close();
+        delete (globalThis as unknown as { window?: Window }).window;
+        delete (globalThis as unknown as { document?: Document }).document;
+        delete (globalThis as unknown as { navigator?: Navigator }).navigator;
+        delete (globalThis as unknown as { acquireVsCodeApi?: () => unknown }).acquireVsCodeApi;
+    });
+
+    test('uses declared struct type and element count for nested struct array header', async () => {
+        const child: StructDef = {
+            id: 'child',
+            name: 'ChildNode',
+            fields: [
+                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent',
+            name: 'Parent',
+            fields: [
+                { name: 'nodes', type: 'struct', refStructId: 'child', count: 3, endian: 'inherit' },
+            ],
+        };
+        const pin: StructPin = {
+            id: 'pin_2',
+            structId: 'parent',
+            addr: 0,
+            name: 'parentInst',
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [pin];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expand = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expand, 'expand button should be rendered');
+        expand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const header = document.querySelector<HTMLElement>('.si-arr-addr');
+        assert.ok(header, 'array header summary should be rendered');
+
+        const text = header!.textContent ?? '';
+        const title = header!.getAttribute('title') ?? '';
+
+        assert.ok(text.includes('[3]'), `expected element count [3] in header text, got: ${text}`);
+        assert.ok(title.includes('[3]'), `expected element count [3] in header title, got: ${title}`);
+        assert.ok(text.includes('ChildNode'), `expected struct name ChildNode in header text, got: ${text}`);
+        assert.ok(title.includes('ChildNode'), `expected struct name ChildNode in header title, got: ${title}`);
+        assert.ok(!text.includes('[6]'), `header should not use flattened child row count, got: ${text}`);
+    });
+
+    test('renders nested struct arrays as element groups with leaf-only labels', async () => {
+        const child: StructDef = {
+            id: 'child',
+            name: 'ChildNode',
+            fields: [
+                { name: 'field0', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'field1', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'field2', type: 'uint8', count: 2, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent',
+            name: 'Parent',
+            fields: [
+                { name: 'nodes', type: 'struct', refStructId: 'child', count: 2, endian: 'inherit' },
+            ],
+        };
+        const pin: StructPin = {
+            id: 'pin_1',
+            structId: 'parent',
+            addr: 0,
+            name: 'parentInst',
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [pin];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should be rendered');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandArray = document.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(expandArray, 'array group expand button should be rendered');
+        expandArray!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topArrayHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        const nodesHeaderCount = topArrayHeaders.filter(name => name === 'nodes').length;
+        assert.strictEqual(nodesHeaderCount, 1, 'parent struct-array group should not be split by nested arrays');
+
+        const firstElementBody = document.querySelector<HTMLElement>('.si-arr-el-body');
+        assert.ok(firstElementBody, 'nested element body should be rendered');
+        assert.strictEqual(firstElementBody!.style.display, 'none', 'nested element body should be collapsed by default');
+
+        const expandElement = document.querySelector<HTMLElement>('.si-arr-el-exp-btn');
+        assert.ok(expandElement, 'nested element expand button should be rendered');
+        expandElement!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const elementHeaderName = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-f-name');
+        assert.ok(elementHeaderName, 'element header name should be rendered');
+        assert.strictEqual(elementHeaderName!.textContent ?? '', '[0]', 'element header should only show index');
+        const elementHeaderMeta = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-arr-addr');
+        assert.ok(elementHeaderMeta, 'element header should show struct summary');
+        assert.strictEqual(elementHeaderMeta!.textContent ?? '', 'ChildNode', 'element header should show struct type');
+
+        const firstLeafName = document.querySelector<HTMLElement>('.si-arr-el-body .si-field .si-f-name');
+        assert.ok(firstLeafName, 'leaf row name should be rendered after expanding an element');
+        const label = firstLeafName!.textContent ?? '';
+        assert.strictEqual(label, 'field0', `expected leaf-only label field0, got: ${label}`);
+        assert.ok(!label.includes('['), `label should not include array index prefix, got: ${label}`);
+        assert.ok(!label.includes('nodes.'), `label should not include parent path, got: ${label}`);
+
+        const nestedHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-arr-grp-hdr'));
+        const nestedField2Header = nestedHeaders.find(h =>
+            h.querySelector<HTMLElement>('.si-f-name')?.textContent === 'field2'
+        );
+        assert.ok(nestedField2Header, 'nested scalar-array node field2 should be rendered');
+
+        const nestedExpandBtn = nestedField2Header!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(nestedExpandBtn, 'nested scalar-array node should have expand button');
+        nestedExpandBtn!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedLeafNames = Array.from(
+            nestedField2Header!
+                .closest<HTMLElement>('.si-arr-grp')!
+                .querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field .si-f-name')
+        ).map(el => el.textContent ?? '');
+        assert.ok(nestedLeafNames.includes('[0]'), 'nested scalar-array child should use index-only label [0]');
+        assert.ok(nestedLeafNames.includes('[1]'), 'nested scalar-array child should use index-only label [1]');
+        assert.ok(!nestedLeafNames.some(name => name.includes('nodes[')), 'nested leaf labels should not include parent array path');
+    });
+
+    test('uses local node label for scalar-struct nested scalar array', async () => {
+        const child: StructDef = {
+            id: 'child',
+            name: 'MyStruct',
+            fields: [
+                { name: 'field0', type: 'uint32', count: 1, endian: 'inherit' },
+                { name: 'field1', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'field2', type: 'uint8', count: 2, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent',
+            name: 'Parent',
+            fields: [
+                { name: 'field3', type: 'struct', refStructId: 'child', count: 1, endian: 'inherit' },
+            ],
+        };
+        const pin: StructPin = {
+            id: 'pin_scalar_struct',
+            structId: 'parent',
+            addr: 0,
+            name: 'parentInst',
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [pin];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should be rendered');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(topHeaders.includes('field3'), 'scalar struct node should be labeled with local field name');
+        assert.ok(topHeaders.includes('field2'), 'nested scalar-array node should be labeled with local field name');
+        assert.ok(!topHeaders.includes('field3.field2'), 'nested scalar-array node should not include parent path');
+
+        const topLevelHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(topLevelHeaders, ['field3'], 'nested scalar-array node should not be rendered at top level');
+
+        const parentGroup = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp');
+        assert.ok(parentGroup, 'scalar struct group should exist');
+        const parentExpandBtn = parentGroup!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(parentExpandBtn, 'scalar struct group should be expandable');
+        parentExpandBtn!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedHeader = parentGroup!.querySelector<HTMLElement>('.si-arr-grp-body .si-arr-grp-hdr .si-f-name');
+        assert.ok(nestedHeader, 'nested scalar-array header should render inside scalar struct body');
+        assert.strictEqual(nestedHeader!.textContent ?? '', 'field2', 'nested scalar-array header should keep local name');
+    });
+
+    test('keeps child composite nodes collapsed by default after opening parent', async () => {
+        const child: StructDef = {
+            id: 'child_collapse',
+            name: 'ChildCollapse',
+            fields: [
+                { name: 'field0', type: 'uint32', count: 1, endian: 'inherit' },
+                { name: 'field1', type: 'uint8', count: 2, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent_collapse',
+            name: 'ParentCollapse',
+            fields: [
+                { name: 'field3', type: 'struct', refStructId: 'child_collapse', count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [{ id: 'pin_collapse', structId: 'parent_collapse', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topGroup = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp');
+        assert.ok(topGroup, 'top composite group should render');
+        const topBody = topGroup!.querySelector<HTMLElement>('.si-arr-grp-body');
+        assert.ok(topBody, 'top group body should render');
+        assert.strictEqual(topBody!.style.display, 'none', 'top group should be collapsed by default');
+
+        const topExpand = topGroup!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(topExpand, 'top group expand button should render');
+        topExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedGroup = topGroup!.querySelector<HTMLElement>('.si-arr-grp-body .si-arr-grp');
+        assert.ok(nestedGroup, 'nested scalar-array group should render inside parent body');
+        const nestedBody = nestedGroup!.querySelector<HTMLElement>('.si-arr-grp-body');
+        assert.ok(nestedBody, 'nested group body should render');
+        assert.strictEqual(nestedBody!.style.display, 'none', 'nested composite should remain collapsed by default');
+    });
+
+    test('renders scalar struct node even when it has only one leaf child', async () => {
+        const child: StructDef = {
+            id: 'single_leaf_child',
+            name: 'SingleLeafChild',
+            fields: [
+                { name: 'only', type: 'uint16', count: 1, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'single_leaf_parent',
+            name: 'SingleLeafParent',
+            fields: [
+                { name: 'wrap', type: 'struct', refStructId: 'single_leaf_child', count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [{ id: 'pin_single_leaf', structId: 'single_leaf_parent', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(topHeaders, ['wrap'], 'struct field should render as a composite node header even with one leaf child');
+
+        const leafAtTop = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-field .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(!leafAtTop.includes('only'), 'child leaf should not render at top level');
+    });
+
+    test('supports rendering nested structs at max depth with local labels', async () => {
+        const level3: StructDef = {
+            id: 'depth_l3',
+            name: 'DepthL3',
+            fields: [
+                { name: 'bytes', type: 'uint8', count: 2, endian: 'inherit' },
+            ],
+        };
+        const level2: StructDef = {
+            id: 'depth_l2',
+            name: 'DepthL2',
+            fields: [
+                { name: 'inner', type: 'struct', refStructId: 'depth_l3', count: 1, endian: 'inherit' },
+            ],
+        };
+        const level1: StructDef = {
+            id: 'depth_l1',
+            name: 'DepthL1',
+            fields: [
+                { name: 'outer', type: 'struct', refStructId: 'depth_l2', count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [level3, level2, level1];
+        S.structPins = [{ id: 'pin_depth', structId: 'depth_l1', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name');
+        assert.ok(topHeader, 'top nested struct header should render');
+        assert.strictEqual(topHeader!.textContent ?? '', 'outer', 'top nested struct should use local label');
+
+        const topExpand = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(topExpand, 'top nested struct expand button should render');
+        topExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const innerHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-body .si-arr-grp-hdr .si-f-name');
+        assert.ok(innerHeader, 'second-level struct header should render at max depth boundary');
+        assert.strictEqual(innerHeader!.textContent ?? '', 'inner', 'second-level struct should use local label');
+
+        const innerExpand = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-body .si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(innerExpand, 'second-level struct expand button should render');
+        innerExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const bytesHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-body .si-arr-grp-body .si-arr-grp-hdr .si-f-name');
+        assert.ok(bytesHeader, 'scalar array at max depth should render as a composite node');
+        assert.strictEqual(bytesHeader!.textContent ?? '', 'bytes', 'max-depth scalar array should use local label');
+    });
+
+    test('renders ascii string field as scalar leaf without collapse node', async () => {
+        const def: StructDef = {
+            id: 'str_leaf',
+            name: 'StrLeaf',
+            fields: [
+                { name: 'name', type: 'ascii', count: 8, endian: 'inherit' },
+            ],
+        };
+        const pin: StructPin = {
+            id: 'pin_str_leaf',
+            structId: 'str_leaf',
+            addr: 0,
+            name: 'inst',
+        };
+
+        S.structs = [def];
+        S.structPins = [pin];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const arrNodeNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(!arrNodeNames.includes('name'), 'ascii field should not render as collapsible array node');
+
+        const leafNames = Array.from(document.querySelectorAll<HTMLElement>('.si-field .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(leafNames.includes('name'), 'ascii field should render as leaf field');
+    });
+
+    test('recurses nested struct arrays without disambiguation suffix labels', async () => {
+        const leaf: StructDef = {
+            id: 'leaf_suffix',
+            name: 'LeafSuffix',
+            fields: [
+                { name: 'field0', type: 'uint8', count: 1, endian: 'inherit' },
+            ],
+        };
+        const mid: StructDef = {
+            id: 'mid_suffix',
+            name: 'MidSuffix',
+            fields: [
+                { name: 'children', type: 'struct', refStructId: 'leaf_suffix', count: 2, endian: 'inherit' },
+            ],
+        };
+        const top: StructDef = {
+            id: 'top_suffix',
+            name: 'TopSuffix',
+            fields: [
+                { name: 'nodes', type: 'struct', refStructId: 'mid_suffix', count: 2, endian: 'inherit' },
+            ],
+        };
+        const pin: StructPin = {
+            id: 'pin_suffix',
+            structId: 'top_suffix',
+            addr: 0,
+            name: 'inst',
+        };
+
+        S.structs = [leaf, mid, top];
+        S.structPins = [pin];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const openFirst = (selector: string) => {
+            const btn = document.querySelector<HTMLElement>(selector);
+            assert.ok(btn, `expand button should exist for ${selector}`);
+            btn!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        };
+
+        openFirst('.si-arr-grp-hdr .si-arr-exp-btn');
+        openFirst('.si-arr-el-hdr .si-arr-el-exp-btn');
+        openFirst('.si-arr-el-body .si-arr-grp-hdr .si-arr-exp-btn');
+        openFirst('.si-arr-el-body .si-arr-el-hdr .si-arr-el-exp-btn');
+
+        const labels = Array.from(document.querySelectorAll<HTMLElement>('.si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(!labels.some(label => /#\d+$/.test(label)), 'nested labels should not use disambiguation suffixes');
+    });
+});

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 
 import {
     fieldByteSize, structByteSize, decodeField, decodeStruct,
-    allStructs, parseStructText, fieldsToText, validateStructs, structToC,
+    allStructs, parseStructText, fieldsToText, validateStructs, structToC, resolveStructFieldByPath,
 } from '../webview/struct-codec';
 import { S } from '../webview/state';
 import { initFlatBytes, getByte } from '../webview/data';
@@ -346,6 +346,57 @@ suite('decodeStruct()', () => {
     });
 });
 
+suite('resolveStructFieldByPath()', () => {
+    setup(() => resetStructState());
+
+    test('resolves nested struct array field using declared type and count', () => {
+        const child: StructDef = {
+            id: 'child',
+            name: 'ChildNode',
+            fields: [{ name: 'v', type: 'uint8', count: 1, endian: 'inherit' }],
+        };
+        const parent: StructDef = {
+            id: 'parent',
+            name: 'Parent',
+            fields: [{ name: 'nodes', type: 'struct', refStructId: 'child', count: 3, endian: 'inherit' }],
+        };
+
+        S.structs = [child, parent];
+
+        const resolved = resolveStructFieldByPath(parent, 'nodes');
+        assert.ok(resolved);
+        assert.strictEqual(resolved!.field.type, 'struct');
+        assert.strictEqual(resolved!.field.count, 3);
+        assert.strictEqual(resolved!.structName, 'ChildNode');
+    });
+
+    test('resolves path containing array indices to declared nested field', () => {
+        const leaf: StructDef = {
+            id: 'leaf',
+            name: 'Leaf',
+            fields: [{ name: 'x', type: 'uint8', count: 1, endian: 'inherit' }],
+        };
+        const mid: StructDef = {
+            id: 'mid',
+            name: 'Mid',
+            fields: [{ name: 'nodes', type: 'struct', refStructId: 'leaf', count: 4, endian: 'inherit' }],
+        };
+        const top: StructDef = {
+            id: 'top',
+            name: 'Top',
+            fields: [{ name: 'wrappers', type: 'struct', refStructId: 'mid', count: 2, endian: 'inherit' }],
+        };
+
+        S.structs = [leaf, mid, top];
+
+        const resolved = resolveStructFieldByPath(top, 'wrappers[0].nodes');
+        assert.ok(resolved);
+        assert.strictEqual(resolved!.field.type, 'struct');
+        assert.strictEqual(resolved!.field.count, 4);
+        assert.strictEqual(resolved!.structName, 'Leaf');
+    });
+});
+
 // ── validateStructs ───────────────────────────────────────────────
 
 suite('validateStructs()', () => {
@@ -364,12 +415,19 @@ suite('validateStructs()', () => {
         assert.ok(errs.some(e => e.includes('cycle')), `errors: ${errs.join(' | ')}`);
     });
 
-    test('reports nesting depth overflow when depth > 3', () => {
-        const d: StructDef = { id: 'd', name: 'D', fields: [{ name: 'x', type: 'uint8', count: 1, endian: 'inherit' }] };
-        const c: StructDef = { id: 'c', name: 'C', fields: [{ name: 'd', type: 'struct', refStructId: 'd', count: 1, endian: 'inherit' }] };
-        const b: StructDef = { id: 'b', name: 'B', fields: [{ name: 'c', type: 'struct', refStructId: 'c', count: 1, endian: 'inherit' }] };
-        const a: StructDef = { id: 'a', name: 'A', fields: [{ name: 'b', type: 'struct', refStructId: 'b', count: 1, endian: 'inherit' }] };
-        const errs = validateStructs([a, b, c, d], 3);
+    test('reports nesting depth overflow when depth exceeds configured limit', () => {
+        const defs: StructDef[] = [];
+        const depth = 34;
+        for (let i = depth; i >= 1; i--) {
+            defs.push({
+                id: `s${i}`,
+                name: `S${i}`,
+                fields: i === depth
+                    ? [{ name: 'x', type: 'uint8', count: 1, endian: 'inherit' }]
+                    : [{ name: `s${i + 1}`, type: 'struct', refStructId: `s${i + 1}`, count: 1, endian: 'inherit' }],
+            });
+        }
+        const errs = validateStructs(defs, 32);
         assert.ok(errs.some(e => e.includes('depth')), `errors: ${errs.join(' | ')}`);
     });
 });

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -12,7 +12,7 @@ import type {
 
 export type { StructDef, StructField, StructFieldType, StructFieldEndian };
 
-export const MAX_NESTED_DEPTH = 3;
+export const MAX_NESTED_DEPTH = 32;
 
 // -- Constants -----------------------------------------------------
 
@@ -178,6 +178,48 @@ export interface DecodedField {
     bytesHex: string;
     decoded: string;
     hasData: boolean;
+}
+
+export interface ResolvedStructFieldPath {
+    field: StructField;
+    structName?: string;
+}
+
+/**
+ * Resolve a dotted field path (optionally containing array indices) to the declared field.
+ * Example accepted paths: "nodes", "nodes[0]", "outer[1].nodes".
+ */
+export function resolveStructFieldByPath(
+    def: StructDef,
+    fieldPath: string,
+    defs: StructDef[] = allStructs(),
+): ResolvedStructFieldPath | null {
+    const normalized = fieldPath.replace(/\[\d+\]/g, '');
+    const parts = normalized.split('.').map(p => p.trim()).filter(Boolean);
+    if (parts.length === 0) { return null; }
+
+    const byId = new Map<string, StructDef>(defs.map(d => [d.id, d]));
+    byId.set(def.id, def);
+
+    let curDef: StructDef | null = def;
+    for (let i = 0; i < parts.length; i++) {
+        if (!curDef) { return null; }
+        const part = parts[i];
+        const field: StructField | undefined = curDef.fields.find((candidate: StructField) => candidate.name === part);
+        if (!field) { return null; }
+        const isLast = i === parts.length - 1;
+        if (isLast) {
+            if (field.type !== 'struct') {
+                return { field };
+            }
+            const child = field.refStructId ? byId.get(field.refStructId) : null;
+            return { field, structName: child?.name };
+        }
+        if (field.type !== 'struct' || !field.refStructId) { return null; }
+        curDef = byId.get(field.refStructId) ?? null;
+    }
+
+    return null;
 }
 
 export function decodeField(

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -448,14 +448,22 @@
 
 /* Expanded field rows */
 .si-fields {
+    --si-col-off: 30px;
+    --si-col-type: 20px;
+    --si-col-toggle: 18px;
+    --si-col-gap: 2px;
+    --si-col-pad-left: 6px;
+    --si-indent-step: 8px;
+    --si-toggle-x: calc(var(--si-col-pad-left) + var(--si-col-off) + var(--si-col-gap) + var(--si-col-type) + var(--si-col-gap) + (var(--si-col-toggle) / 2));
     border-top: 1px solid var(--border);
     padding: 3px 0;
 }
-/* Grid: [offset 40px] [type 28px] [body flex 1fr] */
+/* Grid: [offset] [type] [toggle] [body] */
 .si-field {
     display: grid;
-    grid-template-columns: 40px 28px 1fr;
-    gap: 3px; align-items: baseline;
+    grid-template-columns: var(--si-col-off) var(--si-col-type) var(--si-col-toggle) 1fr;
+    gap: var(--si-col-gap);
+    align-items: baseline;
     padding: 2px 8px;
     cursor: pointer;
     transition: background .1s;
@@ -463,8 +471,9 @@
 .si-field:hover    { background: var(--hover-bg); }
 .si-field.si-selected { background: rgba(79,195,247,.12) !important; }
 
-.si-f-off  { font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor); }
-.si-f-type { font-size: 8px; color: var(--addr-fg); opacity: .55; font-family: var(--font-editor); white-space: nowrap; }
+.si-f-off  { font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor); font-variant-numeric: tabular-nums; }
+.si-f-type { font-size: 8px; color: var(--addr-fg); opacity: .55; font-family: var(--font-editor); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.si-toggle-pad { display: block; width: var(--si-col-toggle); height: 1px; }
 
 /* name + dotted leader + value */
 .si-f-body {
@@ -515,15 +524,18 @@
 .si-f-ptr-sym { color: var(--addr-fg); font-style: normal; opacity: .8; }
 .si-no-data { opacity: .4; }
 
-/* Array field group — same grid for alignment */
+/* Composite node header rows */
 .si-arr-grp-hdr {
     display: grid;
-    grid-template-columns: 40px 28px 1fr;
-    gap: 3px; align-items: center;
+    grid-template-columns: var(--si-col-off) var(--si-col-type) var(--si-col-toggle) 1fr;
+    gap: var(--si-col-gap);
+    align-items: center;
     padding: 2px 8px;
     cursor: pointer;
     transition: background .1s;
     border-top: 1px solid rgba(255,255,255,.05);
+    position: relative;
+    border-radius: 3px;
 }
 
 /* per-field value-type menu */
@@ -550,13 +562,107 @@
 .si-arr-grp-hdr:hover      { background: var(--hover-bg); }
 .si-arr-grp-hdr.si-selected { background: rgba(79,195,247,.12) !important; }
 .si-arr-exp-btn {
-    width: 16px; height: 16px;
+    width: 100%;
+    height: 18px;
     display: flex; align-items: center; justify-content: center;
     background: transparent; border: none; padding: 0;
     color: var(--addr-fg); font-size: 12px; cursor: pointer; line-height: 1;
+    border-radius: 3px;
+    transition: background .12s ease, color .12s ease;
+    position: relative;
+    z-index: 2;
+}
+.si-arr-exp-btn:hover,
+.si-arr-el-exp-btn:hover {
+    background: rgba(255,255,255,.08);
+    color: var(--fg);
 }
 .si-arr-addr {
     font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor);
+    font-variant-numeric: tabular-nums;
     white-space: nowrap; flex-shrink: 0;
 }
-.si-arr-grp-body .si-field { padding-left: 16px; }
+.si-node-pad {
+    width: var(--si-col-off);
+    height: 1px;
+}
+.si-node-type-pad {
+    width: var(--si-col-type);
+    height: 1px;
+}
+
+.si-arr-grp-body,
+.si-arr-el-body {
+    position: relative;
+    margin-left: 0;
+    border-left: none;
+}
+
+.si-arr-grp-body::before,
+.si-arr-el-body::before {
+    content: '';
+    position: absolute;
+    left: var(--si-toggle-x);
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid rgba(255,255,255,.14);
+    pointer-events: none;
+}
+
+.si-arr-el-hdr {
+    display: grid;
+    grid-template-columns: var(--si-col-off) var(--si-col-type) var(--si-col-toggle) 1fr;
+    gap: var(--si-col-gap);
+    align-items: center;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition: background .1s;
+    position: relative;
+    border-radius: 3px;
+}
+.si-arr-el-hdr:hover { background: var(--hover-bg); }
+.si-arr-el-hdr.si-selected { background: rgba(79,195,247,.12) !important; }
+.si-arr-el-exp-btn {
+    width: 100%;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--addr-fg);
+    font-size: 12px;
+    cursor: pointer;
+    line-height: 1;
+    position: relative;
+    z-index: 2;
+}
+
+.si-field .si-f-body,
+.si-arr-grp-hdr .si-f-body,
+.si-arr-el-hdr .si-f-body {
+    padding-left: calc(var(--si-level, 0) * var(--si-indent-step));
+}
+
+.si-arr-grp-hdr .si-arr-exp-btn,
+.si-arr-el-hdr .si-arr-el-exp-btn {
+    margin-left: calc(var(--si-level, 0) * var(--si-indent-step));
+}
+
+.si-arr-grp-hdr::before,
+.si-arr-el-hdr::before {
+    content: '';
+    position: absolute;
+    left: calc(var(--si-toggle-x) + (var(--si-level, 0) * var(--si-indent-step)));
+    top: 50%;
+    width: 10px;
+    border-top: 1px solid rgba(255,255,255,.18);
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.si-arr-grp-body::before,
+.si-arr-el-body::before {
+    left: calc(var(--si-toggle-x) + ((var(--si-level, 1) - 1) * var(--si-indent-step)));
+}

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -10,7 +10,7 @@ import { rerender } from './render';
 import { getByte }  from './data';
 import {
     FIELD_TYPES,
-    fieldByteSize, structByteSize, decodeStruct, allStructs,
+    fieldByteSize, structByteSize, decodeStruct, allStructs, resolveStructFieldByPath,
     parseStructText, fieldsToText, structToC, validateStructs, MAX_NESTED_DEPTH,
 } from './struct-codec.js';
 import type { DecodedField } from './struct-codec.js';
@@ -32,6 +32,8 @@ let _applyStructId: string | null = null;
 const _expanded = new Set<string>();
 /** Array field groups that are expanded. Key: `${pinId}::${baseName}`. Collapsed by default. */
 const _expandedArrayFields = new Set<string>();
+/** Nested element groups that are expanded. Key: `${pinId}::${baseName}::${idx}`. Collapsed by default. */
+const _expandedArrayElements = new Set<string>();
 
 type ColType = 'hex' | 'dec' | 'ascii' | 'bin' | 'ieee';
 /** Default display type for value cells (per-field default). */
@@ -44,6 +46,8 @@ let _addingPin = false;
 let _selectedFieldAddr: number | null = null;
 /** Array group key of the currently highlighted array header. */
 let _selectedArrKey: string | null = null;
+/** Nested array element key of the currently highlighted element header. */
+let _selectedArrElemKey: string | null = null;
 /** Byte start addresses marked with struct-arr-sep in the hex view. */
 const _arrSepAddrs: number[] = [];
 /** Pin id of the currently selected instance card. */
@@ -659,6 +663,7 @@ export function resetStructViewState(): void {
     _managingTypes           = false;
     _editingPinId            = null;
     _editingPinDraftStructId = null;
+    _selectedArrElemKey      = null;
     renderStructPins();
 }
 
@@ -869,7 +874,7 @@ const TYPE_ABBREV: Record<string, string> = {
     float32: 'f32', float64: 'f64', pointer: 'ptr',
 };
 
-function mkFieldRow(r: DecodedField, bs: number, bc: number): string {
+function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: string): string {
     const nd  = !r.hasData ? ' si-no-data' : '';
     const ptr = r.type === 'pointer';
     let t = _fieldValTypes.get(bs);
@@ -890,8 +895,9 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number): string {
         `data-byte-start="${bs}" data-byte-cnt="${bc}">` +
         `<span class="si-f-off">+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
         `<span class="si-f-type" title="${esc(fullTypeLabel)}">${abbrev}</span>` +
+        `<span class="si-toggle-pad" aria-hidden="true"></span>` +
         `<span class="si-f-body">` +
-        `<span class="si-f-name">${esc(r.fieldName)}</span>` +
+        `<span class="si-f-name">${esc(displayName ?? leafName(r.fieldName))}</span>` +
         `<span class="si-f-lead"></span>` +
         `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${bs}">${valHtml}</span>` +
         `</span>` +
@@ -899,14 +905,60 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number): string {
     );
 }
 
+function parseArrayIndex(fieldPath: string, baseName: string): number | null {
+    const escBase = baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const m = fieldPath.match(new RegExp(`^${escBase}\\[(\\d+)\\]`));
+    if (!m) { return null; }
+    const idx = parseInt(m[1], 10);
+    return isNaN(idx) ? null : idx;
+}
+
+function indexedLeafName(fieldPath: string, baseName: string, idx: number): string {
+    const prefix = `${baseName}[${idx}].`;
+    if (fieldPath.startsWith(prefix)) {
+        const nested = fieldPath.slice(prefix.length);
+        const parts = nested.split('.').filter(Boolean);
+        return parts.length > 0 ? parts[parts.length - 1] : nested;
+    }
+    const parts = fieldPath.split('.').filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : fieldPath;
+}
+
+function indexOnlyName(fieldPath: string, baseName: string): string {
+    const idx = parseArrayIndex(fieldPath, baseName);
+    return idx === null ? leafName(fieldPath) : `[${idx}]`;
+}
+
+function leafName(fieldPath: string): string {
+    const parts = fieldPath.split('.').filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : fieldPath;
+}
+
+function disambiguateLeafNames(names: string[]): string[] {
+    const seen = new Map<string, number>();
+    return names.map(name => {
+        const count = (seen.get(name) ?? 0) + 1;
+        seen.set(name, count);
+        return count === 1 ? name : `${name}#${count}`;
+    });
+}
+
 function arrayGroupBaseName(fieldPath: string): string {
-    // Group by the nearest array ancestor (last [N] in the path), so names like
-    // "parent.arr[0].child" and "parent.arr[1].child" collapse under "parent.arr".
+    // Group by the first local segment (before first dot), even when arrays are present.
+    // This keeps nested fields under their owning parent node.
     const matches = [...fieldPath.matchAll(/\[\d+\]/g)];
-    if (matches.length === 0) { return fieldPath; }
-    const last = matches[matches.length - 1];
-    if (last.index === undefined) { return fieldPath; }
-    return fieldPath.slice(0, last.index);
+    if (matches.length === 0) {
+        const dot = fieldPath.indexOf('.');
+        return dot >= 0 ? fieldPath.slice(0, dot) : fieldPath;
+    }
+    const first = matches[0];
+    if (first.index === undefined) { return fieldPath; }
+    const firstArrayIdx = first.index;
+    const firstDot = fieldPath.indexOf('.');
+    if (firstDot >= 0 && firstDot < firstArrayIdx) {
+        return fieldPath.slice(0, firstDot);
+    }
+    return fieldPath.slice(0, first.index);
 }
 
 function buildInstanceCard(pin: StructPin, i: number): string {
@@ -919,8 +971,118 @@ function buildInstanceCard(pin: StructPin, i: number): string {
     let bodyHtml = '';
     if (expanded && def) {
         const rows = decodeStruct(def, pin.addr, getByte, S.endian);
+        const rowByteCnt = (r: DecodedField) => r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
 
-        // Group consecutive rows by nearest array ancestor for collapsible array sections.
+        const renderStructChildren = (structRows: DecodedField[], structBase: string, parentKey: string): string => {
+            const structPrefix = `${structBase}.`;
+            const nestedGroups: Array<{ baseRel: string; fullBase: string; rows: DecodedField[] }> = [];
+            for (const r of structRows) {
+                const relPath = r.fieldName.startsWith(structPrefix)
+                    ? r.fieldName.slice(structPrefix.length)
+                    : r.fieldName;
+                const baseRel = arrayGroupBaseName(relPath);
+                const fullBase = `${structBase}.${baseRel}`;
+                const lastNested = nestedGroups[nestedGroups.length - 1];
+                if (lastNested && lastNested.fullBase === fullBase) { lastNested.rows.push(r); }
+                else { nestedGroups.push({ baseRel, fullBase, rows: [r] }); }
+            }
+
+            return nestedGroups.map(ng => {
+                const nestedDeclared = resolveStructFieldByPath(def, ng.fullBase);
+                const nestedType = nestedDeclared?.field.type ?? ng.rows[0].type;
+                const nestedCount = nestedDeclared?.field.count ?? ng.rows.length;
+                const nestedIsStruct = nestedType === 'struct';
+                const nestedIsString = nestedType === 'ascii';
+                const nestedIsComposite = nestedIsStruct || (nestedCount > 1 && !nestedIsString);
+                if (!nestedIsComposite) {
+                    const labels = disambiguateLeafNames(ng.rows.map(r => leafName(r.fieldName)));
+                    return ng.rows.map((r, idx) =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), labels[idx])
+                    ).join('');
+                }
+
+                const nestedStructName = nestedDeclared?.structName ?? 'struct';
+                const nestedTypeAbbrev = TYPE_ABBREV[nestedType] ?? nestedType;
+                const nestedSummary = nestedIsStruct
+                    ? (nestedCount > 1 ? `${nestedStructName}[${nestedCount}]` : nestedStructName)
+                    : `${nestedTypeAbbrev}[${nestedCount}]`;
+                const nestedKey = `${parentKey}::${ng.baseRel}`;
+                const nestedOpen = _expandedArrayFields.has(nestedKey);
+                const nestedStart = pin.addr + ng.rows[0].byteOffset;
+                const nestedCnt = ng.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+
+                let nestedBodyHtml = '';
+                if (nestedIsStruct && nestedCount > 1) {
+                    type ElementGroup = { idx: number; rows: DecodedField[] };
+                    const elements: ElementGroup[] = [];
+                    for (const r of ng.rows) {
+                        const idx = parseArrayIndex(r.fieldName, ng.fullBase);
+                        if (idx === null) { continue; }
+                        const last = elements[elements.length - 1];
+                        if (last && last.idx === idx) { last.rows.push(r); }
+                        else { elements.push({ idx, rows: [r] }); }
+                    }
+                    nestedBodyHtml = elements.map(element => {
+                        const first = element.rows[0];
+                        const elementByteStart = pin.addr + first.byteOffset;
+                        const elementByteCnt = element.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+                        const elementKey = `${nestedKey}::${element.idx}`;
+                        const isElementOpen = _expandedArrayElements.has(elementKey);
+                        const childRowsHtml = renderStructChildren(
+                            element.rows,
+                            `${ng.fullBase}[${element.idx}]`,
+                            elementKey,
+                        );
+                        return (
+                            `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
+                            `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
+                            `<span class="si-node-pad" aria-hidden="true"></span>` +
+                            `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                            `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
+                            `<span class="si-f-body">` +
+                            `<span class="si-f-name">[${element.idx}]</span>` +
+                            `<span class="si-f-lead"></span>` +
+                            `<span class="si-arr-addr">${esc(nestedStructName)}</span>` +
+                            `</span>` +
+                            `</div>` +
+                            `<div class="si-arr-el-body"${isElementOpen ? '' : ' style=\"display:none\"'}>${childRowsHtml}</div>` +
+                            `</div>`
+                        );
+                    }).join('');
+                } else if (nestedIsStruct && nestedCount === 1) {
+                    nestedBodyHtml = renderStructChildren(ng.rows, ng.fullBase, nestedKey);
+                } else if (!nestedIsStruct && nestedCount > 1 && !nestedIsString) {
+                    nestedBodyHtml = ng.rows.map(r =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, ng.fullBase))
+                    ).join('');
+                } else {
+                    const nestedLeafNames = disambiguateLeafNames(
+                        ng.rows.map(r => leafName(r.fieldName))
+                    );
+                    nestedBodyHtml = ng.rows.map((r, idx) =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), nestedLeafNames[idx])
+                    ).join('');
+                }
+
+                return (
+                    `<div class="si-arr-grp${nestedOpen ? ' open' : ''}" data-arr-key="${esc(nestedKey)}">` +
+                    `<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
+                    `<span class="si-node-pad" aria-hidden="true"></span>` +
+                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                    `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
+                    `<span class="si-f-body">` +
+                    `<span class="si-f-name">${esc(leafName(ng.baseRel))}</span>` +
+                    `<span class="si-f-lead"></span>` +
+                    `<span class="si-arr-addr">${esc(nestedSummary)}</span>` +
+                    `</span>` +
+                    `</div>` +
+                    `<div class="si-arr-grp-body"${nestedOpen ? '' : ' style=\"display:none\"'}>${nestedBodyHtml}</div>` +
+                    `</div>`
+                );
+            }).join('');
+        };
+
+        // Group consecutive rows into composite/leaf sections.
         const groups: Array<{ baseName: string; rows: typeof rows }> = [];
         for (const r of rows) {
             const base = arrayGroupBaseName(r.fieldName);
@@ -930,39 +1092,96 @@ function buildInstanceCard(pin: StructPin, i: number): string {
         }
 
         const fieldHtml = groups.map(g => {
-            if (g.rows.length === 1) {
-                // Scalar field — render flat
-                const r = g.rows[0];
-                const rowByteCnt = r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
-                return mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt);
-            } else {
-                // Array field group — collapsible, collapsed by default
-                const key     = `${pin.id}::${g.baseName}`;
-                const isOpen  = _expandedArrayFields.has(key);
-                const r0      = g.rows[0];
-                const byteStart = pin.addr + r0.byteOffset;
-                const rowByteCnt = (r: DecodedField) => r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
-                const totalCnt  = g.rows.reduce((s, r) => s + rowByteCnt(r), 0);
-                const elHtml     = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r))).join('');
-                const arrAbbrev  = TYPE_ABBREV[r0.type] ?? r0.type;
-                const arrSummary = `[${g.rows.length}]\u202f\u00b7\u202f${arrAbbrev}`;
-                const arrSummaryFull = `[${g.rows.length}] · ${r0.type}`;
-                return (
-                    `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
-                    `<div class="si-arr-grp-hdr" ` +
-                    `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
-                    `<span class="si-f-off">+${r0.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
-                    `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
-                    `<span class="si-f-body">` +
-                    `<span class="si-f-name">${esc(g.baseName)}</span>` +
-                    `<span class="si-f-lead"></span>` +
-                    `<span class="si-arr-addr" title="${esc(arrSummaryFull)}">${esc(arrSummary)}</span>` +
-                    `</span>` +
-                    `</div>` +
-                    `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
-                    `</div>`
-                );
+            const r0 = g.rows[0];
+            const declared = resolveStructFieldByPath(def, g.baseName);
+            const declaredType = declared?.field.type ?? r0.type;
+            const declaredCount = declared?.field.count ?? g.rows.length;
+            const isStruct = declaredType === 'struct';
+            const isArray = declaredCount > 1;
+            const isString = declaredType === 'ascii';
+            const isComposite = isStruct || (isArray && !isString);
+
+            if (!isComposite) {
+                // Scalar leaf field(s) — render flat using local labels.
+                const labels = disambiguateLeafNames(g.rows.map(r => leafName(r.fieldName)));
+                return g.rows.map((r, idx) => mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), labels[idx])).join('');
             }
+
+            // Composite field group — collapsible, collapsed by default.
+            const key     = `${pin.id}::${g.baseName}`;
+            const isOpen  = _expandedArrayFields.has(key);
+            const byteStart = pin.addr + r0.byteOffset;
+            const totalCnt  = g.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+            let elHtml     = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r))).join('');
+                const structName = declared?.structName ?? 'struct';
+                const scalarType = TYPE_ABBREV[declaredType] ?? declaredType;
+                const nodeSummary = isStruct
+                    ? (isArray ? `${structName}[${declaredCount}]` : structName)
+                    : `${scalarType}[${declaredCount}]`;
+                const nodeSummaryFull = nodeSummary;
+
+                if (isStruct && isArray) {
+                    type ElementGroup = { idx: number; rows: DecodedField[] };
+                    const elements: ElementGroup[] = [];
+                    for (const r of g.rows) {
+                        const idx = parseArrayIndex(r.fieldName, g.baseName);
+                        if (idx === null) { continue; }
+                        const last = elements[elements.length - 1];
+                        if (last && last.idx === idx) { last.rows.push(r); }
+                        else { elements.push({ idx, rows: [r] }); }
+                    }
+                    if (elements.length > 0) {
+                        elHtml = elements.map(element => {
+                            const first = element.rows[0];
+                            const elementByteStart = pin.addr + first.byteOffset;
+                            const elementByteCnt = element.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+                            const elementKey = `${key}::${element.idx}`;
+                            const isElementOpen = _expandedArrayElements.has(elementKey);
+                            const elementRowsHtml = renderStructChildren(
+                                element.rows,
+                                `${g.baseName}[${element.idx}]`,
+                                elementKey,
+                            );
+                            return (
+                                `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
+                                `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
+                                `<span class="si-node-pad" aria-hidden="true"></span>` +
+                                `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                                `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
+                                `<span class="si-f-body">` +
+                                `<span class="si-f-name">[${element.idx}]</span>` +
+                                `<span class="si-f-lead"></span>` +
+                                `<span class="si-arr-addr">${esc(structName)}</span>` +
+                                `</span>` +
+                                `</div>` +
+                                `<div class="si-arr-el-body"${isElementOpen ? '' : ' style=\"display:none\"'}>${elementRowsHtml}</div>` +
+                                `</div>`
+                            );
+                        }).join('');
+                    }
+                } else if (isStruct && !isArray) {
+                    elHtml = renderStructChildren(g.rows, g.baseName, key);
+                } else if (!isStruct && isArray) {
+                    elHtml = g.rows.map(r =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, g.baseName))
+                    ).join('');
+                }
+            return (
+                `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
+                `<div class="si-arr-grp-hdr" ` +
+                `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
+                `<span class="si-node-pad" aria-hidden="true"></span>` +
+                `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+                `<span class="si-f-body">` +
+                `<span class="si-f-name">${esc(leafName(g.baseName))}</span>` +
+                `<span class="si-f-lead"></span>` +
+                `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummary)}</span>` +
+                `</span>` +
+                `</div>` +
+                `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
+                `</div>`
+            );
         }).join('');
 
         bodyHtml = `<div class="si-fields">${fieldHtml}</div>`;
@@ -1047,7 +1266,81 @@ function clearSelRow(): void {
         .forEach(el => el.classList.remove('si-selected'));
 }
 
+function setTreeLevel(el: HTMLElement, level: number): void {
+    el.style.setProperty('--si-level', String(level));
+}
+
+function asHtml(el: Element | null): HTMLElement | null {
+    if (!el) { return null; }
+    const candidate = el as HTMLElement;
+    return typeof candidate.classList !== 'undefined' ? candidate : null;
+}
+
+function firstDirectChildByClass(parent: HTMLElement, cls: string): HTMLElement | null {
+    for (const child of Array.from(parent.children)) {
+        const htmlChild = asHtml(child);
+        if (htmlChild && htmlChild.classList.contains(cls)) {
+            return htmlChild;
+        }
+    }
+    return null;
+}
+
+function applyTreeDepthStyles(sec: HTMLElement): void {
+    const annotateBody = (body: HTMLElement, level: number) => {
+        setTreeLevel(body, level);
+        for (const child of Array.from(body.children)) {
+            const htmlChild = asHtml(child);
+            if (!htmlChild) { continue; }
+            if (htmlChild.classList.contains('si-field')) {
+                setTreeLevel(htmlChild, level);
+                continue;
+            }
+            if (htmlChild.classList.contains('si-arr-grp')) {
+                const hdr = firstDirectChildByClass(htmlChild, 'si-arr-grp-hdr');
+                if (hdr) { setTreeLevel(hdr, level); }
+                const childBody = firstDirectChildByClass(htmlChild, 'si-arr-grp-body');
+                if (childBody) { annotateBody(childBody, level + 1); }
+                continue;
+            }
+            if (htmlChild.classList.contains('si-arr-el-grp')) {
+                const hdr = firstDirectChildByClass(htmlChild, 'si-arr-el-hdr');
+                if (hdr) { setTreeLevel(hdr, level); }
+                const childBody = firstDirectChildByClass(htmlChild, 'si-arr-el-body');
+                if (childBody) { annotateBody(childBody, level + 1); }
+            }
+        }
+    };
+
+    sec.querySelectorAll<HTMLElement>('.si-fields').forEach(fields => {
+        setTreeLevel(fields, 0);
+        for (const child of Array.from(fields.children)) {
+            const htmlChild = asHtml(child);
+            if (!htmlChild) { continue; }
+            if (htmlChild.classList.contains('si-field')) {
+                setTreeLevel(htmlChild, 0);
+                continue;
+            }
+            if (htmlChild.classList.contains('si-arr-grp')) {
+                const hdr = firstDirectChildByClass(htmlChild, 'si-arr-grp-hdr');
+                if (hdr) { setTreeLevel(hdr, 0); }
+                const body = firstDirectChildByClass(htmlChild, 'si-arr-grp-body');
+                if (body) { annotateBody(body, 1); }
+                continue;
+            }
+            if (htmlChild.classList.contains('si-arr-el-grp')) {
+                const hdr = firstDirectChildByClass(htmlChild, 'si-arr-el-hdr');
+                if (hdr) { setTreeLevel(hdr, 0); }
+                const body = firstDirectChildByClass(htmlChild, 'si-arr-el-body');
+                if (body) { annotateBody(body, 1); }
+            }
+        }
+    });
+}
+
 function wireInstanceCards(sec: HTMLElement): void {
+    applyTreeDepthStyles(sec);
+
     sec.querySelectorAll<HTMLElement>('.si-expand-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             const id = btn.dataset.pinId!;
@@ -1100,17 +1393,84 @@ function wireInstanceCards(sec: HTMLElement): void {
             if (isNaN(start) || isNaN(cnt)) { return; }
             const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
             _selectedArrKey    = grp.dataset.arrKey!;
+            _selectedArrElemKey = null;
             _selectedFieldAddr = null;
-            // Mark each element's first byte (except element 0) for visual separation
-            grp.querySelectorAll<HTMLElement>('.si-field').forEach((row, i) => {
-                if (i === 0) { return; }
-                const bs = parseInt(row.dataset.byteStart!);
-                if (isNaN(bs)) { return; }
-                _arrSepAddrs.push(bs);
-                const ah = bs.toString(16).toUpperCase().padStart(8, '0');
+            // Mark each nested element's first byte (except element 0) for visual separation.
+            const elementHeaders = grp.querySelectorAll<HTMLElement>('.si-arr-el-hdr');
+            if (elementHeaders.length > 0) {
+                Array.from(elementHeaders).forEach((elHdr, i) => {
+                    if (i === 0) { return; }
+                    const bs = parseInt(elHdr.dataset.byteStart!);
+                    if (isNaN(bs)) { return; }
+                    _arrSepAddrs.push(bs);
+                    const ah = bs.toString(16).toUpperCase().padStart(8, '0');
+                    document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
+                        .forEach(el => el.classList.add('struct-arr-sep'));
+                });
+            } else {
+                grp.querySelectorAll<HTMLElement>('.si-field').forEach((row, i) => {
+                    if (i === 0) { return; }
+                    const bs = parseInt(row.dataset.byteStart!);
+                    if (isNaN(bs)) { return; }
+                    _arrSepAddrs.push(bs);
+                    const ah = bs.toString(16).toUpperCase().padStart(8, '0');
+                    document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
+                        .forEach(el => el.classList.add('struct-arr-sep'));
+                });
+            }
+            S.selStart = start;
+            S.selEnd   = start + cnt - 1;
+            hdr.classList.add('si-selected');
+            import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
+            import('./sidebar.js').then(m => m.updateInspector());
+        });
+    });
+
+    // Nested element: arrow toggles expand; row selects that element range.
+    sec.querySelectorAll<HTMLElement>('.si-arr-el-hdr').forEach(hdr => {
+        const expBtn = hdr.querySelector<HTMLElement>('.si-arr-el-exp-btn')!;
+        const start  = parseInt(hdr.dataset.byteStart!);
+        const cnt    = parseInt(hdr.dataset.byteCnt!);
+
+        expBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            const grp = hdr.closest<HTMLElement>('.si-arr-el-grp')!;
+            const key = grp.dataset.arrElKey!;
+            const body = grp.querySelector<HTMLElement>('.si-arr-el-body')!;
+            const isOpen = _expandedArrayElements.has(key);
+            if (isOpen) {
+                _expandedArrayElements.delete(key);
+                grp.classList.remove('open');
+                body.style.display = 'none';
+                expBtn.textContent = '▸';
+            } else {
+                _expandedArrayElements.add(key);
+                grp.classList.add('open');
+                body.style.display = '';
+                expBtn.textContent = '▾';
+            }
+        });
+
+        hdr.addEventListener('mouseenter', () => {
+            for (let i = 0; i < cnt; i++) {
+                const ah = (start + i).toString(16).toUpperCase().padStart(8, '0');
                 document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
-                    .forEach(el => el.classList.add('struct-arr-sep'));
-            });
+                    .forEach(el => el.classList.add('struct-h'));
+            }
+        });
+        hdr.addEventListener('mouseleave', () => {
+            document.querySelectorAll<HTMLElement>('.struct-h')
+                .forEach(el => el.classList.remove('struct-h'));
+        });
+
+        hdr.addEventListener('click', e => {
+            if ((e.target as HTMLElement).closest('.si-arr-el-exp-btn')) { return; }
+            clearArrSep();
+            clearSelRow();
+            if (isNaN(start) || isNaN(cnt)) { return; }
+            _selectedArrElemKey = hdr.dataset.arrElKey!;
+            _selectedArrKey = null;
+            _selectedFieldAddr = null;
             S.selStart = start;
             S.selEnd   = start + cnt - 1;
             hdr.classList.add('si-selected');
@@ -1126,6 +1486,7 @@ function wireInstanceCards(sec: HTMLElement): void {
             clearSelRow();
             _selectedFieldAddr = null;
             _selectedArrKey    = null;
+            _selectedArrElemKey = null;
             const card = hdr.closest<HTMLElement>('.si-card')!;
             const idx  = parseInt(card.dataset.idx!);
             const pin  = S.structPins[idx];
@@ -1197,6 +1558,7 @@ function wireInstanceCards(sec: HTMLElement): void {
             row.classList.add('si-selected');
             _selectedFieldAddr = start;
             _selectedArrKey    = null;
+            _selectedArrElemKey = null;
             import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
             import('./sidebar.js').then(m => m.updateInspector());
         });
@@ -1308,6 +1670,12 @@ function wireInstanceCards(sec: HTMLElement): void {
         sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
             if (parseInt(row.dataset.byteStart!) === _selectedFieldAddr) {
                 row.classList.add('si-selected');
+            }
+        });
+    } else if (_selectedArrElemKey !== null) {
+        sec.querySelectorAll<HTMLElement>('.si-arr-el-hdr').forEach(hdr => {
+            if (hdr.dataset.arrElKey === _selectedArrElemKey) {
+                hdr.classList.add('si-selected');
             }
         });
     } else if (_selectedArrKey !== null) {
@@ -1628,6 +1996,7 @@ export function onSelectionChangeForStruct(): void {
     clearSelRow();
     _selectedFieldAddr = null;
     _selectedArrKey    = null;
+    _selectedArrElemKey = null;
     _selectedPinId     = null;
     if (S.selStart === null) { return; }
     S.activeStructAddr = S.selStart;


### PR DESCRIPTION
### Changed

- Struct Overlay nested field tree UI was refined with clearer indentation/alignment and guide lines for nested nodes
- Nested group/element expand controls now have clearer visual affordances and more consistent row highlighting

### Fixed

- Struct Overlay now shows declared struct type names for nested struct fields and arrays (instead of generic type labels)
- Nested struct/array rendering now uses the declared array size so element counts and summaries are accurate
- Nested struct array elements now render as distinct expandable nodes, with selection highlighting/jump behavior aligned to each element range