### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -488,11 +488,31 @@ function renderStats(): void {
     if (!el || !S.parseResult) { return; }
     const p = S.parseResult;
     const fmtLabel = p.format === 'srec' ? 'SREC' : 'IHEX';
-    el.innerHTML =
-        `<span class="si si-fmt"><span class="svl">${fmtLabel}</span></span>` +
-        `<span class="si"><span class="slb">Bytes</span><span class="svl">${fmtB(p.totalDataBytes)}</span></span>` +
-        `<span class="si"><span class="slb">Records</span><span class="svl">${p.recordCount ?? p.records.length}</span></span>` +
-    `<span class="si"><span class="slb">Segments</span><span class="svl">${p.segments.length}</span></span>`;
+
+    const addItem = (label: string | null, value: string, extraClass = ''): void => {
+        const item = document.createElement('span');
+        item.className = extraClass ? `si ${extraClass}` : 'si';
+
+        if (label !== null) {
+            const labelEl = document.createElement('span');
+            labelEl.className = 'slb';
+            labelEl.textContent = label;
+            item.appendChild(labelEl);
+        }
+
+        const valueEl = document.createElement('span');
+        valueEl.className = 'svl';
+        valueEl.textContent = value;
+        item.appendChild(valueEl);
+
+        el.appendChild(item);
+    };
+
+    el.textContent = '';
+    addItem(null, fmtLabel, 'si-fmt');
+    addItem('Bytes', fmtB(p.totalDataBytes));
+    addItem('Records', String(p.recordCount ?? p.records.length));
+    addItem('Segments', String(p.segments.length));
 }
 
 // ── Memory view ───────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/deviousprophet/vscode-hex-scope/security/code-scanning/2](https://github.com/deviousprophet/vscode-hex-scope/security/code-scanning/2)

General fix: avoid writing message-influenced data via `innerHTML`; use safe DOM APIs (`textContent`, `createElement`) so values are treated as text, not HTML.

Best single fix here: rewrite `renderStats()` to build the stats bar using DOM node creation and `textContent`, clearing the container first. This preserves current UI/behavior while removing the XSS sink entirely.  
Edit only `src/webview/hexViewer.ts`, in the `renderStats()` function region (around lines 486–496). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
