### PR TITLE
feat: support bit fields in struct overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Array and nested-struct headers now show their first child offset while collapsed, then move offsets to child rows when expanded
 
+### Fixed
+
+- Fixed Records View rendering so record rows display as table rows instead of escaped markup, while avoiding dynamic HTML injection in the record table
+
 ## [2.6.0] — 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Bit field support on Struct Overlay
+
 ## [2.6.0] — 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## [Unreleased]
+## [2.7.0] - 2026-06-12
 
 ### Added
 
-- Bit field support on Struct Overlay
+- Struct Overlay now supports C-style bit fields, including named bit-field groups, nested struct bit-field containers, and bit-field arrays
+- Struct instances now include a Bit Layout control for bit-field allocation (`LSB` / `MSB`) alongside byte endianness
+- Bit-field parent rows can be viewed as full storage-width binary or as `Binary (bit fields only)`
+
+### Changed
+
+- Array and nested-struct headers now show their first child offset while collapsed, then move offsets to child rows when expanded
 
 ## [2.6.0] — 2026-06-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -362,7 +362,7 @@ ${cssLinks}
     }
 }
 
-export interface SegmentLabel {
+interface SegmentLabel {
     id: string;
     name: string;
     startAddress: number;
@@ -399,7 +399,7 @@ function serializeParseResult(result: ParseResult, format: 'ihex' | 'srec'): Ser
 }
 
 // Types safe to transfer over the webview message boundary
-export interface SerializedRecord {
+interface SerializedRecord {
     lineNumber: number;
     raw: string;
     byteCount: number;
@@ -412,12 +412,12 @@ export interface SerializedRecord {
     error?: string;
 }
 
-export interface SerializedSegment {
+interface SerializedSegment {
     startAddress: number;
     data: number[];
 }
 
-export interface SerializedParseResult {
+interface SerializedParseResult {
     records: SerializedRecord[];
     recordCount?: number;
     segments: SerializedSegment[];

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 import { parseIntelHex } from './parser/IntelHexParser';
 import { parseSRec, SREC_ADDR_SIZES, srecIsData } from './parser/SRecParser';
 import type { ParseResult } from './parser/types';
+import { migrateStructDefBitFields } from './webview/struct-codec.js';
+import type { StructDef } from './webview/types';
 
 export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
@@ -68,31 +70,40 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         const globalStructKey = 'hexScope.structs.global.v1';
         const structPinKey = `hexScope.structPins.${document.uri.toString()}`;
 
-        const normalizeStructDefs = (value: unknown): unknown[] => {
-            if (!Array.isArray(value)) { return []; }
-            const out: unknown[] = [];
+        const normalizeStructDefs = (value: unknown): { defs: StructDef[]; changed: boolean } => {
+            if (!Array.isArray(value)) { return { defs: [], changed: false }; }
+            const out: StructDef[] = [];
             const seenIds = new Set<string>();
             const seenNames = new Set<string>();
+            let changed = false;
 
             for (const item of value) {
                 const id = (item as { id?: unknown })?.id;
                 const name = (item as { name?: unknown })?.name;
-                if (typeof id !== 'string' || typeof name !== 'string') { continue; }
-                if (seenIds.has(id) || seenNames.has(name)) { continue; }
+                if (typeof id !== 'string' || typeof name !== 'string') {
+                    changed = true;
+                    continue;
+                }
+                if (seenIds.has(id) || seenNames.has(name)) {
+                    changed = true;
+                    continue;
+                }
                 seenIds.add(id);
                 seenNames.add(name);
-                out.push(item);
+                const migrated = migrateStructDefBitFields(item as StructDef);
+                if (migrated !== item) { changed = true; }
+                out.push(migrated);
             }
-            return out;
+            return { defs: out, changed };
         };
 
         const loadStructs = async () => {
             const globalStructs = this._context.globalState.get<unknown>(globalStructKey, []);
             const legacyStructs = this._context.workspaceState.get<unknown>(structKey, []);
-            let globalArr = normalizeStructDefs(globalStructs);
-            const legacyArr = normalizeStructDefs(legacyStructs);
+            let { defs: globalArr, changed: globalChanged } = normalizeStructDefs(globalStructs);
+            const { defs: legacyArr } = normalizeStructDefs(legacyStructs);
 
-            if (!Array.isArray(globalStructs) || globalArr.length !== globalStructs.length) {
+            if (!Array.isArray(globalStructs) || globalChanged) {
                 await this._context.globalState.update(globalStructKey, globalArr);
             }
 
@@ -121,6 +132,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             }
 
             await this._context.workspaceState.update(structKey, undefined);
+
             return globalArr;
         };
 
@@ -211,7 +223,8 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                     break;
                 }
                 case 'saveStructs': {
-                    await this._context.globalState.update(globalStructKey, normalizeStructDefs(msg.structs));
+                    const { defs } = normalizeStructDefs(msg.structs);
+                    await this._context.globalState.update(globalStructKey, defs);
                     break;
                 }
                 case 'saveStructPins': {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { JSDOM } from 'jsdom';
 
 import { S } from '../webview/state';
+import { initFlatBytes } from '../webview/data';
 import type { StructDef, StructPin } from '../webview/types';
 
 function resetStructState(): void {
@@ -12,6 +13,18 @@ function resetStructState(): void {
     S.segmentIndex = [];
     S.endian = 'le';
     S.sidebarTab = 'struct';
+}
+
+function setBytesInSegment(baseAddr: number, bytes: number[]): void {
+    S.parseResult = {
+        records: [],
+        segments: [{ startAddress: baseAddr, data: bytes }],
+        totalDataBytes: bytes.length,
+        checksumErrors: 0,
+        malformedLines: 0,
+        format: 'ihex',
+    };
+    initFlatBytes();
 }
 
 suite('struct UI array header summary', () => {
@@ -550,6 +563,61 @@ suite('struct UI array header summary', () => {
 
         const childRows = document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field');
         assert.ok(childRows.length > 0, 'bit-field array element should expose child bit rows');
+    });
+
+    test('defaults bit-field parent binary to full storage range', async () => {
+        const def: StructDef = {
+            id: 'bit_binary_modes',
+            name: 'BitBinaryModes',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'bit0', bitWidth: 1 },
+                        { name: 'bit1', bitWidth: 1 },
+                        { name: 'bit2', bitWidth: 1 },
+                        { name: 'bit3', bitWidth: 1 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_binary_modes', structId: 'bit_binary_modes', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [0x33]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const bitHeader = document.querySelector<HTMLElement>('.si-bitunit-hdr');
+        assert.ok(bitHeader, 'bit-field parent header should render');
+
+        const parentValue = bitHeader!.querySelector<HTMLElement>('.si-f-val');
+        assert.ok(parentValue, 'bit-field parent should render a value');
+        assert.strictEqual(parentValue!.dataset.valType, 'bin', 'bit-field parent should default to full binary');
+        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '00110011', 'full binary should show the complete u8 storage range');
+
+        bitHeader!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        const labels = Array.from(document.querySelectorAll<HTMLElement>('#si-val-menu .ctx-row[data-cmd^="disp-"] .ctx-label'))
+            .map(el => el.textContent ?? '');
+        assert.ok(labels.includes('Binary'), 'View as should include full Binary');
+        assert.ok(labels.includes('Binary (bit field sliced)'), 'View as should include sliced bit-field binary');
+
+        const slicedItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-bin-sliced"]');
+        assert.ok(slicedItem, 'sliced binary menu item should render');
+        slicedItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const slicedValue = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-f-val');
+        assert.ok(slicedValue, 'bit-field parent should rerender after selecting sliced binary');
+        assert.strictEqual(slicedValue!.dataset.valType, 'bin-sliced', 'sliced binary should use its own value type');
+        assert.strictEqual(slicedValue!.textContent?.replace(/\s+/g, ''), '0011', 'sliced binary should show the declared bit range as one value');
     });
 
     test('renders nested bit-field arrays with declared field names', async () => {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -83,6 +83,19 @@ suite('struct UI array header summary', () => {
         return expandCard!;
     }
 
+    function captureClipboardWrites(): string[] {
+        const writes: string[] = [];
+        Object.defineProperty(dom.window.navigator, 'clipboard', {
+            value: { writeText: (text: string) => { writes.push(text); return Promise.resolve(); } },
+            configurable: true,
+        });
+        Object.defineProperty(globalThis.navigator, 'clipboard', {
+            value: dom.window.navigator.clipboard,
+            configurable: true,
+        });
+        return writes;
+    }
+
     test('uses declared struct type and element count for nested struct array header', async () => {
         const child: StructDef = {
             id: 'child',
@@ -857,15 +870,7 @@ suite('struct UI array header summary', () => {
     });
 
     test('copies bit-field parent and child values from the clicked row', async () => {
-        const writes: string[] = [];
-        Object.defineProperty(dom.window.navigator, 'clipboard', {
-            value: { writeText: (text: string) => { writes.push(text); return Promise.resolve(); } },
-            configurable: true,
-        });
-        Object.defineProperty(globalThis.navigator, 'clipboard', {
-            value: dom.window.navigator.clipboard,
-            configurable: true,
-        });
+        const writes = captureClipboardWrites();
 
         const def: StructDef = {
             id: 'bit_copy_rows',
@@ -910,6 +915,82 @@ suite('struct UI array header summary', () => {
         assert.ok(childCopyDec, 'child copy decimal item should render');
         childCopyDec!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
         assert.strictEqual(writes.pop(), '6', 'child copy should use the clicked bit-field child value');
+    });
+
+    test('copies every struct value format as a single line', async () => {
+        const writes = captureClipboardWrites();
+        const def: StructDef = {
+            id: 'single_line_copy',
+            name: 'SingleLineCopy',
+            fields: [
+                { name: 'wide', type: 'uint64', count: 1, endian: 'inherit' },
+                { name: 'flt', type: 'float32', count: 1, endian: 'inherit' },
+                { name: 'text', type: 'ascii', count: 4, endian: 'inherit' },
+                {
+                    name: 'flags',
+                    type: 'uint32',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'top', bitWidth: 5 },
+                        { name: 'mid', bitWidth: 7 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_single_line_copy', structId: 'single_line_copy', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+            0x00, 0x00, 0x80, 0x3F,
+            0x41, 0x0A, 0x42, 0x43,
+            0x12, 0x34, 0x56, 0x78,
+        ]);
+
+        await renderPinsAndExpandCard();
+
+        const copyFromRow = (row: HTMLElement, cmd: string): string => {
+            row.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+            const item = document.querySelector<HTMLElement>(`#si-val-menu .ctx-row[data-cmd="${cmd}"]`);
+            assert.ok(item, `${cmd} menu item should render`);
+            item!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+            const copied = writes.pop();
+            assert.ok(copied !== undefined, `${cmd} should write to clipboard`);
+            assert.ok(!/[\r\n]/.test(copied!), `${cmd} should copy a single line`);
+            return copied!;
+        };
+
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-field'));
+        assert.ok(rows.length >= 3, 'scalar rows should render');
+        assert.strictEqual(
+            copyFromRow(rows[0]!, 'copy-bin'),
+            '1110 1111 1100 1101 1010 1011 1000 1001 0110 0111 0100 0101 0010 0011 0000 0001',
+            'wide binary copy should flatten wrapped binary groups',
+        );
+        assert.strictEqual(
+            copyFromRow(rows[1]!, 'copy-ieee'),
+            'sign: 0; exponent: 0x7F; mantissa: 0x000000; class: normal',
+            'IEEE copy should remain a single-line summary',
+        );
+        assert.strictEqual(
+            copyFromRow(rows[2]!, 'copy-ascii'),
+            'A.BC',
+            'ASCII copy should replace non-printable bytes instead of copying line breaks',
+        );
+
+        const bitParent = document.querySelector<HTMLElement>('.si-bitunit-hdr');
+        assert.ok(bitParent, 'bit-field parent should render');
+        assert.strictEqual(
+            copyFromRow(bitParent!, 'copy-bin'),
+            '0111 1000 0101 0110 0011 0100 0001 0010',
+            'bit-field parent full binary copy should be single-line',
+        );
+        assert.strictEqual(
+            copyFromRow(bitParent!, 'copy-bin-sliced'),
+            '0111 1000 0101',
+            'bit-fields-only binary copy should be single-line',
+        );
     });
 
     test('wraps wide bit-field parent binary like scalar binary values', async () => {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -698,6 +698,57 @@ suite('struct UI array header summary', () => {
         assert.ok(childValues.every(el => el.dataset.valType === 'bin'), 'array header view should not change nested bit-field children');
     });
 
+    test('highlights array bit-field parent bits and selected child row', async () => {
+        const def: StructDef = {
+            id: 'bit_array_highlight',
+            name: 'BitArrayHighlight',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 2,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'flags', bitWidth: 5 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_array_highlight', structId: 'bit_array_highlight', addr: 0x100, name: 'inst' }];
+        setBytesInSegment(0x100, [0x33, 0x55]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandArray = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(expandArray, 'bit-field array should be expandable');
+        expandArray!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandFirstElement = document.querySelector<HTMLElement>('.si-arr-el-hdr.si-bitunit-hdr .si-arr-el-exp-btn');
+        assert.ok(expandFirstElement, 'bit-field array element should be expandable');
+        expandFirstElement!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const firstChild = document.querySelector<HTMLElement>('.si-arr-el-body .si-field[data-bit-start]');
+        assert.ok(firstChild, 'bit-field child row should render');
+
+        firstChild!.dispatchEvent(new dom.window.MouseEvent('mousemove', { bubbles: true }));
+        const hoveredBits = document.querySelectorAll<HTMLElement>('.si-arr-el-hdr.si-bitunit-hdr .si-f-val .si-bit.hov');
+        assert.ok(hoveredBits.length > 0, 'hovering array bit-field child should highlight bits in the element parent value');
+
+        firstChild!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        assert.ok(firstChild!.classList.contains('si-selected'), 'selecting bit-field child should highlight the child row');
+
+        const selectedBits = document.querySelectorAll<HTMLElement>('.si-arr-el-hdr.si-bitunit-hdr .si-f-val .si-bit.sel');
+        assert.ok(selectedBits.length > 0, 'selecting array bit-field child should highlight bits in the element parent value');
+    });
+
     test('renders nested bit-field arrays with declared field names', async () => {
         const child: StructDef = {
             id: 'child_bits',

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -12,6 +12,7 @@ function resetStructState(): void {
     S.parseResult = null;
     S.segmentIndex = [];
     S.endian = 'le';
+    S.bitFieldAllocation = 'msb';
     S.sidebarTab = 'struct';
 }
 
@@ -647,6 +648,65 @@ suite('struct UI array header summary', () => {
 
         const childRows = document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field');
         assert.ok(childRows.length > 0, 'bit-field array element should expose child bit rows');
+    });
+
+    test('shows independent byte endianness and bit-field allocation toggles', async () => {
+        const def: StructDef = {
+            id: 'bit_alloc_toggle',
+            name: 'BitAllocToggle',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'a', bitWidth: 3 },
+                        { name: 'b', bitWidth: 5 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_alloc_toggle', structId: 'bit_alloc_toggle', addr: 0x600, name: 'inst' }];
+        setBytesInSegment(0x600, [0xB1]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const toggleGroups = Array.from(document.querySelectorAll<HTMLElement>('.si-toggle-group'))
+            .map(el => el.getAttribute('title') ?? '');
+        assert.ok(toggleGroups.some(title => title.includes('Byte endianness')), 'byte endianness detail should be available on hover');
+        assert.ok(toggleGroups.some(title => title.includes('Bit-field allocation')), 'bit-field allocation detail should be available on hover');
+        const toggleLabels = Array.from(document.querySelectorAll<HTMLElement>('.si-toggle-label'))
+            .map(el => el.textContent ?? '');
+        assert.ok(toggleLabels.includes('Endian'), 'compact endian label should render above the byte endianness toggle');
+        assert.ok(toggleLabels.includes('Bit Layout'), 'compact bit layout label should render above the bit-field allocation toggle');
+        assert.strictEqual(document.getElementById('sa-btn-le')?.textContent, 'LE');
+        assert.strictEqual(document.getElementById('sa-btn-be')?.textContent, 'BE');
+        assert.strictEqual(document.getElementById('sa-btn-bit-lsb')?.textContent, 'LSB');
+        assert.strictEqual(document.getElementById('sa-btn-bit-msb')?.textContent, 'MSB');
+        assert.ok(document.getElementById('sa-btn-bit-lsb')?.getAttribute('title')?.includes('least significant bit'), 'LSB button should explain allocation on hover');
+        assert.ok(document.getElementById('sa-btn-bit-msb')?.getAttribute('title')?.includes('most significant bit'), 'MSB button should explain allocation on hover');
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandBits = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
+        assert.ok(expandBits, 'bit-field parent should be expandable');
+        expandBits!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childValuesMsb = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(childValuesMsb, ['101', '1 0001'], 'MSB-first should allocate from high bits by default');
+
+        document.getElementById('sa-btn-bit-lsb')!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childValuesLsb = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(childValuesLsb, ['001', '1 0110'], 'LSB-first should allocate from low bits independently of byte endianness');
     });
 
     test('defaults bit-field parent binary to full storage range', async () => {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -391,6 +391,90 @@ suite('struct UI array header summary', () => {
         assert.strictEqual(bytesHeader!.textContent ?? '', 'bytes', 'max-depth scalar array should use local label');
     });
 
+    test('moves array offset from collapsed header to expanded child rows', async () => {
+        const def: StructDef = {
+            id: 'array_offset',
+            name: 'ArrayOffset',
+            fields: [
+                { name: 'prefix', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'values', type: 'uint16', count: 2, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_array_offset', structId: 'array_offset', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [0xAA, 0x11, 0x22, 0x33, 0x44]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const arrayHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
+        assert.ok(arrayHeader, 'array header should render');
+        assert.strictEqual(arrayHeader!.querySelector<HTMLElement>('.si-f-off')?.textContent ?? '', '+002', 'collapsed array header should show first element offset');
+
+        const expandArray = arrayHeader!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(expandArray, 'array expand button should render');
+        expandArray!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandedHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
+        assert.ok(expandedHeader, 'expanded array header should render');
+        assert.strictEqual(expandedHeader!.querySelector<HTMLElement>('.si-f-off'), null, 'expanded array header should not duplicate child offsets');
+
+        const childOffsets = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-body > .si-field .si-f-off'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(childOffsets, ['+002', '+004'], 'expanded array children should keep their own offsets');
+    });
+
+    test('moves nested struct offset from collapsed header to expanded child rows', async () => {
+        const child: StructDef = {
+            id: 'nested_offset_child',
+            name: 'NestedOffsetChild',
+            fields: [
+                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'nested_offset_parent',
+            name: 'NestedOffsetParent',
+            fields: [
+                { name: 'prefix', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'node', type: 'struct', refStructId: 'nested_offset_child', count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [{ id: 'pin_nested_offset', structId: 'nested_offset_parent', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [0xAA, 0x11, 0x22, 0x33]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const structHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
+        assert.ok(structHeader, 'nested struct header should render');
+        assert.strictEqual(structHeader!.querySelector<HTMLElement>('.si-f-off')?.textContent ?? '', '+002', 'collapsed nested struct header should show first child offset');
+
+        const expandStruct = structHeader!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(expandStruct, 'nested struct expand button should render');
+        expandStruct!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandedHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
+        assert.ok(expandedHeader, 'expanded nested struct header should render');
+        assert.strictEqual(expandedHeader!.querySelector<HTMLElement>('.si-f-off'), null, 'expanded nested struct header should not duplicate child offsets');
+
+        const childOffsets = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-body > .si-field .si-f-off'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(childOffsets, ['+002', '+004'], 'expanded nested struct children should keep their own offsets');
+    });
+
     test('renders ascii string field as scalar leaf without collapse node', async () => {
         const def: StructDef = {
             id: 'str_leaf',
@@ -608,7 +692,7 @@ suite('struct UI array header summary', () => {
         const labels = Array.from(document.querySelectorAll<HTMLElement>('#si-val-menu .ctx-row[data-cmd^="disp-"] .ctx-label'))
             .map(el => el.textContent ?? '');
         assert.ok(labels.includes('Binary'), 'View as should include full Binary');
-        assert.ok(labels.includes('Binary (bit field sliced)'), 'View as should include sliced bit-field binary');
+        assert.ok(labels.includes('Binary (bit fields only)'), 'View as should include bit-fields-only binary');
 
         const slicedItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-bin-sliced"]');
         assert.ok(slicedItem, 'sliced binary menu item should render');
@@ -680,7 +764,7 @@ suite('struct UI array header summary', () => {
         const labels = Array.from(document.querySelectorAll<HTMLElement>('#si-val-menu .ctx-row[data-cmd^="disp-"] .ctx-label'))
             .map(el => el.textContent ?? '');
         assert.ok(labels.includes('Binary'), 'View as should include full Binary');
-        assert.ok(!labels.includes('Binary (bit field sliced)'), 'View as should omit sliced binary when it matches full range');
+        assert.ok(!labels.includes('Binary (bit fields only)'), 'View as should omit bit-fields-only binary when it matches full range');
     });
 
     test('groups bit-field child binary from lower bits first', async () => {
@@ -887,6 +971,67 @@ suite('struct UI array header summary', () => {
         assert.ok(nestedChildNames.includes('mode'), 'nested bit-field child row should contain mode');
         assert.ok(nestedChildNames.includes('flags'), 'nested bit-field child row should contain flags');
         assert.ok(!nestedChildNames.includes('BitField'), 'nested bit-field groups should not use synthetic labels');
+    });
+
+    test('renders nested single bit-field groups like top-level bit-field groups', async () => {
+        const child: StructDef = {
+            id: 'child_single_bits',
+            name: 'ChildSingleBits',
+            fields: [
+                {
+                    name: 'control',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'enabled', bitWidth: 1 },
+                    ],
+                },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent_single_bits',
+            name: 'ParentSingleBits',
+            fields: [
+                { name: 'node', type: 'struct', refStructId: 'child_single_bits', count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [{ id: 'pin_nested_single_bits', structId: 'parent_single_bits', addr: 0x40, name: 'inst' }];
+        setBytesInSegment(0x40, [0x0B]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandNode = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(expandNode, 'nested struct node should be expandable');
+        expandNode!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedBitHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-body > .si-arr-grp > .si-bitunit-hdr');
+        assert.ok(nestedBitHeader, 'nested single bit-field group should use the scalar-like bit-field header');
+        assert.strictEqual(nestedBitHeader!.querySelector<HTMLElement>('.si-f-name')?.textContent ?? '', 'control', 'nested bit-field header should use declared field name');
+        assert.strictEqual(nestedBitHeader!.querySelector<HTMLElement>('.si-f-off')?.textContent ?? '', '+000', 'nested bit-field header should show its byte offset');
+        assert.strictEqual(nestedBitHeader!.querySelector<HTMLElement>('.si-f-type')?.textContent ?? '', 'u8', 'nested bit-field header should show the base scalar type');
+
+        const parentValue = nestedBitHeader!.querySelector<HTMLElement>('.si-f-val');
+        assert.ok(parentValue, 'nested bit-field parent should show an aggregate value');
+        assert.strictEqual(parentValue!.dataset.valType, 'bin', 'nested bit-field parent should default to full binary');
+        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '00001011', 'nested bit-field parent should show full storage binary');
+
+        const expandBits = nestedBitHeader!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(expandBits, 'nested bit-field group should be expandable');
+        expandBits!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childNames = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-body .si-field[data-bit-start] .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(childNames.includes('mode'), 'nested bit-field child row should contain mode');
+        assert.ok(childNames.includes('enabled'), 'nested bit-field child row should contain enabled');
     });
 
     test('keeps scalar arrays separate from bit-field groups', async () => {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -856,6 +856,62 @@ suite('struct UI array header summary', () => {
         assert.ok(!labels.includes('Binary (bit fields only)'), 'View as should omit bit-fields-only binary when it matches full range');
     });
 
+    test('copies bit-field parent and child values from the clicked row', async () => {
+        const writes: string[] = [];
+        Object.defineProperty(dom.window.navigator, 'clipboard', {
+            value: { writeText: (text: string) => { writes.push(text); return Promise.resolve(); } },
+            configurable: true,
+        });
+        Object.defineProperty(globalThis.navigator, 'clipboard', {
+            value: dom.window.navigator.clipboard,
+            configurable: true,
+        });
+
+        const def: StructDef = {
+            id: 'bit_copy_rows',
+            name: 'BitCopyRows',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'a', bitWidth: 2 },
+                        { name: 'b', bitWidth: 3 },
+                        { name: 'c', bitWidth: 3 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_copy_rows', structId: 'bit_copy_rows', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [0xB1]);
+
+        await renderPinsAndExpandCard();
+
+        const parent = document.querySelector<HTMLElement>('.si-bitunit-hdr');
+        assert.ok(parent, 'bit-field parent should render');
+        parent!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        const parentCopyHex = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="copy-hex"]');
+        assert.ok(parentCopyHex, 'parent copy hex item should render');
+        parentCopyHex!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        assert.strictEqual(writes.pop(), '0xB1', 'parent copy should use the aggregate storage value');
+
+        const expandParent = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
+        assert.ok(expandParent, 'bit-field parent should be expandable');
+        expandParent!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const children = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start]'));
+        assert.strictEqual(children.length, 3, 'three bit-field children should render');
+        children[1]!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        const childCopyDec = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="copy-dec"]');
+        assert.ok(childCopyDec, 'child copy decimal item should render');
+        childCopyDec!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        assert.strictEqual(writes.pop(), '6', 'child copy should use the clicked bit-field child value');
+    });
+
     test('wraps wide bit-field parent binary like scalar binary values', async () => {
         const def: StructDef = {
             id: 'wide_bit_parent_binary',

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -473,13 +473,23 @@ suite('struct UI array header summary', () => {
             name: 'BitStruct',
             fields: [
                 {
-                    name: 'flags',
-                    type: 'uint16',
-                    count: 1,
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 2,
                     endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
+                    ],
+                },
+                {
+                    name: 'field1',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'bit0', bitWidth: 1 },
+                        { name: 'bit1', bitWidth: 1 },
                     ],
                 },
             ],
@@ -495,54 +505,50 @@ suite('struct UI array header summary', () => {
         assert.ok(expandCard, 'expand button should render');
         expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 
-        const unitHeader = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-name');
-        assert.ok(unitHeader, 'bit-field unit header should render');
-        assert.strictEqual(unitHeader!.textContent ?? '', 'BitField', 'bit-field header should display BitField');
+        const topField0 = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp:nth-child(1) > .si-arr-grp-hdr .si-f-name');
+        assert.ok(topField0, 'array bit-field group should render a top-level header');
+        assert.strictEqual(topField0!.textContent ?? '', 'field0', 'array bit-field group should display the declared field name');
 
-        const unitType = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-type');
+        const topField1 = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp:nth-child(2) > .si-arr-grp-hdr .si-f-name');
+        assert.ok(topField1, 'second bit-field group should render a top-level header');
+        assert.strictEqual(topField1!.textContent ?? '', 'field1', 'single bit-field group should display the declared field name');
+
+        const unitType = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-hdr .si-f-type');
         assert.ok(unitType, 'bit-field header should show scalar-like type');
-        assert.strictEqual(unitType!.textContent ?? '', 'u16', 'bit-field header should use base scalar type');
+        assert.strictEqual(unitType!.textContent ?? '', 'u8', 'bit-field header should use base scalar type');
 
-        const unitOffset = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-off');
+        const unitOffset = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-hdr .si-f-off');
         assert.ok(unitOffset, 'bit-field header should show scalar-like offset');
 
-        const unitValue = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-val');
+        const unitValue = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-hdr .si-f-val');
         assert.ok(unitValue, 'bit-field unit should show scalar-like value cell');
         assert.strictEqual(unitValue!.dataset.valType, 'bin', 'bit-field parent row should default to binary view');
 
-        const unitExpand = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-arr-exp-btn');
+        const unitExpand = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-grp-hdr .si-arr-exp-btn');
         assert.ok(unitExpand, 'bit-field unit should be expandable');
         unitExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 
-        const childNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field .si-f-name'))
+        const childNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field .si-f-name'))
             .map(el => el.textContent ?? '');
         assert.ok(childNames.includes('mode'), 'bit-field child row should contain mode');
         assert.ok(childNames.includes('flags'), 'bit-field child row should contain flags');
 
-        const childType = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field .si-f-type');
-        assert.ok(childType, 'bit-field child row should show type');
-        assert.strictEqual(childType!.textContent ?? '', 'bit:3', 'bit-field child type should be displayed as bit:N');
+        const firstElementHeader = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-f-name');
+        assert.ok(firstElementHeader, 'bit-field array element should render a scalar-like header');
+        assert.strictEqual(firstElementHeader!.textContent ?? '', '[0]', 'bit-field array element header should show its index');
 
-        const childOffset = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field .si-f-off');
-        assert.ok(childOffset, 'bit-field child row should show offset');
-        assert.strictEqual(childOffset!.textContent ?? '', '.0', 'bit-field child offset should use .N format');
+        const firstElementValue = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-f-val');
+        assert.ok(firstElementValue, 'bit-field array element should show a scalar-like value cell');
+        assert.strictEqual(firstElementValue!.dataset.valType, 'bin', 'bit-field array element should default to binary view');
 
-        const firstChild = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field');
-        assert.ok(firstChild, 'first bit-field child should render');
-        firstChild!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        const elementExpand = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-arr-el-exp-btn');
+        assert.ok(elementExpand, 'bit-field array element should be expandable');
+        elementExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 
         const selectedBits = document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-val .si-bit.sel');
-        assert.ok(selectedBits.length > 0, 'selecting bit-field child should highlight corresponding parent bits');
+        assert.ok(selectedBits.length === 0, 'array element expansion should not select bits by itself');
 
-        const selectedRows = document.querySelectorAll<HTMLElement>('.si-field.si-selected');
-        assert.strictEqual(selectedRows.length, 0, 'bit-field child selection should not apply row selection/jump styling');
-
-        // Hover highlight should clear when pointer leaves the struct panel.
-        const panel = document.getElementById('s-struct-pins');
-        assert.ok(panel, 'struct panel should exist');
-        panel!.dispatchEvent(new dom.window.MouseEvent('mouseleave', { bubbles: true }));
-
-        const selectedBitsAfterLeave = document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-val .si-bit.sel');
-        assert.ok(selectedBitsAfterLeave.length > 0, 'selected highlight should remain after hover leaves');
+        const childRows = document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field');
+        assert.ok(childRows.length > 0, 'bit-field array element should expose child bit rows');
     });
 });

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -618,6 +618,84 @@ suite('struct UI array header summary', () => {
         assert.ok(slicedValue, 'bit-field parent should rerender after selecting sliced binary');
         assert.strictEqual(slicedValue!.dataset.valType, 'bin-sliced', 'sliced binary should use its own value type');
         assert.strictEqual(slicedValue!.textContent?.replace(/\s+/g, ''), '0011', 'sliced binary should show the declared bit range as one value');
+
+        const parentExpand = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
+        assert.ok(parentExpand, 'bit-field parent should be expandable');
+        parentExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childValues = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val'));
+        assert.ok(childValues.length >= 2, 'bit-field child rows should render after expanding parent');
+        assert.ok(childValues.every(el => el.dataset.valType === 'bin'), 'changing bit-field parent view should not change child row views');
+
+        const firstChild = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start]');
+        assert.ok(firstChild, 'first bit-field child should render');
+        firstChild!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+
+        const childDecItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-dec"]');
+        assert.ok(childDecItem, 'bit-field child decimal menu item should render');
+        childDecItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const parentAfterChildChange = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-f-val');
+        assert.ok(parentAfterChildChange, 'bit-field parent should still render after changing a child');
+        assert.strictEqual(parentAfterChildChange!.dataset.valType, 'bin-sliced', 'changing a bit-field child should not change parent view');
+
+        const childValuesAfterChange = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val'));
+        assert.strictEqual(childValuesAfterChange[0]?.dataset.valType, 'dec', 'changing a bit-field child should affect that child');
+        assert.strictEqual(childValuesAfterChange[1]?.dataset.valType, 'bin', 'changing a bit-field child should not affect sibling children');
+    });
+
+    test('array header view changes direct bit-field elements only', async () => {
+        const def: StructDef = {
+            id: 'bit_array_view_scope',
+            name: 'BitArrayViewScope',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 2,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'flags', bitWidth: 5 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_array_view_scope', structId: 'bit_array_view_scope', addr: 0, name: 'inst' }];
+        setBytesInSegment(0, [0x33, 0x55]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const arrayHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
+        assert.ok(arrayHeader, 'bit-field array header should render');
+        arrayHeader!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+
+        const hexItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-hex"]');
+        assert.ok(hexItem, 'array header hex menu item should render');
+        hexItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const expandArray = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(expandArray, 'bit-field array should be expandable');
+        expandArray!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const elementValues = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-hdr.si-bitunit-hdr .si-f-val'));
+        assert.strictEqual(elementValues.length, 2, 'bit-field array should render two direct element aggregate values');
+        assert.ok(elementValues.every(el => el.dataset.valType === 'hex'), 'array header view should change direct bit-field element parents');
+
+        const expandFirstElement = document.querySelector<HTMLElement>('.si-arr-el-hdr.si-bitunit-hdr .si-arr-el-exp-btn');
+        assert.ok(expandFirstElement, 'bit-field array element should be expandable');
+        expandFirstElement!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childValues = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field[data-bit-start] .si-f-val'));
+        assert.ok(childValues.length > 0, 'bit-field array element should render child bit rows');
+        assert.ok(childValues.every(el => el.dataset.valType === 'bin'), 'array header view should not change nested bit-field children');
     });
 
     test('renders nested bit-field arrays with declared field names', async () => {

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -767,6 +767,57 @@ suite('struct UI array header summary', () => {
         assert.ok(!labels.includes('Binary (bit fields only)'), 'View as should omit bit-fields-only binary when it matches full range');
     });
 
+    test('wraps wide bit-field parent binary like scalar binary values', async () => {
+        const def: StructDef = {
+            id: 'wide_bit_parent_binary',
+            name: 'WideBitParentBinary',
+            fields: [
+                {
+                    name: 'flags',
+                    type: 'uint32',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'lo', bitWidth: 4 },
+                        { name: 'hi', bitWidth: 4 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_wide_bit_parent_binary', structId: 'wide_bit_parent_binary', addr: 0x500, name: 'inst' }];
+        setBytesInSegment(0x500, [0x12, 0x34, 0x56, 0x78]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const parentValue = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-f-val[data-val-type="bin"]');
+        assert.ok(parentValue, 'wide bit-field parent should render full binary by default');
+        assert.strictEqual(parentValue!.querySelectorAll('br').length, 1, 'uint32 bit-field parent binary should wrap after 16 bits');
+        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '00010010001101000101011001111000', 'wide bit-field parent binary should still show full storage bits');
+
+        const expandBits = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
+        assert.ok(expandBits, 'wide bit-field parent should be expandable');
+        expandBits!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const firstChild = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start]');
+        assert.ok(firstChild, 'wide bit-field child row should render');
+        firstChild!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const selectedBits = Array.from(document.querySelectorAll<HTMLElement>('.si-bitunit-hdr .si-f-val[data-val-type="bin"] .si-bit.sel'));
+        assert.strictEqual(selectedBits.length, 4, 'selecting a wide bit-field child should highlight its bits on the wrapped parent value');
+        assert.deepStrictEqual(
+            selectedBits.map(el => el.dataset.bitIdx).sort(),
+            ['0', '1', '2', '3'],
+            'wrapped parent binary highlight should preserve bit indexes across lines',
+        );
+    });
+
     test('groups bit-field child binary from lower bits first', async () => {
         const def: StructDef = {
             id: 'bit_child_binary_grouping',

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -73,6 +73,16 @@ suite('struct UI array header summary', () => {
         delete (globalThis as unknown as { acquireVsCodeApi?: () => unknown }).acquireVsCodeApi;
     });
 
+    async function renderPinsAndExpandCard(): Promise<HTMLElement> {
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        return expandCard!;
+    }
+
     test('uses declared struct type and element count for nested struct array header', async () => {
         const child: StructDef = {
             id: 'child',
@@ -99,12 +109,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [pin];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expand = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expand, 'expand button should be rendered');
-        expand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const header = document.querySelector<HTMLElement>('.si-arr-addr');
         assert.ok(header, 'array header summary should be rendered');
@@ -146,12 +151,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [pin];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should be rendered');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const expandArray = document.querySelector<HTMLElement>('.si-arr-exp-btn');
         assert.ok(expandArray, 'array group expand button should be rendered');
@@ -231,12 +231,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [pin];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should be rendered');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-name'))
             .map(el => el.textContent ?? '');
@@ -279,12 +274,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [{ id: 'pin_collapse', structId: 'parent_collapse', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topGroup = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp');
         assert.ok(topGroup, 'top composite group should render');
@@ -322,12 +312,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [{ id: 'pin_single_leaf', structId: 'single_leaf_parent', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name'))
             .map(el => el.textContent ?? '');
@@ -364,12 +349,7 @@ suite('struct UI array header summary', () => {
         S.structs = [level3, level2, level1];
         S.structPins = [{ id: 'pin_depth', structId: 'depth_l1', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name');
         assert.ok(topHeader, 'top nested struct header should render');
@@ -406,12 +386,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_array_offset', structId: 'array_offset', addr: 0, name: 'inst' }];
         setBytesInSegment(0, [0xAA, 0x11, 0x22, 0x33, 0x44]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const arrayHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
         assert.ok(arrayHeader, 'array header should render');
@@ -452,12 +427,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_nested_offset', structId: 'nested_offset_parent', addr: 0, name: 'inst' }];
         setBytesInSegment(0, [0xAA, 0x11, 0x22, 0x33]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const structHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
         assert.ok(structHeader, 'nested struct header should render');
@@ -494,12 +464,7 @@ suite('struct UI array header summary', () => {
         S.structs = [def];
         S.structPins = [pin];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const arrNodeNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-name'))
             .map(el => el.textContent ?? '');
@@ -542,12 +507,7 @@ suite('struct UI array header summary', () => {
         S.structs = [leaf, mid, top];
         S.structPins = [pin];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const openFirst = (selector: string) => {
             const btn = document.querySelector<HTMLElement>(selector);
@@ -596,12 +556,7 @@ suite('struct UI array header summary', () => {
         S.structs = [def];
         S.structPins = [{ id: 'pin_bits', structId: 'bit_struct', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topField0 = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp:nth-child(1) > .si-arr-grp-hdr .si-f-name');
         assert.ok(topField0, 'array bit-field group should render a top-level header');
@@ -672,8 +627,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_alloc_toggle', structId: 'bit_alloc_toggle', addr: 0x600, name: 'inst' }];
         setBytesInSegment(0x600, [0xB1]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
+        await renderPinsAndExpandCard();
 
         const toggleGroups = Array.from(document.querySelectorAll<HTMLElement>('.si-toggle-group'))
             .map(el => el.getAttribute('title') ?? '');
@@ -690,10 +644,6 @@ suite('struct UI array header summary', () => {
         assert.ok(document.getElementById('sa-btn-bit-lsb')?.getAttribute('title')?.includes('least significant bit'), 'LSB button should explain allocation on hover');
         assert.ok(document.getElementById('sa-btn-bit-msb')?.getAttribute('title')?.includes('most significant bit'), 'MSB button should explain allocation on hover');
 
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
-
         const expandBits = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
         assert.ok(expandBits, 'bit-field parent should be expandable');
         expandBits!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
@@ -707,6 +657,95 @@ suite('struct UI array header summary', () => {
         const childValuesLsb = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val'))
             .map(el => el.textContent ?? '');
         assert.deepStrictEqual(childValuesLsb, ['001', '1 0110'], 'LSB-first should allocate from low bits independently of byte endianness');
+    });
+
+    test('renders scalar values with each field effective endian instead of the global toggle', async () => {
+        const fields: StructDef['fields'] = [
+            { name: 'u16', type: 'uint16', count: 1, endian: 'inherit' },
+            { name: 'i16', type: 'int16', count: 1, endian: 'inherit' },
+            { name: 'u32', type: 'uint32', count: 1, endian: 'inherit' },
+            { name: 'i32', type: 'int32', count: 1, endian: 'inherit' },
+            { name: 'u64', type: 'uint64', count: 1, endian: 'inherit' },
+            { name: 'i64', type: 'int64', count: 1, endian: 'inherit' },
+            { name: 'f32', type: 'float32', count: 1, endian: 'inherit' },
+            { name: 'f64', type: 'float64', count: 1, endian: 'inherit' },
+            { name: 'ptr', type: 'pointer', count: 1, endian: 'inherit' },
+            { name: 'arr', type: 'uint16', count: 2, endian: 'inherit' },
+        ];
+        const leBytes = [
+            0x34, 0x12, 0xFE, 0xFF, 0x78, 0x56, 0x34, 0x12,
+            0xFE, 0xFF, 0xFF, 0xFF, 0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01,
+            0xFE,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF, 0x00, 0x00, 0x80, 0x3F,
+            0x00,0x00,0x00,0x00,0x00,0x00,0xF0,0x3F, 0x78, 0x56, 0x34, 0x12,
+            0x34, 0x12, 0x78, 0x56,
+        ];
+        const beBytes = [
+            0x12, 0x34, 0xFF, 0xFE, 0x12, 0x34, 0x56, 0x78,
+            0xFF, 0xFF, 0xFF, 0xFE, 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
+            0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE, 0x3F, 0x80, 0x00, 0x00,
+            0x3F,0xF0,0x00,0x00,0x00,0x00,0x00,0x00, 0x12, 0x34, 0x56, 0x78,
+            0x12, 0x34, 0x56, 0x78,
+        ];
+
+        const renderValues = async (fieldEndian: 'le' | 'be', globalEndian: 'le' | 'be', bytes: number[]) => {
+            resetStructState();
+            S.endian = globalEndian;
+            const def: StructDef = {
+                id: `scalar_${fieldEndian}`,
+                name: `Scalar${fieldEndian.toUpperCase()}`,
+                packed: true,
+                fields: fields.map(f => ({ ...f, endian: fieldEndian })),
+            };
+            S.structs = [def];
+            S.structPins = [{ id: `pin_${fieldEndian}`, structId: def.id, addr: 0, name: 'inst' }];
+            setBytesInSegment(0, bytes);
+            await renderPinsAndExpandCard();
+            return Array.from(document.querySelectorAll<HTMLElement>('.si-field > .si-f-body > .si-f-val'))
+                .map(el => el.textContent?.replace(/\s+/g, ' ').trim() ?? '');
+        };
+
+        const leValues = await renderValues('le', 'be', leBytes);
+        assert.ok(leValues[0].includes('0x1234'), `u16 LE display: ${leValues[0]}`);
+        assert.ok(leValues[1].includes('0xFFFE'), `i16 LE display: ${leValues[1]}`);
+        assert.ok(leValues[2].includes('0x12345678'), `u32 LE display: ${leValues[2]}`);
+        assert.ok(leValues[3].includes('0xFFFFFFFE'), `i32 LE display: ${leValues[3]}`);
+        assert.ok(leValues[4].includes('0x0102030405060708'), `u64 LE display: ${leValues[4]}`);
+        assert.ok(leValues[5].includes('0xFFFFFFFFFFFFFFFE'), `i64 LE display: ${leValues[5]}`);
+        assert.ok(leValues[6].startsWith('1.000000e+0'), `f32 LE display: ${leValues[6]}`);
+        assert.ok(leValues[7].startsWith('1.0000000000000000e+0'), `f64 LE display: ${leValues[7]}`);
+        assert.ok(leValues[8].includes('0x12345678'), `ptr LE display: ${leValues[8]}`);
+        let firstRow = document.querySelector<HTMLElement>('.si-field');
+        assert.ok(firstRow, 'first scalar row should render');
+        firstRow!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        let binItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-bin"]');
+        assert.ok(binItem, 'binary view menu item should render');
+        binItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        let firstBinary = document.querySelector<HTMLElement>('.si-field .si-f-val[data-val-type="bin"]');
+        assert.strictEqual(firstBinary?.textContent?.replace(/\s+/g, ' ').trim(), '0001 0010 0011 0100', 'LE binary should display the numeric value bits, not raw memory byte order');
+        firstRow = document.querySelector<HTMLElement>('.si-field');
+        firstRow!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        const hexItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-hex"]');
+        assert.ok(hexItem, 'hex view menu item should render');
+        hexItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const beValues = await renderValues('be', 'le', beBytes);
+        assert.ok(beValues[0].includes('0x1234'), `u16 BE display: ${beValues[0]}`);
+        assert.ok(beValues[1].includes('0xFFFE'), `i16 BE display: ${beValues[1]}`);
+        assert.ok(beValues[2].includes('0x12345678'), `u32 BE display: ${beValues[2]}`);
+        assert.ok(beValues[3].includes('0xFFFFFFFE'), `i32 BE display: ${beValues[3]}`);
+        assert.ok(beValues[4].includes('0x0102030405060708'), `u64 BE display: ${beValues[4]}`);
+        assert.ok(beValues[5].includes('0xFFFFFFFFFFFFFFFE'), `i64 BE display: ${beValues[5]}`);
+        assert.ok(beValues[6].startsWith('1.000000e+0'), `f32 BE display: ${beValues[6]}`);
+        assert.ok(beValues[7].startsWith('1.0000000000000000e+0'), `f64 BE display: ${beValues[7]}`);
+        assert.ok(beValues[8].includes('0x12345678'), `ptr BE display: ${beValues[8]}`);
+        firstRow = document.querySelector<HTMLElement>('.si-field');
+        assert.ok(firstRow, 'first scalar row should render after BE rerender');
+        firstRow!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+        binItem = document.querySelector<HTMLElement>('#si-val-menu .ctx-row[data-cmd="disp-bin"]');
+        assert.ok(binItem, 'binary view menu item should render after BE rerender');
+        binItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        firstBinary = document.querySelector<HTMLElement>('.si-field .si-f-val[data-val-type="bin"]');
+        assert.strictEqual(firstBinary?.textContent?.replace(/\s+/g, ' ').trim(), '0001 0010 0011 0100', 'BE binary should display the same numeric value bits for the same decoded value');
     });
 
     test('defaults bit-field parent binary to full storage range', async () => {
@@ -733,12 +772,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_binary_modes', structId: 'bit_binary_modes', addr: 0, name: 'inst' }];
         setBytesInSegment(0, [0x33]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const bitHeader = document.querySelector<HTMLElement>('.si-bitunit-hdr');
         assert.ok(bitHeader, 'bit-field parent header should render');
@@ -810,12 +844,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_full_range_menu', structId: 'bit_full_range_menu', addr: 0x200, name: 'inst' }];
         setBytesInSegment(0x200, [0x33]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const bitHeader = document.querySelector<HTMLElement>('.si-bitunit-hdr');
         assert.ok(bitHeader, 'bit-field parent header should render');
@@ -849,17 +878,12 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_wide_bit_parent_binary', structId: 'wide_bit_parent_binary', addr: 0x500, name: 'inst' }];
         setBytesInSegment(0x500, [0x12, 0x34, 0x56, 0x78]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const parentValue = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-f-val[data-val-type="bin"]');
         assert.ok(parentValue, 'wide bit-field parent should render full binary by default');
         assert.strictEqual(parentValue!.querySelectorAll('br').length, 1, 'uint32 bit-field parent binary should wrap after 16 bits');
-        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '00010010001101000101011001111000', 'wide bit-field parent binary should still show full storage bits');
+        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '01111000010101100011010000010010', 'wide bit-field parent binary should show full storage bits in effective endian order');
 
         const expandBits = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
         assert.ok(expandBits, 'wide bit-field parent should be expandable');
@@ -899,12 +923,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_child_binary_grouping', structId: 'bit_child_binary_grouping', addr: 0x300, name: 'inst' }];
         setBytesInSegment(0x300, [0x00]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const parentExpand = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
         assert.ok(parentExpand, 'bit-field parent should be expandable');
@@ -937,12 +956,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_array_view_scope', structId: 'bit_array_view_scope', addr: 0, name: 'inst' }];
         setBytesInSegment(0, [0x33, 0x55]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const arrayHeader = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr');
         assert.ok(arrayHeader, 'bit-field array header should render');
@@ -991,12 +1005,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_bit_array_highlight', structId: 'bit_array_highlight', addr: 0x100, name: 'inst' }];
         setBytesInSegment(0x100, [0x33, 0x55]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const expandArray = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
         assert.ok(expandArray, 'bit-field array should be expandable');
@@ -1049,12 +1058,7 @@ suite('struct UI array header summary', () => {
         S.structs = [child, parent];
         S.structPins = [{ id: 'pin_nested_bits', structId: 'parent_bits', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const parentGroupExpand = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-exp-btn');
         assert.ok(parentGroupExpand, 'nested struct array group should be expandable');
@@ -1113,12 +1117,7 @@ suite('struct UI array header summary', () => {
         S.structPins = [{ id: 'pin_nested_single_bits', structId: 'parent_single_bits', addr: 0x40, name: 'inst' }];
         setBytesInSegment(0x40, [0x0B]);
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const expandNode = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-arr-exp-btn');
         assert.ok(expandNode, 'nested struct node should be expandable');
@@ -1177,12 +1176,7 @@ suite('struct UI array header summary', () => {
         S.structs = [def];
         S.structPins = [{ id: 'pin_mixed_bits', structId: 'mixed_bits', addr: 0, name: 'inst' }];
 
-        const { renderStructPins } = await import('../webview/struct.js');
-        renderStructPins();
-
-        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
-        assert.ok(expandCard, 'expand button should render');
-        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        await renderPinsAndExpandCard();
 
         const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name'))
             .map(el => el.textContent ?? '');

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -551,4 +551,125 @@ suite('struct UI array header summary', () => {
         const childRows = document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-field');
         assert.ok(childRows.length > 0, 'bit-field array element should expose child bit rows');
     });
+
+    test('renders nested bit-field arrays with declared field names', async () => {
+        const child: StructDef = {
+            id: 'child_bits',
+            name: 'ChildBits',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 2,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'flags', bitWidth: 5 },
+                    ],
+                },
+                { name: 'payload', type: 'uint8', count: 2, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'parent_bits',
+            name: 'ParentBits',
+            fields: [
+                { name: 'nodes', type: 'struct', refStructId: 'child_bits', count: 2, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [child, parent];
+        S.structPins = [{ id: 'pin_nested_bits', structId: 'parent_bits', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const parentGroupExpand = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp .si-arr-exp-btn');
+        assert.ok(parentGroupExpand, 'nested struct array group should be expandable');
+        parentGroupExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const elementExpand = document.querySelector<HTMLElement>('.si-arr-el-hdr .si-arr-el-exp-btn');
+        assert.ok(elementExpand, 'nested struct array element should be expandable');
+        elementExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedBitGroup = document.querySelector<HTMLElement>('.si-arr-el-body .si-arr-grp-hdr .si-f-name');
+        assert.ok(nestedBitGroup, 'nested bit-field group should render a header');
+        assert.strictEqual(nestedBitGroup!.textContent ?? '', 'field0', 'nested bit-field group should show the declared field name');
+
+        const nestedBitExpand = document.querySelector<HTMLElement>('.si-arr-el-body .si-arr-grp .si-arr-exp-btn');
+        assert.ok(nestedBitExpand, 'nested bit-field group should be expandable');
+        nestedBitExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const nestedElementNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-arr-el-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(nestedElementNames.includes('[0]'), 'nested bit-field array should show element index [0]');
+        assert.ok(nestedElementNames.includes('[1]'), 'nested bit-field array should show element index [1]');
+
+        const nestedChildNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-el-body .si-arr-el-body .si-field .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(nestedChildNames.includes('mode'), 'nested bit-field child row should contain mode');
+        assert.ok(nestedChildNames.includes('flags'), 'nested bit-field child row should contain flags');
+        assert.ok(!nestedChildNames.includes('BitField'), 'nested bit-field groups should not use synthetic labels');
+    });
+
+    test('keeps scalar arrays separate from bit-field groups', async () => {
+        const def: StructDef = {
+            id: 'mixed_bits',
+            name: 'MixedBits',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 2,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'flags', bitWidth: 5 },
+                    ],
+                },
+                { name: 'data', type: 'uint8', count: 3, endian: 'inherit' },
+                {
+                    name: 'field1',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'bit0', bitWidth: 1 },
+                        { name: 'bit1', bitWidth: 1 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_mixed_bits', structId: 'mixed_bits', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const topHeaders = Array.from(document.querySelectorAll<HTMLElement>('.si-fields > .si-arr-grp > .si-arr-grp-hdr .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.deepStrictEqual(topHeaders, ['field0', 'data', 'field1'], 'mixed sibling groups should keep their declared order and names');
+
+        const dataGroup = document.querySelector<HTMLElement>('.si-fields > .si-arr-grp:nth-child(2)');
+        assert.ok(dataGroup, 'scalar array group should render at the top level');
+        const dataExpand = dataGroup!.querySelector<HTMLElement>('.si-arr-exp-btn');
+        assert.ok(dataExpand, 'scalar array group should be expandable');
+        dataExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const scalarArrayNames = Array.from(dataGroup!.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(scalarArrayNames.includes('[0]'), 'scalar array should keep index-only child labels');
+        assert.ok(scalarArrayNames.includes('[1]'), 'scalar array should keep index-only child labels');
+        assert.ok(scalarArrayNames.includes('[2]'), 'scalar array should keep index-only child labels');
+        assert.ok(!scalarArrayNames.includes('BitField'), 'scalar arrays should not be reclassified as bit-field groups');
+    });
 });

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -472,8 +472,16 @@ suite('struct UI array header summary', () => {
             id: 'bit_struct',
             name: 'BitStruct',
             fields: [
-                { name: 'mode', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
-                { name: 'flags', type: 'uint16', bitWidth: 5, count: 1, endian: 'inherit' },
+                {
+                    name: 'flags',
+                    type: 'uint16',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'mode', bitWidth: 3 },
+                        { name: 'flags', bitWidth: 5 },
+                    ],
+                },
             ],
         };
 

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -466,4 +466,75 @@ suite('struct UI array header summary', () => {
             .map(el => el.textContent ?? '');
         assert.ok(!labels.some(label => /#\d+$/.test(label)), 'nested labels should not use disambiguation suffixes');
     });
+
+    test('groups bit fields by storage unit with child rows', async () => {
+        const def: StructDef = {
+            id: 'bit_struct',
+            name: 'BitStruct',
+            fields: [
+                { name: 'mode', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
+                { name: 'flags', type: 'uint16', bitWidth: 5, count: 1, endian: 'inherit' },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bits', structId: 'bit_struct', addr: 0, name: 'inst' }];
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const unitHeader = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-name');
+        assert.ok(unitHeader, 'bit-field unit header should render');
+        assert.strictEqual(unitHeader!.textContent ?? '', 'BitField', 'bit-field header should display BitField');
+
+        const unitType = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-type');
+        assert.ok(unitType, 'bit-field header should show scalar-like type');
+        assert.strictEqual(unitType!.textContent ?? '', 'u16', 'bit-field header should use base scalar type');
+
+        const unitOffset = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-off');
+        assert.ok(unitOffset, 'bit-field header should show scalar-like offset');
+
+        const unitValue = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-f-val');
+        assert.ok(unitValue, 'bit-field unit should show scalar-like value cell');
+        assert.strictEqual(unitValue!.dataset.valType, 'bin', 'bit-field parent row should default to binary view');
+
+        const unitExpand = document.querySelector<HTMLElement>('.si-arr-grp-hdr .si-arr-exp-btn');
+        assert.ok(unitExpand, 'bit-field unit should be expandable');
+        unitExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childNames = Array.from(document.querySelectorAll<HTMLElement>('.si-arr-grp-body .si-field .si-f-name'))
+            .map(el => el.textContent ?? '');
+        assert.ok(childNames.includes('mode'), 'bit-field child row should contain mode');
+        assert.ok(childNames.includes('flags'), 'bit-field child row should contain flags');
+
+        const childType = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field .si-f-type');
+        assert.ok(childType, 'bit-field child row should show type');
+        assert.strictEqual(childType!.textContent ?? '', 'bit:3', 'bit-field child type should be displayed as bit:N');
+
+        const childOffset = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field .si-f-off');
+        assert.ok(childOffset, 'bit-field child row should show offset');
+        assert.strictEqual(childOffset!.textContent ?? '', '.0', 'bit-field child offset should use .N format');
+
+        const firstChild = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field');
+        assert.ok(firstChild, 'first bit-field child should render');
+        firstChild!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const selectedBits = document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-val .si-bit.sel');
+        assert.ok(selectedBits.length > 0, 'selecting bit-field child should highlight corresponding parent bits');
+
+        const selectedRows = document.querySelectorAll<HTMLElement>('.si-field.si-selected');
+        assert.strictEqual(selectedRows.length, 0, 'bit-field child selection should not apply row selection/jump styling');
+
+        // Hover highlight should clear when pointer leaves the struct panel.
+        const panel = document.getElementById('s-struct-pins');
+        assert.ok(panel, 'struct panel should exist');
+        panel!.dispatchEvent(new dom.window.MouseEvent('mouseleave', { bubbles: true }));
+
+        const selectedBitsAfterLeave = document.querySelectorAll<HTMLElement>('.si-arr-grp-hdr .si-f-val .si-bit.sel');
+        assert.ok(selectedBitsAfterLeave.length > 0, 'selected highlight should remain after hover leaves');
+    });
 });

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -644,6 +644,82 @@ suite('struct UI array header summary', () => {
         assert.strictEqual(childValuesAfterChange[1]?.dataset.valType, 'bin', 'changing a bit-field child should not affect sibling children');
     });
 
+    test('omits sliced binary when bit fields fill parent storage', async () => {
+        const def: StructDef = {
+            id: 'bit_full_range_menu',
+            name: 'BitFullRangeMenu',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'lo', bitWidth: 4 },
+                        { name: 'hi', bitWidth: 4 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_full_range_menu', structId: 'bit_full_range_menu', addr: 0x200, name: 'inst' }];
+        setBytesInSegment(0x200, [0x33]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const bitHeader = document.querySelector<HTMLElement>('.si-bitunit-hdr');
+        assert.ok(bitHeader, 'bit-field parent header should render');
+        bitHeader!.dispatchEvent(new dom.window.MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 4 }));
+
+        const labels = Array.from(document.querySelectorAll<HTMLElement>('#si-val-menu .ctx-row[data-cmd^="disp-"] .ctx-label'))
+            .map(el => el.textContent ?? '');
+        assert.ok(labels.includes('Binary'), 'View as should include full Binary');
+        assert.ok(!labels.includes('Binary (bit field sliced)'), 'View as should omit sliced binary when it matches full range');
+    });
+
+    test('groups bit-field child binary from lower bits first', async () => {
+        const def: StructDef = {
+            id: 'bit_child_binary_grouping',
+            name: 'BitChildBinaryGrouping',
+            fields: [
+                {
+                    name: 'field0',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'wide', bitWidth: 5 },
+                    ],
+                },
+            ],
+        };
+
+        S.structs = [def];
+        S.structPins = [{ id: 'pin_bit_child_binary_grouping', structId: 'bit_child_binary_grouping', addr: 0x300, name: 'inst' }];
+        setBytesInSegment(0x300, [0x00]);
+
+        const { renderStructPins } = await import('../webview/struct.js');
+        renderStructPins();
+
+        const expandCard = document.querySelector<HTMLElement>('.si-expand-btn');
+        assert.ok(expandCard, 'expand button should render');
+        expandCard!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const parentExpand = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
+        assert.ok(parentExpand, 'bit-field parent should be expandable');
+        parentExpand!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        const childValue = document.querySelector<HTMLElement>('.si-arr-grp-body .si-field[data-bit-start] .si-f-val');
+        assert.ok(childValue, 'bit-field child value should render');
+        assert.strictEqual(childValue!.textContent, '0 0000', 'bit-field child binary should keep the lower four bits packed together');
+    });
+
     test('array header view changes direct bit-field elements only', async () => {
         const def: StructDef = {
             id: 'bit_array_view_scope',

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -239,6 +239,27 @@ suite('decodeField()', () => {
         assert.strictEqual(r, '-1');
     });
 
+    test('all multi-byte scalar types honor little and big endian byte order', () => {
+        assert.ok(decodeField([0x34, 0x12], 'uint16', 'le').startsWith('4660'), 'uint16 LE');
+        assert.ok(decodeField([0x12, 0x34], 'uint16', 'be').startsWith('4660'), 'uint16 BE');
+        assert.strictEqual(decodeField([0xFE, 0xFF], 'int16', 'le'), '-2', 'int16 LE');
+        assert.strictEqual(decodeField([0xFF, 0xFE], 'int16', 'be'), '-2', 'int16 BE');
+        assert.ok(decodeField([0x78, 0x56, 0x34, 0x12], 'uint32', 'le').startsWith('305419896'), 'uint32 LE');
+        assert.ok(decodeField([0x12, 0x34, 0x56, 0x78], 'uint32', 'be').startsWith('305419896'), 'uint32 BE');
+        assert.strictEqual(decodeField([0xFE, 0xFF, 0xFF, 0xFF], 'int32', 'le'), '-2', 'int32 LE');
+        assert.strictEqual(decodeField([0xFF, 0xFF, 0xFF, 0xFE], 'int32', 'be'), '-2', 'int32 BE');
+        assert.ok(decodeField([0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01], 'uint64', 'le').startsWith('72623859790382856'), 'uint64 LE');
+        assert.ok(decodeField([0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08], 'uint64', 'be').startsWith('72623859790382856'), 'uint64 BE');
+        assert.strictEqual(decodeField([0xFE,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF], 'int64', 'le'), '-2', 'int64 LE');
+        assert.strictEqual(decodeField([0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE], 'int64', 'be'), '-2', 'int64 BE');
+        assert.strictEqual(parseFloat(decodeField([0x00, 0x00, 0x80, 0x3F], 'float32', 'le')), 1, 'float32 LE');
+        assert.strictEqual(parseFloat(decodeField([0x3F, 0x80, 0x00, 0x00], 'float32', 'be')), 1, 'float32 BE');
+        assert.strictEqual(parseFloat(decodeField([0x00,0x00,0x00,0x00,0x00,0x00,0xF0,0x3F], 'float64', 'le')), 1, 'float64 LE');
+        assert.strictEqual(parseFloat(decodeField([0x3F,0xF0,0x00,0x00,0x00,0x00,0x00,0x00], 'float64', 'be')), 1, 'float64 BE');
+        assert.strictEqual(decodeField([0x78, 0x56, 0x34, 0x12], 'pointer', 'le'), '0x12345678', 'pointer LE');
+        assert.strictEqual(decodeField([0x12, 0x34, 0x56, 0x78], 'pointer', 'be'), '0x12345678', 'pointer BE');
+    });
+
     test('float32 LE 1.0 (0x3F800000)', () => {
         // 1.0f LE bytes: 00 00 80 3F
         const r = decodeField([0x00, 0x00, 0x80, 0x3F], 'float32', 'le');
@@ -334,6 +355,45 @@ suite('decodeStruct()', () => {
         // BE read of 00 01 = 1
         const rows = decodeStruct(def, 0, getByte, 'le');
         assert.ok(rows[0].decoded.startsWith('1'), rows[0].decoded);
+    });
+
+    test('decoded rows keep effective endian for arrays and nested structs', () => {
+        const child: StructDef = {
+            id: 'endian_child',
+            name: 'EndianChild',
+            fields: [
+                { name: 'word', type: 'uint16', count: 2, endian: 'inherit' },
+                { name: 'flt', type: 'float32', count: 1, endian: 'inherit' },
+                { name: 'ptr', type: 'pointer', count: 1, endian: 'inherit' },
+            ],
+        };
+        const parent: StructDef = {
+            id: 'endian_parent',
+            name: 'EndianParent',
+            packed: true,
+            fields: [
+                { name: 'leWord', type: 'uint16', count: 1, endian: 'le' },
+                { name: 'beNode', type: 'struct', refStructId: 'endian_child', count: 1, endian: 'be' },
+            ],
+        };
+        S.structs = [child, parent];
+        setBytesInSegment(0, [
+            0x34, 0x12,
+            0x12, 0x34,
+            0x56, 0x78,
+            0x3F, 0x80, 0x00, 0x00,
+            0x12, 0x34, 0x56, 0x78,
+        ]);
+
+        const rows = decodeStruct(parent, 0, getByte, 'le');
+        assert.strictEqual(rows[0].fieldName, 'leWord');
+        assert.strictEqual(rows[0].endian, 'le');
+        assert.ok(rows[0].decoded.startsWith('4660'), rows[0].decoded);
+        assert.deepStrictEqual(rows.slice(1).map(r => r.endian), ['be', 'be', 'be', 'be']);
+        assert.ok(rows[1].decoded.startsWith('4660'), rows[1].decoded);
+        assert.ok(rows[2].decoded.startsWith('22136'), rows[2].decoded);
+        assert.strictEqual(parseFloat(rows[3].decoded), 1);
+        assert.strictEqual(rows[4].decoded, '0x12345678');
     });
 
     test('byte offsets accumulate correctly (packed)', () => {

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -144,7 +144,7 @@ suite('structByteSize()', () => {
         assert.strictEqual(structByteSize(def), 2);
 
         setBytesInSegment(0, [0x81, 0x7F]);
-        const rows = decodeStruct(def, 0, getByte, 'le');
+        const rows = decodeStruct(def, 0, getByte, 'le', 'lsb');
         assert.strictEqual(rows.length, 4);
         assert.strictEqual(rows[0].fieldName, 'flags[0].enabled');
         assert.strictEqual(rows[1].fieldName, 'flags[0].mode');
@@ -360,32 +360,64 @@ suite('decodeStruct()', () => {
         assert.strictEqual(rows[2].byteOffset, 8);
     });
 
-    test('decodes LE bit fields LSB-first as unsigned values', () => {
+    test('decodes bit fields MSB-first by default as unsigned values', () => {
         const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
             { name: 'a', type: 'uint8', bitWidth: 3, count: 1, endian: 'inherit' },
             { name: 'b', type: 'uint8', bitWidth: 5, count: 1, endian: 'inherit' },
         ]};
-        // 0b10110001 => a=0b001=1, b=0b10110=22 in LE LSB-first consumption.
+        // 0xB1 => a=0b101=5, b=0b10001=17 in MSB-first allocation.
         setBytesInSegment(0, [0xB1]);
         const rows = decodeStruct(def, 0, getByte, 'le');
         assert.strictEqual(rows.length, 2);
         assert.strictEqual(rows[0].isBitField, true);
         assert.strictEqual(rows[0].bitOffset, 0);
-        assert.strictEqual(rows[0].bitValueUnsigned, '1');
+        assert.strictEqual(rows[0].bitValueUnsigned, '5');
         assert.strictEqual(rows[1].bitOffset, 3);
-        assert.strictEqual(rows[1].bitValueUnsigned, '22');
+        assert.strictEqual(rows[1].bitValueUnsigned, '17');
     });
 
-    test('decodes BE bit fields MSB-first as unsigned values', () => {
+    test('decodes bit fields LSB-first when allocation is LSB', () => {
         const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
             { name: 'a', type: 'uint8', bitWidth: 3, count: 1, endian: 'inherit' },
             { name: 'b', type: 'uint8', bitWidth: 5, count: 1, endian: 'inherit' },
         ]};
-        // 0xB1 => a=0b101=5, b=0b10001=17 in BE MSB-first consumption.
+        // 0b10110001 => a=0b001=1, b=0b10110=22 in LSB-first allocation.
         setBytesInSegment(0, [0xB1]);
-        const rows = decodeStruct(def, 0, getByte, 'be');
-        assert.strictEqual(rows[0].bitValueUnsigned, '5');
-        assert.strictEqual(rows[1].bitValueUnsigned, '17');
+        const rows = decodeStruct(def, 0, getByte, 'le', 'lsb');
+        assert.strictEqual(rows[0].bitValueUnsigned, '1');
+        assert.strictEqual(rows[1].bitValueUnsigned, '22');
+    });
+
+    test('byte endianness and bit-field allocation are independent', () => {
+        const def: StructDef = { id: 'x', name: 'Bits16', packed: true, fields: [
+            {
+                name: 'word',
+                type: 'uint16',
+                count: 1,
+                endian: 'inherit',
+                bitFields: [
+                    { name: 'a', bitWidth: 4 },
+                    { name: 'b', bitWidth: 4 },
+                ],
+            },
+        ]};
+        setBytesInSegment(0, [0x12, 0x34]);
+
+        const leLsb = decodeStruct(def, 0, getByte, 'le', 'lsb');
+        assert.strictEqual(leLsb[0].bitValueUnsigned, '2');
+        assert.strictEqual(leLsb[1].bitValueUnsigned, '1');
+
+        const beLsb = decodeStruct(def, 0, getByte, 'be', 'lsb');
+        assert.strictEqual(beLsb[0].bitValueUnsigned, '4');
+        assert.strictEqual(beLsb[1].bitValueUnsigned, '3');
+
+        const leMsb = decodeStruct(def, 0, getByte, 'le', 'msb');
+        assert.strictEqual(leMsb[0].bitValueUnsigned, '3');
+        assert.strictEqual(leMsb[1].bitValueUnsigned, '4');
+
+        const beMsb = decodeStruct(def, 0, getByte, 'be', 'msb');
+        assert.strictEqual(beMsb[0].bitValueUnsigned, '1');
+        assert.strictEqual(beMsb[1].bitValueUnsigned, '2');
     });
 
     test('bytesHex shows ?? for missing bytes', () => {

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -109,6 +109,24 @@ suite('structByteSize()', () => {
         assert.strictEqual(structByteSize(def), 12);
     });
 
+    test('bit fields share storage unit for same base type', () => {
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
+            { name: 'b', type: 'uint16', bitWidth: 5, count: 1, endian: 'inherit' },
+            { name: 'c', type: 'uint16', bitWidth: 4, count: 1, endian: 'inherit' },
+        ]};
+        assert.strictEqual(structByteSize(def), 2);
+    });
+
+    test('bit fields followed by normal field align to next natural boundary', () => {
+        const def: StructDef = { id: 'x', name: 'S', fields: [
+            { name: 'a', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
+            { name: 'b', type: 'uint16', bitWidth: 5, count: 1, endian: 'inherit' },
+            { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },
+        ]};
+        assert.strictEqual(structByteSize(def), 8);
+    });
+
     test('nested struct contributes child size and alignment', () => {
         const child: StructDef = {
             id: 'child',
@@ -315,6 +333,34 @@ suite('decodeStruct()', () => {
         assert.strictEqual(rows[2].byteOffset, 8);
     });
 
+    test('decodes LE bit fields LSB-first as unsigned values', () => {
+        const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
+            { name: 'a', type: 'uint8', bitWidth: 3, count: 1, endian: 'inherit' },
+            { name: 'b', type: 'uint8', bitWidth: 5, count: 1, endian: 'inherit' },
+        ]};
+        // 0b10110001 => a=0b001=1, b=0b10110=22 in LE LSB-first consumption.
+        setBytesInSegment(0, [0xB1]);
+        const rows = decodeStruct(def, 0, getByte, 'le');
+        assert.strictEqual(rows.length, 2);
+        assert.strictEqual(rows[0].isBitField, true);
+        assert.strictEqual(rows[0].bitOffset, 0);
+        assert.strictEqual(rows[0].bitValueUnsigned, '1');
+        assert.strictEqual(rows[1].bitOffset, 3);
+        assert.strictEqual(rows[1].bitValueUnsigned, '22');
+    });
+
+    test('decodes BE bit fields MSB-first as unsigned values', () => {
+        const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
+            { name: 'a', type: 'uint8', bitWidth: 3, count: 1, endian: 'inherit' },
+            { name: 'b', type: 'uint8', bitWidth: 5, count: 1, endian: 'inherit' },
+        ]};
+        // 0xB1 => a=0b101=5, b=0b10001=17 in BE MSB-first consumption.
+        setBytesInSegment(0, [0xB1]);
+        const rows = decodeStruct(def, 0, getByte, 'be');
+        assert.strictEqual(rows[0].bitValueUnsigned, '5');
+        assert.strictEqual(rows[1].bitValueUnsigned, '17');
+    });
+
     test('bytesHex shows ?? for missing bytes', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
             { name: 'a', type: 'uint16', count: 1, endian: 'inherit' },
@@ -429,6 +475,21 @@ suite('validateStructs()', () => {
         }
         const errs = validateStructs(defs, 32);
         assert.ok(errs.some(e => e.includes('depth')), `errors: ${errs.join(' | ')}`);
+    });
+
+    test('reports bit-field width overflow and boundary crossing', () => {
+        const bad: StructDef = {
+            id: 'bad',
+            name: 'BadBits',
+            fields: [
+                { name: 'a', type: 'uint8', bitWidth: 9, count: 1, endian: 'inherit' },
+                { name: 'b', type: 'uint8', bitWidth: 4, count: 1, endian: 'inherit' },
+                { name: 'c', type: 'uint8', bitWidth: 5, count: 1, endian: 'inherit' },
+            ],
+        };
+        const errs = validateStructs([bad]);
+        assert.ok(errs.some(e => e.includes('exceeds 8 bits')), errs.join(' | '));
+        assert.ok(errs.some(e => e.includes('crosses a 8-bit storage unit boundary')), errs.join(' | '));
     });
 });
 
@@ -580,6 +641,21 @@ suite('parseStructText()', () => {
         const { fields } = parseStructText('uint32_t x');
         assert.strictEqual(fields[0].name, 'x');
     });
+
+    test('parses fixed-width integer bit fields with :N syntax', () => {
+        const { fields, errors } = parseStructText('uint16_t mode:3;\nuint16_t flags:5;');
+        assert.strictEqual(errors.length, 0, errors.join(' | '));
+        assert.strictEqual(fields.length, 2);
+        assert.strictEqual(fields[0].bitWidth, 3);
+        assert.strictEqual(fields[1].bitWidth, 5);
+        assert.strictEqual(fields[0].count, 1);
+    });
+
+    test('rejects bit field arrays', () => {
+        const { fields, errors } = parseStructText('uint16_t mode:3[2];');
+        assert.strictEqual(fields.length, 0);
+        assert.ok(errors.some(e => e.includes('cannot be declared as an array')), errors.join(' | '));
+    });
 });
 
 // ── fieldsToText() ────────────────────────────────────────────────
@@ -624,6 +700,11 @@ suite('fieldsToText()', () => {
         const f: StructField[] = [{ name: 'val', type: 'float64', count: 1, endian: 'inherit' }];
         assert.ok(fieldsToText(f).startsWith('double '));
     });
+
+    test('bit field emits :N suffix', () => {
+        const f: StructField[] = [{ name: 'mode', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' }];
+        assert.ok(fieldsToText(f).includes('mode:3;'));
+    });
 });
 
 // ── parseStructText() round-trip ─────────────────────────────────
@@ -632,6 +713,7 @@ suite('parseStructText() round-trip', () => {
     test('fields → text → parse produces identical fields', () => {
         const original: StructField[] = [
             { name: 'sp',   type: 'uint32',  count: 1,  endian: 'inherit' },
+            { name: 'mode', type: 'uint16',  bitWidth: 3, count: 1, endian: 'inherit' },
             { name: 'data', type: 'uint8',   count: 16, endian: 'inherit' },
             { name: 'temp', type: 'float32', count: 1,  endian: 'be' },
             { name: 'val',  type: 'int16',   count: 2,  endian: 'le' },
@@ -643,6 +725,7 @@ suite('parseStructText() round-trip', () => {
         for (let i = 0; i < original.length; i++) {
             assert.strictEqual(fields[i].name,   original[i].name,   `name mismatch at ${i}`);
             assert.strictEqual(fields[i].type,   original[i].type,   `type mismatch at ${i}`);
+            assert.strictEqual(fields[i].bitWidth, original[i].bitWidth, `bitWidth mismatch at ${i}`);
             assert.strictEqual(fields[i].count,  original[i].count,  `count mismatch at ${i}`);
             assert.strictEqual(fields[i].endian, original[i].endian, `endian mismatch at ${i}`);
         }
@@ -694,5 +777,47 @@ suite('structToC()', () => {
         const text = structToC(def, [def]);
         assert.ok(text.includes('_pad5[3]'), text);
         assert.ok(text.includes('/* 8B, align=4 */'), text);
+    });
+
+    test('renders bit fields with :width declarations', () => {
+        const def: StructDef = {
+            id: 'x',
+            name: 'Bits',
+            fields: [
+                { name: 'mode', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
+                { name: 'flags', type: 'uint16', bitWidth: 5, count: 1, endian: 'inherit' },
+            ],
+        };
+        const text = structToC(def, [def]);
+        assert.ok(text.includes('mode:3;'), text);
+        assert.ok(text.includes('flags:5;'), text);
+    });
+
+    test('renders nested struct for bit-field container', () => {
+        const def: StructDef = {
+            id: 'x',
+            name: 'Status',
+            fields: [
+                {
+                    name: 'flags',
+                    type: 'uint8',
+                    count: 1,
+                    endian: 'inherit',
+                    bitFields: [
+                        { name: 'enabled', bitWidth: 1 },
+                        { name: 'error', bitWidth: 1 },
+                        { name: 'mode', bitWidth: 2 },
+                        { name: 'speed', bitWidth: 4 },
+                    ],
+                },
+            ],
+        };
+        const text = structToC(def, [def]);
+        assert.ok(text.includes('struct {'), text);
+        assert.ok(text.includes('uint8_t enabled:1;'), text);
+        assert.ok(text.includes('uint8_t error:1;'), text);
+        assert.ok(text.includes('uint8_t mode:2;'), text);
+        assert.ok(text.includes('uint8_t speed:4;'), text);
+        assert.ok(text.includes('} flags;'), text);
     });
 });

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import {
     fieldByteSize, structByteSize, decodeField, decodeStruct,
     allStructs, parseStructText, fieldsToText, validateStructs, structToC, resolveStructFieldByPath,
+    migrateStructDefBitFields,
 } from '../webview/struct-codec';
 import { S } from '../webview/state';
 import { initFlatBytes, getByte } from '../webview/data';
@@ -125,6 +126,32 @@ suite('structByteSize()', () => {
             { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },
         ]};
         assert.strictEqual(structByteSize(def), 8);
+    });
+
+    test('bit-field containers can be arrays', () => {
+        const def: StructDef = { id: 'x', name: 'Bits', fields: [
+            {
+                name: 'flags',
+                type: 'uint8',
+                count: 2,
+                endian: 'inherit',
+                bitFields: [
+                    { name: 'enabled', bitWidth: 1 },
+                    { name: 'mode', bitWidth: 7 },
+                ],
+            },
+        ]};
+        assert.strictEqual(structByteSize(def), 2);
+
+        setBytesInSegment(0, [0x81, 0x7F]);
+        const rows = decodeStruct(def, 0, getByte, 'le');
+        assert.strictEqual(rows.length, 4);
+        assert.strictEqual(rows[0].fieldName, 'flags[0].enabled');
+        assert.strictEqual(rows[1].fieldName, 'flags[0].mode');
+        assert.strictEqual(rows[2].fieldName, 'flags[1].enabled');
+        assert.strictEqual(rows[3].fieldName, 'flags[1].mode');
+        assert.strictEqual(rows[0].bitValueUnsigned, '1');
+        assert.strictEqual(rows[1].bitValueUnsigned, '64');
     });
 
     test('nested struct contributes child size and alignment', () => {
@@ -729,6 +756,24 @@ suite('parseStructText() round-trip', () => {
             assert.strictEqual(fields[i].count,  original[i].count,  `count mismatch at ${i}`);
             assert.strictEqual(fields[i].endian, original[i].endian, `endian mismatch at ${i}`);
         }
+    });
+});
+
+suite('migrateStructDefBitFields()', () => {
+    test('converts legacy flat bitWidth fields into container fields', () => {
+        const legacy: StructDef = {
+            id: 'x',
+            name: 'Legacy',
+            fields: [
+                { name: 'mode', type: 'uint16', bitWidth: 3, count: 1, endian: 'inherit' },
+            ],
+        };
+        const migrated = migrateStructDefBitFields(legacy);
+        assert.strictEqual(migrated.fields[0].bitWidth, undefined);
+        assert.ok(Array.isArray(migrated.fields[0].bitFields), 'bitFields should exist after migration');
+        assert.strictEqual(migrated.fields[0].bitFields?.length, 1);
+        assert.strictEqual(migrated.fields[0].bitFields?.[0].name, 'mode');
+        assert.strictEqual(migrated.fields[0].bitFields?.[0].bitWidth, 3);
     });
 });
 

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -100,6 +100,9 @@ suite('state constants and defaults', () => {
     test('default byte order is little-endian', () => {
         assert.strictEqual(S.endian, 'le');
     });
+    test('default bit-field allocation is MSB-first', () => {
+        assert.strictEqual(S.bitFieldAllocation, 'msb');
+    });
     test('default search mode is "bytes"', () => {
         assert.strictEqual(S.searchMode, 'bytes');
     });

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -1,7 +1,7 @@
 // ── Shared mutable state ─────────────────────────────────────────
 // All modules import this object and mutate it directly.
 
-import type { SerializedParseResult, SegmentLabel, SearchMode, SearchEndianness, MemRow, StructDef, StructPin } from './types';
+import type { SerializedParseResult, SegmentLabel, SearchMode, SearchEndianness, BitFieldAllocation, MemRow, StructDef, StructPin } from './types';
 
 export const BPR = 16; // bytes per memory row
 
@@ -14,6 +14,7 @@ export const S = {
     selStart:     null   as number | null,
     selEnd:       null   as number | null,
     endian:       'le'   as 'le' | 'be',
+    bitFieldAllocation: 'msb' as BitFieldAllocation,
     searchMode:   'bytes'  as SearchMode,
     searchEndianness: 'auto' as SearchEndianness,
     matchAddrs:   []     as number[],

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -3,6 +3,7 @@
 
 import { S } from './state';
 import type {
+    BitFieldChild,
     StructDef,
     StructField,
     StructFieldType,
@@ -10,7 +11,7 @@ import type {
     StructScalarFieldType,
 } from './types';
 
-export type { StructDef, StructField, StructFieldType, StructFieldEndian };
+export type { BitFieldChild, StructDef, StructField, StructFieldType, StructFieldEndian };
 
 export const MAX_NESTED_DEPTH = 32;
 
@@ -23,6 +24,63 @@ export const FIELD_TYPES: StructScalarFieldType[] = [
     'float32', 'float64',
     'pointer',
 ];
+
+type IntScalarFieldType =
+    | 'uint8' | 'uint16' | 'uint32' | 'uint64'
+    | 'int8' | 'int16' | 'int32' | 'int64';
+
+function isIntScalarType(type: StructScalarFieldType): type is IntScalarFieldType {
+    return (
+        type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64' ||
+        type === 'int8' || type === 'int16' || type === 'int32' || type === 'int64'
+    );
+}
+
+type UnsignedScalarType = 'uint8' | 'uint16' | 'uint32' | 'uint64';
+
+function isUnsignedScalarType(type: StructFieldType): type is UnsignedScalarType {
+    return type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64';
+}
+
+function isBitField(field: StructField): boolean {
+    return field.type !== 'struct' && typeof field.bitWidth === 'number';
+}
+
+function isBitFieldContainer(field: StructField): boolean {
+    return Array.isArray(field.bitFields) && field.bitFields.length > 0 &&
+        isUnsignedScalarType(field.type);
+}
+
+/** Migrate a legacy bitWidth field to the new bitFields container model. */
+export function migrateFieldToBitFields(field: StructField): StructField {
+    if (!isBitField(field) || isBitFieldContainer(field)) { return field; }
+    const { bitWidth, ...rest } = field;
+    return { ...rest, bitFields: [{ name: field.name, bitWidth: bitWidth! }] };
+}
+
+/** Migrate all legacy bitWidth fields in a StructDef to bitFields containers. */
+export function migrateStructDefBitFields(def: StructDef): StructDef {
+    return { ...def, fields: def.fields.map(migrateFieldToBitFields) };
+}
+
+function bitMask(width: number): bigint {
+    return (1n << BigInt(width)) - 1n;
+}
+
+function bytesToBigUint(raw: number[], endian: 'le' | 'be'): bigint {
+    if (endian === 'le') {
+        let v = 0n;
+        for (let i = 0; i < raw.length; i++) {
+            v |= BigInt(raw[i]) << BigInt(i * 8);
+        }
+        return v;
+    }
+    let v = 0n;
+    for (const b of raw) {
+        v = (v << 8n) | BigInt(b);
+    }
+    return v;
+}
 
 export function fieldByteSize(type: StructScalarFieldType): number {
     switch (type) {
@@ -97,19 +155,69 @@ function structAlignmentWithDefs(def: StructDef, map: Map<string, StructDef>, de
 }
 
 function structByteSizeWithDefs(def: StructDef, map: Map<string, StructDef>, depth: number): number {
-    if (def.packed) {
-        return def.fields.reduce((s, f) => s + fieldSizeWithDefs(f, map, depth) * f.count, 0);
-    }
-
     let offset = 0;
     let maxAlign = 1;
+    let bitUnitStart = -1;
+    let bitUnitBytes = 0;
+    let bitUnitType: StructScalarFieldType | null = null;
+    let bitUsed = 0;
+
+    const flushBitUnit = () => {
+        if (bitUnitStart < 0) { return; }
+        offset = bitUnitStart + bitUnitBytes;
+        bitUnitStart = -1;
+        bitUnitBytes = 0;
+        bitUnitType = null;
+        bitUsed = 0;
+    };
+
     for (const f of def.fields) {
+            if (isBitField(f) && f.type !== 'struct' && isIntScalarType(f.type)) {
+            const width = f.bitWidth ?? 0;
+            const unitBytes = fieldByteSize(f.type);
+            const unitBits = unitBytes * 8;
+            const align = def.packed ? 1 : fieldAlignWithDefs(f, map, depth);
+
+            if (align > maxAlign) { maxAlign = align; }
+
+            const compatibleUnit =
+                bitUnitStart >= 0 &&
+                bitUnitType === f.type &&
+                bitUnitBytes === unitBytes;
+
+            if (!compatibleUnit) {
+                flushBitUnit();
+                offset = alignUp(offset, align);
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = f.type;
+                bitUsed = 0;
+            }
+
+            if (bitUsed + width > unitBits) {
+                // Invalid bit-field layout; keep deterministic sizing by starting a fresh unit.
+                flushBitUnit();
+                offset = alignUp(offset, align);
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = f.type;
+                bitUsed = 0;
+            }
+
+            bitUsed += width;
+            continue;
+        }
+
+        flushBitUnit();
         const sz = fieldSizeWithDefs(f, map, depth);
-        const align = fieldAlignWithDefs(f, map, depth);
+        const align = def.packed ? 1 : fieldAlignWithDefs(f, map, depth);
         if (align > maxAlign) { maxAlign = align; }
         offset = alignUp(offset, align);
         offset += sz * f.count;
     }
+
+    flushBitUnit();
+    if (def.packed) { return offset; }
     return alignUp(offset, maxAlign);
 }
 
@@ -130,13 +238,86 @@ export function validateStructs(defs: StructDef[], maxDepth = MAX_NESTED_DEPTH):
 
     for (const d of defs) {
         for (const f of d.fields) {
-            if (f.type !== 'struct') { continue; }
-            if (!f.refStructId) {
-                errors.push(`Struct "${d.name}": field "${f.name}" is missing a referenced struct.`);
+            if (f.type === 'struct') {
+                if (!f.refStructId) {
+                    errors.push(`Struct "${d.name}": field "${f.name}" is missing a referenced struct.`);
+                    continue;
+                }
+                if (!byId.has(f.refStructId)) {
+                    errors.push(`Struct "${d.name}": field "${f.name}" references an unknown struct.`);
+                }
+            }
+
+            // ── New bitFields container validation ──────────────────────────────
+            if (isBitFieldContainer(f)) {
+                if (!isUnsignedScalarType(f.type)) {
+                    errors.push(`Struct "${d.name}": field "${f.name}" bit-field container must be an unsigned type.`);
+                    continue;
+                }
+                const unitBits = fieldByteSize(f.type as UnsignedScalarType) * 8;
+                let totalBits = 0;
+                for (const child of f.bitFields!) {
+                    if (!Number.isInteger(child.bitWidth) || child.bitWidth <= 0) {
+                        errors.push(`Struct "${d.name}": field "${f.name}" child "${child.name}" bit width must be > 0.`);
+                    } else {
+                        totalBits += child.bitWidth;
+                    }
+                }
+                if (totalBits > unitBits) {
+                    errors.push(`Struct "${d.name}": field "${f.name}" children total ${totalBits} bits exceeds ${unitBits}-bit container.`);
+                }
                 continue;
             }
-            if (!byId.has(f.refStructId)) {
-                errors.push(`Struct "${d.name}": field "${f.name}" references an unknown struct.`);
+
+            if (!isBitField(f)) { continue; }
+
+            if (f.type === 'struct') {
+                errors.push(`Struct "${d.name}": field "${f.name}" cannot be a bit-field.`);
+                continue;
+            }
+            if (!isIntScalarType(f.type)) {
+                errors.push(`Struct "${d.name}": field "${f.name}" uses unsupported bit-field base type "${f.type}".`);
+                continue;
+            }
+
+            const width = f.bitWidth ?? 0;
+            const maxBits = fieldByteSize(f.type) * 8;
+            if (!Number.isInteger(width) || width <= 0) {
+                errors.push(`Struct "${d.name}": field "${f.name}" bit width must be > 0.`);
+            }
+            if (width > maxBits) {
+                errors.push(`Struct "${d.name}": field "${f.name}" bit width exceeds ${maxBits} bits.`);
+            }
+            if (f.count !== 1) {
+                errors.push(`Struct "${d.name}": field "${f.name}" bit-fields cannot be arrays.`);
+            }
+            if (f.endian !== 'inherit') {
+                errors.push(`Struct "${d.name}": field "${f.name}" bit-fields must inherit global endian.`);
+            }
+        }
+
+        let bitUnitType: StructScalarFieldType | null = null;
+        let bitUnitUsed = 0;
+        let bitUnitBits = 0;
+        for (const f of d.fields) {
+            if (isBitField(f) && f.type !== 'struct' && isIntScalarType(f.type)) {
+                const width = f.bitWidth ?? 0;
+                const unitBits = fieldByteSize(f.type) * 8;
+                const compatibleUnit = bitUnitType === f.type;
+                if (!compatibleUnit) {
+                    bitUnitType = f.type;
+                    bitUnitUsed = 0;
+                    bitUnitBits = unitBits;
+                }
+                if (bitUnitUsed + width > bitUnitBits) {
+                    errors.push(`Struct "${d.name}": field "${f.name}" crosses a ${bitUnitBits}-bit storage unit boundary.`);
+                } else {
+                    bitUnitUsed += width;
+                }
+            } else {
+                bitUnitType = null;
+                bitUnitUsed = 0;
+                bitUnitBits = 0;
             }
         }
     }
@@ -178,6 +359,12 @@ export interface DecodedField {
     bytesHex: string;
     decoded: string;
     hasData: boolean;
+    isBitField?: boolean;
+    bitWidth?: number;
+    /** Bit offset within the storage unit in declaration order. */
+    bitOffset?: number;
+    bitStorageByteSize?: number;
+    bitValueUnsigned?: string;
 }
 
 export interface ResolvedStructFieldPath {
@@ -296,11 +483,161 @@ function decodeStructRecursive(
     baseOffset: number,
 ): number {
     let offset = 0;
+    let bitUnitStart = -1;
+    let bitUnitBytes = 0;
+    let bitUnitType: StructScalarFieldType | null = null;
+    let bitUsed = 0;
+
+    const flushBitUnit = () => {
+        if (bitUnitStart < 0) { return; }
+        offset = bitUnitStart + bitUnitBytes;
+        bitUnitStart = -1;
+        bitUnitBytes = 0;
+        bitUnitType = null;
+        bitUsed = 0;
+    };
 
     for (const field of def.fields) {
         const align = def.packed ? 1 : fieldAlignWithDefs(field, map, depth);
         const elemSize = fieldSizeWithDefs(field, map, depth);
         const endian = field.endian === 'inherit' ? globalEndian : field.endian;
+
+        // ── New: named BitField container (uint8/16/32/64 with bitFields[]) ──────
+        if (isBitFieldContainer(field)) {
+            flushBitUnit();
+            const unitBytes = fieldByteSize(field.type as UnsignedScalarType);
+            const unitBits = unitBytes * 8;
+            offset = alignUp(offset, align);
+
+            for (let idx = 0; idx < field.count; idx++) {
+                const elementName = field.count > 1 ? `${field.name}[${idx}]` : field.name;
+                const fieldPath = pathPrefix ? `${pathPrefix}.${elementName}` : elementName;
+                const absOffset = baseOffset + offset + idx * unitBytes;
+
+                const raw: number[] = [];
+                for (let b = 0; b < unitBytes; b++) {
+                    const v = getByte(baseAddr + absOffset + b);
+                    raw.push(v !== undefined ? v : -1);
+                }
+                const hasData = raw.every(v => v >= 0);
+                const bytesHex = raw
+                    .map(v => (v >= 0 ? v.toString(16).toUpperCase().padStart(2, '0') : '??'))
+                    .join(' ');
+                const unitValue = hasData ? bytesToBigUint(raw.filter(v => v >= 0), endian) : 0n;
+
+                let bitPos = 0;
+                for (const child of field.bitFields!) {
+                    const w = child.bitWidth;
+                    if (w <= 0) { bitPos += w; continue; }
+                    const childName = child.name || `bit${bitPos}`;
+                    const childPath = `${fieldPath}.${childName}`;
+
+                    const shift = endian === 'le'
+                        ? bitPos
+                        : unitBits - bitPos - w;
+                    const unsignedValue = hasData ? (unitValue >> BigInt(shift)) & bitMask(w) : 0n;
+                    const hexDigits = Math.max(1, Math.ceil(w / 4));
+                    const decoded = hasData
+                        ? `${unsignedValue.toString(10)}  (0x${unsignedValue.toString(16).toUpperCase().padStart(hexDigits, '0')})`
+                        : '??';
+
+                    rows.push({
+                        fieldName: childPath,
+                        type: field.type as UnsignedScalarType,
+                        arrayIdx: idx,
+                        byteOffset: absOffset,
+                        bytesHex,
+                        decoded,
+                        hasData,
+                        isBitField: true,
+                        bitWidth: w,
+                        bitOffset: bitPos,
+                        bitStorageByteSize: unitBytes,
+                        bitValueUnsigned: hasData ? unsignedValue.toString(10) : undefined,
+                    });
+
+                    bitPos += w;
+                }
+            }
+
+            offset += unitBytes * field.count;
+            continue;
+        }
+
+        if (isBitField(field) && field.type !== 'struct' && isIntScalarType(field.type)) {
+            const width = field.bitWidth ?? 0;
+            const unitBytes = fieldByteSize(field.type);
+            const unitBits = unitBytes * 8;
+            const compatibleUnit =
+                bitUnitStart >= 0 &&
+                bitUnitType === field.type &&
+                bitUnitBytes === unitBytes;
+
+            if (!compatibleUnit) {
+                flushBitUnit();
+                offset = alignUp(offset, align);
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = field.type;
+                bitUsed = 0;
+            }
+
+            if (bitUsed + width > unitBits) {
+                flushBitUnit();
+                offset = alignUp(offset, align);
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = field.type;
+                bitUsed = 0;
+            }
+
+            const absOffset = baseOffset + bitUnitStart;
+            const marker = `@bf_${absOffset.toString(16).toUpperCase().padStart(4, '0')}`;
+            const fieldPath = pathPrefix ? `${pathPrefix}.${marker}.${field.name}` : `${marker}.${field.name}`;
+            const raw: number[] = [];
+            for (let b = 0; b < unitBytes; b++) {
+                const v = getByte(baseAddr + absOffset + b);
+                raw.push(v !== undefined ? v : -1);
+            }
+            const hasData = raw.every(v => v >= 0);
+            const bytesHex = raw
+                .map(v => (v >= 0 ? v.toString(16).toUpperCase().padStart(2, '0') : '??'))
+                .join(' ');
+
+            const bitOffset = bitUsed;
+            let unsignedValue = 0n;
+            if (hasData && width > 0) {
+                const unitValue = bytesToBigUint(raw.filter(v => v >= 0), endian);
+                const shift = endian === 'le'
+                    ? bitOffset
+                    : unitBits - bitOffset - width;
+                unsignedValue = (unitValue >> BigInt(shift)) & bitMask(width);
+            }
+            const hexDigits = Math.max(1, Math.ceil(width / 4));
+            const decoded = hasData
+                ? `${unsignedValue.toString(10)}  (0x${unsignedValue.toString(16).toUpperCase().padStart(hexDigits, '0')})`
+                : '??';
+
+            rows.push({
+                fieldName: fieldPath,
+                type: field.type,
+                arrayIdx: 0,
+                byteOffset: absOffset,
+                bytesHex,
+                decoded,
+                hasData,
+                isBitField: true,
+                bitWidth: width,
+                bitOffset,
+                bitStorageByteSize: unitBytes,
+                bitValueUnsigned: hasData ? unsignedValue.toString(10) : undefined,
+            });
+
+            bitUsed += width;
+            continue;
+        }
+
+        flushBitUnit();
         offset = alignUp(offset, align);
 
         if (field.type === 'ascii') {
@@ -388,6 +725,8 @@ function decodeStructRecursive(
             offset += elemSize;
         }
     }
+
+    flushBitUnit();
 
     if (!def.packed) {
         const structAlign = structAlignmentWithDefs(def, map, depth);
@@ -513,7 +852,7 @@ export function parseStructText(text: string): ParseStructTextResult {
         }
 
         const unqual = stripped.replace(/^(?:(?:const|volatile|static|register)\s+)+/, '');
-        const m = unqual.match(/^((?:unsigned|signed)\s+\w+|\w+)\s+(\w+)\s*(?:\[(\d+)\])?$/);
+        const m = unqual.match(/^((?:unsigned|signed)\s+\w+|\w+)\s+(\w+)\s*(?::\s*(\d+))?\s*(?:\[(\d+)\])?$/);
         if (!m) {
             if (unqual) { errors.push(`Cannot parse: "${stripped}"`); }
             continue;
@@ -521,7 +860,8 @@ export function parseStructText(text: string): ParseStructTextResult {
 
         const rawType = m[1].replace(/\s+/g, ' ');
         const fieldName = m[2];
-        const count = m[3] ? Math.max(1, parseInt(m[3], 10)) : 1;
+        const bitWidth = m[3] ? parseInt(m[3], 10) : null;
+        const count = m[4] ? Math.max(1, parseInt(m[4], 10)) : 1;
 
         const mapped = C_TYPE_MAP[rawType] ?? C_TYPE_MAP[rawType.toLowerCase()];
         if (!mapped) {
@@ -529,11 +869,35 @@ export function parseStructText(text: string): ParseStructTextResult {
             continue;
         }
 
-        let endian: StructFieldEndian = 'inherit';
-        if (/\bbe\b/i.test(comment)) { endian = 'be'; }
-        else if (/\ble\b/i.test(comment)) { endian = 'le'; }
+        if (bitWidth !== null) {
+            if (!isIntScalarType(mapped)) {
+                errors.push(`Bit-field "${fieldName}" must use an int/uint base type.`);
+                continue;
+            }
+            if (!Number.isInteger(bitWidth) || bitWidth <= 0) {
+                errors.push(`Bit-field "${fieldName}" has invalid width "${bitWidth}".`);
+                continue;
+            }
+            const maxBits = fieldByteSize(mapped) * 8;
+            if (bitWidth > maxBits) {
+                errors.push(`Bit-field "${fieldName}" width ${bitWidth} exceeds ${maxBits}.`);
+                continue;
+            }
+            if (count !== 1) {
+                errors.push(`Bit-field "${fieldName}" cannot be declared as an array.`);
+                continue;
+            }
+        }
 
-        fields.push({ name: fieldName, type: mapped, count, endian });
+        let endian: StructFieldEndian = 'inherit';
+        if (bitWidth === null) {
+            if (/\bbe\b/i.test(comment)) { endian = 'be'; }
+            else if (/\ble\b/i.test(comment)) { endian = 'le'; }
+        }
+
+        const field: StructField = { name: fieldName, type: mapped, count, endian };
+        if (bitWidth !== null) { field.bitWidth = bitWidth; }
+        fields.push(field);
     }
 
     return { structName, fields, errors };
@@ -547,10 +911,17 @@ export function fieldsToText(fields: StructField[], defs: StructDef[] = allStruc
     const maxTypeLen = Math.max(...typeNames.map(t => t.length));
 
     return fields.map((f, i) => {
+        // BitFields container: emit each child as a flat C bit declaration
+        if (isBitFieldContainer(f)) {
+            const cType = fieldTypeToC(f, byId).padEnd(maxTypeLen);
+            const arr = f.count > 1 ? `[${f.count}]` : '';
+            return f.bitFields!.map(child => `${cType} ${child.name}${arr}:${child.bitWidth};`).join('\n');
+        }
         const cType = typeNames[i].padEnd(maxTypeLen);
-        const arr = f.count > 1 ? `[${f.count}]` : '';
+        const bit = isBitField(f) ? `:${f.bitWidth}` : '';
+        const arr = !isBitField(f) && f.count > 1 ? `[${f.count}]` : '';
         const hint = f.endian !== 'inherit' ? `  // ${f.endian}` : '';
-        return `${cType} ${f.name}${arr};${hint}`;
+        return `${cType} ${f.name}${bit}${arr};${hint}`;
     }).join('\n');
 }
 
@@ -568,8 +939,115 @@ export function structToC(def: StructDef, defs: StructDef[] = allStructs()): str
 
     let offset = 0;
     let maxAlign = 1;
+    let bitUnitStart = -1;
+    let bitUnitBytes = 0;
+    let bitUnitType: StructScalarFieldType | null = null;
+    let bitUsed = 0;
+
+    const flushBitUnit = () => {
+        if (bitUnitStart < 0) { return; }
+        offset = bitUnitStart + bitUnitBytes;
+        bitUnitStart = -1;
+        bitUnitBytes = 0;
+        bitUnitType = null;
+        bitUsed = 0;
+    };
 
     def.fields.forEach((f, fi) => {
+        // ── New: BitField container ────────────────────────────────────────────
+        if (isBitFieldContainer(f)) {
+            flushBitUnit();
+            const unitBytes = fieldByteSize(f.type as UnsignedScalarType);
+            const unitBits = unitBytes * 8;
+            const align = def.packed ? 1 : fieldAlignWithDefs(f, byId, 1);
+            if (align > maxAlign) { maxAlign = align; }
+            const aligned = alignUp(offset, align);
+            if (!def.packed && aligned > offset) {
+                const padBytes = aligned - offset;
+                lines.push(
+                    `    uint8_t  _pad${offset}[${padBytes}];`.padEnd(44) +
+                    `/* +${offset.toString().padStart(3)}  ${padBytes}B padding */`
+                );
+            }
+            offset = aligned;
+            const cType = fieldTypeToC(f, byId);
+            const arr = f.count > 1 ? `[${f.count}]` : '';
+            const fieldName = f.name || 'bitfield';
+
+            // Generate nested struct for bit-field container
+            lines.push(`    struct {`);
+            let childBitPos = 0;
+            for (const child of f.bitFields!) {
+                const w = child.bitWidth;
+                const childName = child.name || `bit${childBitPos}`;
+                lines.push(
+                    `        ${cType} ${childName}:${w};`.padEnd(44) +
+                    `/* ${childBitPos.toString().padStart(2)}..${(childBitPos + w - 1).toString().padStart(2)} */`
+                );
+                childBitPos += w;
+            }
+            lines.push(`    } ${fieldName}${arr};`);
+            offset += unitBytes * f.count;
+            return;
+        }
+
+        if (isBitField(f) && f.type !== 'struct' && isIntScalarType(f.type)) {
+            const width = f.bitWidth ?? 0;
+            const unitBytes = fieldByteSize(f.type);
+            const unitBits = unitBytes * 8;
+            const align = def.packed ? 1 : fieldAlignWithDefs(f, byId, 1);
+            if (align > maxAlign) { maxAlign = align; }
+
+            const compatibleUnit =
+                bitUnitStart >= 0 &&
+                bitUnitType === f.type &&
+                bitUnitBytes === unitBytes;
+            if (!compatibleUnit) {
+                flushBitUnit();
+                const aligned = alignUp(offset, align);
+                if (!def.packed && aligned > offset) {
+                    const padBytes = aligned - offset;
+                    lines.push(
+                        `    uint8_t  _pad${offset}[${padBytes}];`.padEnd(44) +
+                        `/* +${offset.toString().padStart(3)}  ${padBytes}B padding */`
+                    );
+                }
+                offset = aligned;
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = f.type;
+                bitUsed = 0;
+            }
+
+            if (bitUsed + width > unitBits) {
+                flushBitUnit();
+                const aligned = alignUp(offset, align);
+                if (!def.packed && aligned > offset) {
+                    const padBytes = aligned - offset;
+                    lines.push(
+                        `    uint8_t  _pad${offset}[${padBytes}];`.padEnd(44) +
+                        `/* +${offset.toString().padStart(3)}  ${padBytes}B padding */`
+                    );
+                }
+                offset = aligned;
+                bitUnitStart = offset;
+                bitUnitBytes = unitBytes;
+                bitUnitType = f.type;
+                bitUsed = 0;
+            }
+
+            const cType = fieldTypeToC(f, byId).padEnd(maxTypeLen);
+            const displayFieldName = f.name || `field${fi}`;
+            const startBit = bitUsed;
+            lines.push(
+                `    ${cType} ${displayFieldName}:${width};`.padEnd(44) +
+                `/* +${offset.toString().padStart(3)}:${startBit.toString().padStart(2)}  ${unitBits}b unit */`
+            );
+            bitUsed += width;
+            return;
+        }
+
+        flushBitUnit();
         const sz = fieldSizeWithDefs(f, byId, 1);
         const align = def.packed ? 1 : fieldAlignWithDefs(f, byId, 1);
         if (align > maxAlign) { maxAlign = align; }
@@ -597,6 +1075,8 @@ export function structToC(def: StructDef, defs: StructDef[] = allStructs()): str
 
         offset += fieldBytes;
     });
+
+    flushBitUnit();
 
     const totalUnpadded = offset;
     const totalPadded = alignUp(offset, maxAlign);

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -12,7 +12,7 @@ import type {
     StructScalarFieldType,
 } from './types';
 
-export type { BitFieldChild, StructDef, StructField, StructFieldType, StructFieldEndian };
+export type { StructDef, StructField, StructFieldType, StructFieldEndian };
 
 export const MAX_NESTED_DEPTH = 32;
 
@@ -53,7 +53,7 @@ function isBitFieldContainer(field: StructField): boolean {
 }
 
 /** Migrate a legacy bitWidth field to the new bitFields container model. */
-export function migrateFieldToBitFields(field: StructField): StructField {
+function migrateFieldToBitFields(field: StructField): StructField {
     if (!isBitField(field) || isBitFieldContainer(field)) { return field; }
     const { bitWidth, ...rest } = field;
     return { ...rest, bitFields: [{ name: field.name, bitWidth: bitWidth! }] };
@@ -354,6 +354,8 @@ export function validateStructs(defs: StructDef[], maxDepth = MAX_NESTED_DEPTH):
 export interface DecodedField {
     fieldName: string;
     type: StructScalarFieldType;
+    /** Effective byte endianness used to decode this row. */
+    endian: 'le' | 'be';
     /** Index within the array (0 for scalars). */
     arrayIdx: number;
     byteOffset: number;
@@ -551,6 +553,7 @@ function decodeStructRecursive(
                         bytesHex,
                         decoded,
                         hasData,
+                        endian,
                         isBitField: true,
                         bitWidth: w,
                         bitOffset: bitPos,
@@ -628,6 +631,7 @@ function decodeStructRecursive(
                 bytesHex,
                 decoded,
                 hasData,
+                endian,
                 isBitField: true,
                 bitWidth: width,
                 bitOffset,
@@ -674,6 +678,7 @@ function decodeStructRecursive(
                 bytesHex,
                 decoded,
                 hasData,
+                endian,
             });
             offset += totalBytes;
             continue;
@@ -691,7 +696,7 @@ function decodeStructRecursive(
                         child,
                         baseAddr,
                         getByte,
-                        globalEndian,
+                        endian,
                         bitFieldAllocation,
                         map,
                         rows,
@@ -723,6 +728,7 @@ function decodeStructRecursive(
                 bytesHex,
                 decoded,
                 hasData,
+                endian,
             });
 
             offset += elemSize;

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -3,6 +3,7 @@
 
 import { S } from './state';
 import type {
+    BitFieldAllocation,
     BitFieldChild,
     StructDef,
     StructField,
@@ -292,7 +293,7 @@ export function validateStructs(defs: StructDef[], maxDepth = MAX_NESTED_DEPTH):
                 errors.push(`Struct "${d.name}": field "${f.name}" bit-fields cannot be arrays.`);
             }
             if (f.endian !== 'inherit') {
-                errors.push(`Struct "${d.name}": field "${f.name}" bit-fields must inherit global endian.`);
+                errors.push(`Struct "${d.name}": field "${f.name}" bit-fields must inherit global byte endianness.`);
             }
         }
 
@@ -476,6 +477,7 @@ function decodeStructRecursive(
     baseAddr: number,
     getByte: (addr: number) => number | undefined,
     globalEndian: 'le' | 'be',
+    bitFieldAllocation: BitFieldAllocation,
     map: Map<string, StructDef>,
     rows: DecodedField[],
     depth: number,
@@ -532,7 +534,7 @@ function decodeStructRecursive(
                     const childName = child.name || `bit${bitPos}`;
                     const childPath = `${fieldPath}.${childName}`;
 
-                    const shift = endian === 'le'
+                    const shift = bitFieldAllocation === 'lsb'
                         ? bitPos
                         : unitBits - bitPos - w;
                     const unsignedValue = hasData ? (unitValue >> BigInt(shift)) & bitMask(w) : 0n;
@@ -608,7 +610,7 @@ function decodeStructRecursive(
             let unsignedValue = 0n;
             if (hasData && width > 0) {
                 const unitValue = bytesToBigUint(raw.filter(v => v >= 0), endian);
-                const shift = endian === 'le'
+                const shift = bitFieldAllocation === 'lsb'
                     ? bitOffset
                     : unitBits - bitOffset - width;
                 unsignedValue = (unitValue >> BigInt(shift)) & bitMask(width);
@@ -690,6 +692,7 @@ function decodeStructRecursive(
                         baseAddr,
                         getByte,
                         globalEndian,
+                        bitFieldAllocation,
                         map,
                         rows,
                         depth + 1,
@@ -741,10 +744,11 @@ export function decodeStruct(
     baseAddr: number,
     getByte: (addr: number) => number | undefined,
     globalEndian: 'le' | 'be',
+    bitFieldAllocation: BitFieldAllocation = 'msb',
 ): DecodedField[] {
     const rows: DecodedField[] = [];
     const map = defsMap(def);
-    decodeStructRecursive(def, baseAddr, getByte, globalEndian, map, rows, 1, '', 0);
+    decodeStructRecursive(def, baseAddr, getByte, globalEndian, bitFieldAllocation, map, rows, 1, '', 0);
     return rows;
 }
 

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -128,18 +128,6 @@
 }
 .sfe-type-sel:focus { border-color: var(--focus-bdr); }
 
-.sfe-bit-inp {
-    width: 100%; text-align: center;
-    background: rgba(0,0,0,.25); border: 1px solid var(--border);
-    border-radius: 2px; color: var(--fg); font-family: var(--font-editor);
-    font-size: 10px; padding: 1px 2px; outline: none; box-sizing: border-box;
-    appearance: textfield;
-}
-.sfe-bit-inp::-webkit-outer-spin-button,
-.sfe-bit-inp::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-.sfe-bit-inp:focus { border-color: var(--focus-bdr); }
-.sfe-bit-inp:disabled { opacity: .45; }
-
 /* Array cell */
 .sfe-arr-cell {
     display: flex; align-items: center; gap: 2px; width: 100%;

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -98,7 +98,7 @@
 /* Field header + rows */
 .se-field-hdr {
     display: grid;
-    grid-template-columns: 64px 1fr 72px 30px 18px;
+    grid-template-columns: 64px 1fr 40px 72px 30px 18px;
     gap: 3px; align-items: center;
     font-size: 9px; font-weight: 700; text-transform: uppercase;
     letter-spacing: .04em; color: var(--addr-fg); font-family: var(--font-ui);
@@ -108,7 +108,7 @@
 
 .struct-field-row {
     display: grid;
-    grid-template-columns: 64px 1fr 72px 30px 18px;
+    grid-template-columns: 64px 1fr 40px 72px 30px 18px;
     gap: 3px; align-items: center; padding: 1px 0;
 }
 
@@ -127,6 +127,18 @@
     box-sizing: border-box;
 }
 .sfe-type-sel:focus { border-color: var(--focus-bdr); }
+
+.sfe-bit-inp {
+    width: 100%; text-align: center;
+    background: rgba(0,0,0,.25); border: 1px solid var(--border);
+    border-radius: 2px; color: var(--fg); font-family: var(--font-editor);
+    font-size: 10px; padding: 1px 2px; outline: none; box-sizing: border-box;
+    appearance: textfield;
+}
+.sfe-bit-inp::-webkit-outer-spin-button,
+.sfe-bit-inp::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.sfe-bit-inp:focus { border-color: var(--focus-bdr); }
+.sfe-bit-inp:disabled { opacity: .45; }
 
 /* Array cell */
 .sfe-arr-cell {
@@ -162,6 +174,80 @@
 }
 .sfe-del-btn:hover { color: var(--err); }
 .sfe-del-placeholder { display: block; width: 18px; }
+
+/* ── Bit-field toggle button (:N) ─────────────────────────────── */
+.sfe-bit-btn {
+    width: 28px; flex-shrink: 0; text-align: center;
+    background: transparent; border: 1px dashed var(--border);
+    border-radius: 2px; color: var(--addr-fg); font-family: var(--font-editor);
+    font-size: 9px; cursor: pointer; padding: 1px 1px; line-height: 1.4;
+    white-space: nowrap; transition: border-color .1s, color .1s, background .1s;
+}
+.sfe-bit-btn:hover:not(:disabled)        { border-color: var(--high-color); color: var(--high-color); }
+.sfe-bit-btn.sfe-bit-btn-on              { border-style: solid; border-color: var(--high-color);
+                                            color: var(--high-color); background: rgba(79,195,247,.1); }
+.sfe-bit-btn.sfe-bit-btn-on:hover        { border-color: var(--err); color: var(--err);
+                                            background: rgba(255,80,80,.08); }
+.sfe-bit-btn:disabled                    { opacity: .35; cursor: not-allowed; }
+
+/* ── Bit-field children container ─────────────────────────────── */
+.sfe-bf-children {
+    grid-column: 1 / -1;
+    display: flex; flex-direction: column; gap: 2px;
+    padding: 3px 0 0 0; margin: 0;
+    border-top: 1px solid rgba(255,255,255,.06);
+    background: rgba(0,0,0,.1);
+}
+.struct-field-row.has-bit-children {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+.sfe-bf-child-row {
+    display: flex; align-items: center; gap: 3px;
+    padding: 1px 4px 1px 8px;
+}
+.sfe-bf-child-indent {
+    flex-shrink: 0; width: 8px;
+}
+.sfe-bf-child-name {
+    flex: 1; min-width: 0;
+    background: rgba(0,0,0,.25); border: 1px solid var(--border);
+    border-radius: 2px; color: var(--fg); font-family: var(--font-editor);
+    font-size: 10px; padding: 1px 4px; outline: none; width: 60px;
+    box-sizing: border-box;
+}
+.sfe-bf-child-name:focus { border-color: var(--focus-bdr); }
+.sfe-bf-child-width {
+    width: 32px; text-align: center;
+    background: rgba(0,0,0,.25); border: 1px solid var(--border);
+    border-radius: 2px; color: var(--fg); font-family: var(--font-editor);
+    font-size: 10px; padding: 1px 2px; outline: none; box-sizing: border-box;
+    appearance: textfield;
+}
+.sfe-bf-child-width::-webkit-outer-spin-button,
+.sfe-bf-child-width::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.sfe-bf-child-width:focus { border-color: var(--focus-bdr); }
+.sfe-bf-child-unit {
+    flex-shrink: 0;
+    font-size: 9px; color: var(--addr-fg); font-family: var(--font-editor);
+    -webkit-user-select: none; user-select: none;
+}
+.sfe-bf-child-move {
+    display: flex; align-items: center; gap: 1px;
+}
+.sfe-bf-del-child {
+    background: transparent; border: none; color: var(--addr-fg);
+    font-size: 10px; cursor: pointer; padding: 0; line-height: 1; text-align: center;
+}
+.sfe-bf-del-child:hover { color: var(--err); }
+.sfe-bf-add-child {
+    background: transparent; border: 1px dashed var(--border);
+    border-radius: 2px; color: var(--addr-fg); font-size: 9px;
+    font-family: var(--font-ui); padding: 2px 6px; cursor: pointer;
+    transition: border-color .1s, color .1s; text-align: center;
+    margin: 2px 4px;
+}
+.sfe-bf-add-child:hover { border-color: var(--high-color); color: var(--high-color); }
 
 .sfe-move-btns {
     display: flex; flex-direction: row; align-items: center; justify-content: center; gap: 1px;
@@ -518,6 +604,17 @@
 .si-bit { font-family: var(--font-editor); display: inline-block; letter-spacing: 0; padding: 0 .25ch; }
 .si-bit.one  { color: var(--fg); font-weight: 700; }
 .si-bit.zero { color: var(--fg); opacity: .70; }
+.si-bit.unknown { color: var(--addr-fg); opacity: .75; }
+.si-bit.sel {
+    background: rgba(79,195,247,.22);
+    border-bottom: 1px solid rgba(79,195,247,.85);
+    border-radius: 2px;
+}
+.si-bit.hov {
+    background: rgba(79,195,247,.12);
+    border-bottom: 1px dashed rgba(79,195,247,.55);
+    border-radius: 2px;
+}
 .si-bin-wrap { display: inline-block; max-width: 100%; white-space: normal; }
 .si-bin-wrap br { display: block; line-height: 1.1; }
 .si-f-ptr { color: #e8a020 !important; font-style: italic; }

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -292,12 +292,24 @@
     padding-left: 1px; /* prevent border clipping on slide edge */
 }
 
-/* Header row: title + badge + ⚙ Types + LE/BE tabs + ＋ Add */
+/* Header row: title + badge + toggles + ＋ Add + ⚙ Types */
 .si-hdr-row {
     display: flex; align-items: center; gap: 6px;
     margin-bottom: 6px;
 }
 .si-hdr-row .sb-hdr { flex: 1; margin-bottom: 0; }
+.si-toggle-group {
+    display: flex; flex-direction: column; align-items: center; gap: 1px;
+    flex-shrink: 0;
+}
+.si-toggle-label {
+    color: var(--addr-fg);
+    font-family: var(--font-ui);
+    font-size: 8px;
+    line-height: 1;
+    white-space: nowrap;
+}
+.si-toggle-group .endian-tabs button { font-size: 9px; padding: 1px 5px; }
 
 .si-add-btn {
     flex-shrink: 0;
@@ -341,7 +353,8 @@
 
 .sa-row { display: flex; align-items: center; gap: 4px; }
 .sa-btn-row { gap: 6px; }
-.sa-endian-tabs { flex-shrink: 0; }
+.sa-endian-tabs,
+.sa-bit-order-tabs { flex-shrink: 0; }
 
 /* Inline instance-edit form inside a card */
 .si-pin-edit-form {
@@ -594,15 +607,17 @@
 .si-bit.zero { color: var(--fg); opacity: .70; }
 .si-bit.unknown { color: var(--addr-fg); opacity: .75; }
 .si-bit.sel {
-    background: rgba(79,195,247,.22);
-    border-bottom: 1px solid rgba(79,195,247,.85);
+    background: var(--sel-bg);
+    color: var(--sel-fg, var(--fg));
     border-radius: 2px;
+    opacity: 1;
 }
 .si-bit.hov {
     background: rgba(79,195,247,.12);
     border-bottom: 1px dashed rgba(79,195,247,.55);
     border-radius: 2px;
 }
+.si-bit.sel.hov { border-bottom: 0; }
 .si-bin-wrap { display: inline-block; max-width: 100%; white-space: normal; }
 .si-bin-wrap br { display: block; line-height: 1.1; }
 .si-f-ptr { color: #e8a020 !important; font-style: italic; }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1354,12 +1354,16 @@ function leafName(fieldPath: string): string {
     return parts.length > 0 ? parts[parts.length - 1] : fieldPath;
 }
 
+function displayFieldName(fieldPath: string): string {
+    return leafName(fieldPath).replace(/\[\d+\]$/, '');
+}
+
 function isBitUnitGroup(rows: DecodedField[]): boolean {
     return rows.length > 0 && rows.every(r => isBitFieldRow(r));
 }
 
-function groupHeaderName(baseName: string, rows: DecodedField[]): string {
-    return leafName(baseName);
+function groupHeaderName(baseName: string): string {
+    return displayFieldName(baseName);
 }
 
 function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
@@ -1409,7 +1413,7 @@ function bitUnitHeaderHtml(
     kind: 'group' | 'element' = 'group',
 ): string {
     const agg = buildBitUnitAggregateRow(rows);
-    const headerName = headerNameOverride ?? groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''), rows);
+    const headerName = headerNameOverride ?? groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''));
     const headerClass = kind === 'element' ? 'si-arr-el-hdr' : 'si-arr-grp-hdr';
     const buttonClass = kind === 'element' ? 'si-arr-el-exp-btn' : 'si-arr-exp-btn';
     if (!agg) {
@@ -1495,6 +1499,10 @@ function arrayGroupBaseName(fieldPath: string): string {
     return fieldPath.slice(0, first.index);
 }
 
+function bitUnitArrayBaseName(fieldPath: string): string {
+    return fieldPath.replace(/\[\d+\]$/, '');
+}
+
 function buildInstanceCard(pin: StructPin, i: number): string {
     const def        = allStructs().find(d => d.id === pin.structId);
     const defName    = def ? def.name : '?';
@@ -1522,10 +1530,11 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             baseName: string,
             parentKey: string,
         ): string => {
+            const arrayBase = bitUnitArrayBaseName(baseName);
             type ElementGroup = { idx: number; rows: DecodedField[] };
             const elements: ElementGroup[] = [];
             for (const r of unitRows) {
-                const idx = parseArrayIndex(r.fieldName, baseName);
+                const idx = parseArrayIndex(r.fieldName, arrayBase);
                 if (idx === null) { continue; }
                 const last = elements[elements.length - 1];
                 if (last && last.idx === idx) { last.rows.push(r); }
@@ -1659,7 +1668,7 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                     `<span class="si-node-type-pad" aria-hidden="true"></span>` +
                     `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
                     `<span class="si-f-body">` +
-                    `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel, ng.rows))}</span>` +
+                    `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel))}</span>` +
                     `<span class="si-f-lead"></span>` +
                     `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
                     `</span>` +
@@ -1773,7 +1782,7 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                       `<span class="si-node-type-pad" aria-hidden="true"></span>` +
                       `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
                       `<span class="si-f-body">` +
-                      `<span class="si-f-name">${esc(groupHeaderName(g.baseName, g.rows))}</span>` +
+                      `<span class="si-f-name">${esc(groupHeaderName(g.baseName))}</span>` +
                       `<span class="si-f-lead"></span>` +
                       `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummaryFull)}</span>` +
                       `</span>` +

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -2630,6 +2630,24 @@ function showFieldValMenu(
     const findFieldAt = (addr: number): DecodedField | null => {
         return findRowsAt(addr)[0] ?? null;
     };
+    const findFieldForKey = (rows: DecodedField[], addr: number, valKey?: string): DecodedField | null => {
+        const atAddr = rows.filter(rr => rr.byteOffset === addr);
+        if (!valKey) { return atAddr[0] ?? null; }
+        if (valKey.startsWith('bit:')) {
+            const parts = valKey.split(':');
+            const bitStart = parseInt(parts[2] ?? '', 10);
+            const bitWidth = parseInt(parts[3] ?? '', 10);
+            return atAddr.find(rr =>
+                isBitFieldRow(rr) &&
+                rr.bitOffset === bitStart &&
+                rr.bitWidth === bitWidth
+            ) ?? atAddr[0] ?? null;
+        }
+        if (valKey.startsWith('bitunit:')) {
+            return buildBitUnitAggregateRow(atAddr.filter(isBitFieldRow));
+        }
+        return atAddr[0] ?? null;
+    };
     const sampleField = findFieldAt(sampleAddr);
     const sampleType = sampleField?.type ?? null;
     const isBitSample = sampleField ? isBitFieldRow(sampleField) : false;
@@ -2772,7 +2790,7 @@ function showFieldValMenu(
                 const def = all.find(d => d.id === pin!.structId);
                 if (!def) { hideFieldValMenu(); return; }
                 const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
-                const r = rows.find(rr => pin!.addr + rr.byteOffset === bs);
+                const r = findFieldForKey(rows, bs - pin.addr, opts?.valKey);
                 const toCopy = r ? getCopyText(r, 'hex') : '??';
                 if (navigator.clipboard && navigator.clipboard.writeText) {
                     navigator.clipboard.writeText(toCopy).catch(() => {
@@ -2845,12 +2863,13 @@ function showFieldValMenu(
                 if (!def) { hideFieldValMenu(); return; }
                 const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
                 const toCopy = (bsList && bsList.length > 0)
-                    ? bsList.map(b => {
-                        const r = rows.find(rr => pin!.addr + rr.byteOffset === b);
+                    ? bsList.map((b, idx) => {
+                        const listKey = opts?.keyList?.[idx];
+                        const r = findFieldForKey(rows, b - pin!.addr, listKey);
                         return r ? getCopyText(r, t) : '??';
                       }).join('\n')
                     : (() => {
-                        const r = rows.find(rr => pin!.addr + rr.byteOffset === bs);
+                        const r = findFieldForKey(rows, bs - pin!.addr, opts?.valKey);
                         return r ? getCopyText(r, t) : '??';
                       })();
                 if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -110,13 +110,41 @@ function renderBitSpan(bit: string, idx: number, selected: boolean): string {
     return `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}${sel}" data-bit-idx="${idx}">${bit}</span>`;
 }
 
-function allocationBitIndexForDisplayedBit(byteIdx: number, bitInByte: number, bitCount: number): number {
-    const numericBitIdx = S.endian === 'le'
-        ? byteIdx * 8 + bitInByte
-        : bitCount - (byteIdx * 8 + (8 - bitInByte));
-    return S.bitFieldAllocation === 'lsb'
-        ? numericBitIdx
-        : bitCount - numericBitIdx - 1;
+function renderUnknownBitSpan(bitIdx: number, selected: boolean): string {
+    return `<span class="si-bit unknown${selected ? ' sel' : ''}" data-bit-idx="${bitIdx}">?</span>`;
+}
+
+function isBitSelected(
+    bitIdx: number,
+    selectedRange?: { startBit: number; endBit: number } | null,
+): boolean {
+    return !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
+}
+
+function byteHexParts(bytesHex: string): string[] {
+    return bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
+}
+
+function hasMissingByte(parts: string[]): boolean {
+    return parts.length === 0 || parts.some(p => p === '??');
+}
+
+function bytesFromHexParts(parts: string[]): number[] {
+    return parts.map(h => parseInt(h, 16));
+}
+
+function bytesToValue(raw: number[], endian: 'le' | 'be'): bigint {
+    let value = 0n;
+    if (endian === 'le') {
+        for (let i = 0; i < raw.length; i++) {
+            value |= BigInt(raw[i]) << BigInt(i * 8);
+        }
+        return value;
+    }
+    for (const b of raw) {
+        value = (value << 8n) | BigInt(b);
+    }
+    return value;
 }
 
 function makeBitRowKey(byteStart: number, bitStart: number, bitWidth: number): string {
@@ -168,6 +196,23 @@ function renderBinarySpanLines(spans: string[]): string {
     return `<span class="si-bin-wrap">${lines.join('<br>')}</span>`;
 }
 
+function binaryBitsForValue(bytes: number[], endian: 'le' | 'be'): string {
+    return bytesToValue(bytes, endian).toString(2).padStart(bytes.length * 8, '0');
+}
+
+function renderPlainBinaryBits(bits: string): string {
+    return renderBinarySpanLines([...bits].map((bit, idx) => renderBitSpan(bit, idx, false)));
+}
+
+function formatPlainBinaryBits(bits: string): string {
+    const groups = bits.match(/.{1,4}/g) || [];
+    const lines: string[] = [];
+    for (let i = 0; i < groups.length; i += 4) {
+        lines.push(groups.slice(i, i + 4).join(' '));
+    }
+    return lines.join('\n');
+}
+
 function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
     const byteStart = parseInt(row.dataset.byteStart ?? '', 10);
     const bitStart = parseInt(row.dataset.bitStart ?? '', 10);
@@ -212,20 +257,11 @@ function renderBinaryFromBitRows(
     if (!first || usedWidth <= 0) {
         return '<span class="si-bin-wrap"></span>';
     }
-    const rawParts = first.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
-    const missing = rawParts.length === 0 || rawParts.some(p => p === '??') || !first.hasData;
+    const rawParts = byteHexParts(first.bytesHex);
+    const missing = hasMissingByte(rawParts) || !first.hasData;
     if (!missing) {
-        const raw = rawParts.map(h => parseInt(h, 16));
-        let value = 0n;
-        if (S.endian === 'le') {
-            for (let i = 0; i < raw.length; i++) {
-                value |= BigInt(raw[i]) << BigInt(i * 8);
-            }
-        } else {
-            for (const b of raw) {
-                value = (value << 8n) | BigInt(b);
-            }
-        }
+        const raw = bytesFromHexParts(rawParts);
+        const value = bytesToValue(raw, first.endian);
         const unitBits = raw.length * 8;
         const mask = (1n << BigInt(usedWidth)) - 1n;
         const slicedValue = S.bitFieldAllocation === 'lsb'
@@ -234,8 +270,7 @@ function renderBinaryFromBitRows(
         const bits = slicedValue.toString(2).padStart(usedWidth, '0');
         const spans = [...bits].map((bit, displayIdx) => {
             const bitIdx = S.bitFieldAllocation === 'lsb' ? usedWidth - displayIdx - 1 : displayIdx;
-            const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
-            return renderBitSpan(bit, bitIdx, selected);
+            return renderBitSpan(bit, bitIdx, isBitSelected(bitIdx, selectedRange));
         });
         return renderBinarySpanLines(spans);
     }
@@ -243,9 +278,7 @@ function renderBinaryFromBitRows(
     const spans: string[] = [];
     for (let displayIdx = 0; displayIdx < usedWidth; displayIdx++) {
         const bitIdx = S.bitFieldAllocation === 'lsb' ? usedWidth - displayIdx - 1 : displayIdx;
-        const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
-        const sel = selected ? ' sel' : '';
-        spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`);
+        spans.push(renderUnknownBitSpan(bitIdx, isBitSelected(bitIdx, selectedRange)));
     }
 
     return renderBinarySpanLines(spans);
@@ -255,33 +288,26 @@ function renderBinaryStorageUnit(
     r: DecodedField,
     selectedRange?: { startBit: number; endBit: number } | null,
 ): string {
-    const rawParts = r.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
-    if (rawParts.length === 0 || rawParts.some(p => p === '??')) {
+    const rawParts = byteHexParts(r.bytesHex);
+    if (hasMissingByte(rawParts)) {
         const byteCount = r.bitStorageByteSize ?? (rawParts.length || 1);
         const bitCount = byteCount * 8;
         const spans = Array.from({ length: bitCount }, (_, displayIdx) => {
-            const byteIdx = Math.floor(displayIdx / 8);
-            const bitInByte = 7 - (displayIdx % 8);
-            const bitIdx = allocationBitIndexForDisplayedBit(byteIdx, bitInByte, bitCount);
-            const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
-            const sel = selected ? ' sel' : '';
-            return `<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`;
+            const numericBitIdx = bitCount - displayIdx - 1;
+            const bitIdx = S.bitFieldAllocation === 'lsb' ? numericBitIdx : displayIdx;
+            return renderUnknownBitSpan(bitIdx, isBitSelected(bitIdx, selectedRange));
         });
         return renderBinarySpanLines(spans);
     }
 
-    const bytes = rawParts.map(h => parseInt(h, 16));
+    const bytes = bytesFromHexParts(rawParts);
     const bitCount = bytes.length * 8;
-    const spans: string[] = [];
-    for (let byteIdx = 0; byteIdx < bytes.length; byteIdx++) {
-        const byte = bytes[byteIdx];
-        for (let bitInByte = 7; bitInByte >= 0; bitInByte--) {
-            const bit = ((byte >> bitInByte) & 1).toString();
-            const storageBitIdx = allocationBitIndexForDisplayedBit(byteIdx, bitInByte, bitCount);
-            const selected = !!selectedRange && storageBitIdx >= selectedRange.startBit && storageBitIdx <= selectedRange.endBit;
-            spans.push(renderBitSpan(bit, storageBitIdx, selected));
-        }
-    }
+    const bits = binaryBitsForValue(bytes, r.endian);
+    const spans = [...bits].map((bit, displayIdx) => {
+        const numericBitIdx = bitCount - displayIdx - 1;
+        const storageBitIdx = S.bitFieldAllocation === 'lsb' ? numericBitIdx : displayIdx;
+        return renderBitSpan(bit, storageBitIdx, isBitSelected(storageBitIdx, selectedRange));
+    });
 
     return renderBinarySpanLines(spans);
 }
@@ -1212,26 +1238,10 @@ function getValForType(r: DecodedField, valType: ColType): string {
     const buf   = new ArrayBuffer(bytes.length);
     const dv    = new DataView(buf);
     bytes.forEach((b, i) => dv.setUint8(i, b));
-    const le    = S.endian === 'le';
-    const binFn = () => {
-        // Continuous bit string (MSB-first per byte), grouped into 4-bit nibbles.
-        const bitSeq = bytes.map(b => b.toString(2).padStart(8, '0')).join('');
-        const groups = bitSeq.match(/.{1,4}/g) || [];
-        const renderGroups = (grps: string[]) => grps.map(g =>
-            [...g].map(bit => `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}">${bit}</span>`).join('')
-        ).join(' ');
-
-        // Full HTML broken into lines of max 16 bits (4 nibbles) per line.
-        const groupsPerLine = 4; // 4 nibbles = 16 bits
-        const lines: string[] = [];
-        for (let i = 0; i < groups.length; i += groupsPerLine) {
-            lines.push(renderGroups(groups.slice(i, i + groupsPerLine)));
-        }
-        const fullHtml = lines.join('<br>');
-
-        // Always return the full, multi-line binary HTML.
-        return `<span class="si-bin-wrap">${fullHtml}</span>`;
-    };
+    const endian = r.endian ?? S.endian;
+    const le    = endian === 'le';
+    const rawBinFn = () => renderPlainBinaryBits(bytes.map(b => b.toString(2).padStart(8, '0')).join(''));
+    const numericBinFn = () => renderPlainBinaryBits(binaryBitsForValue(bytes, endian));
     // Pointer always renders as arrow → hex address regardless of valType
     if (r.type === 'pointer') {
         const v = dv.getUint32(0, le) >>> 0;
@@ -1242,14 +1252,14 @@ function getValForType(r: DecodedField, valType: ColType): string {
             const hex = bytes.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join('');
             return formatHexHtml(`0x${hex}`);
         }
-        if (valType === 'bin' || valType === 'bin-sliced') { return binFn(); }
+        if (valType === 'bin' || valType === 'bin-sliced') { return rawBinFn(); }
         const s = r.decoded === '??' ? '' : r.decoded;
         return `'${s}'`;
     }
-    if (valType === 'bin' || valType === 'bin-sliced') { return binFn(); }
+    if (valType === 'bin' || valType === 'bin-sliced') { return numericBinFn(); }
     if (valType === 'ieee') {
         if (r.type !== 'float32' && r.type !== 'float64') { return r.decoded; }
-        const parts = getFloatParts(bytes, r.type as 'float32' | 'float64', S.endian);
+        const parts = getFloatParts(bytes, r.type as 'float32' | 'float64', endian);
         if (!parts) { return '??'; }
         return (
             `<pre class="si-ieee">` +
@@ -1359,7 +1369,8 @@ function getCopyText(r: DecodedField, valType: ColType): string {
     }
     if (r.type === 'ascii') { return r.decoded; }
     const bytes = r.bytesHex.split(' ').map(h => parseInt(h, 16));
-    const le    = S.endian === 'le';
+    const endian = r.endian ?? S.endian;
+    const le    = endian === 'le';
     const hexPad = (v: number, pad: number) => `0x${(v >>> 0).toString(16).toUpperCase().padStart(pad, '0')}`;
     const hexPadBig = (v: bigint, pad: number) => `0x${v.toString(16).toUpperCase().padStart(pad, '0')}`;
     if (r.type === 'pointer') {
@@ -1370,13 +1381,11 @@ function getCopyText(r: DecodedField, valType: ColType): string {
         return hexPad(v, 8);
     }
     if (valType === 'bin' || valType === 'bin-sliced') {
-        const bitSeq = bytes.map(b => b.toString(2).padStart(8, '0')).join('');
-        const groups = bitSeq.match(/.{1,4}/g) || [];
-        return groups.join(' ');
+        return formatPlainBinaryBits(binaryBitsForValue(bytes, endian));
     }
     if (valType === 'ieee') {
         if (r.type !== 'float32' && r.type !== 'float64') { return r.decoded; }
-        const parts = getFloatParts(bytes, r.type as 'float32' | 'float64', S.endian);
+        const parts = getFloatParts(bytes, r.type as 'float32' | 'float64', endian);
         if (!parts) { return '??'; }
         // Copy as a single-line summary (UI remains multiline)
         return `sign: ${parts.sign}; exponent: ${parts.exponentHex}; mantissa: ${parts.mantissaHex}; class: ${parts.className}`;
@@ -1503,22 +1512,12 @@ function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
     if (!isBitUnitGroup(rows)) { return fallback; }
     const first = rows[0];
     if (!first) { return fallback; }
-    const rawParts = first.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
-    if (rawParts.length === 0 || rawParts.some(p => p === '??')) { return '??'; }
-    const raw = rawParts.map(h => parseInt(h, 16));
+    const rawParts = byteHexParts(first.bytesHex);
+    if (hasMissingByte(rawParts)) { return '??'; }
+    const raw = bytesFromHexParts(rawParts);
     if (raw.some(v => !Number.isFinite(v) || v < 0 || v > 0xFF)) { return '??'; }
 
-    let value = 0n;
-    if (S.endian === 'le') {
-        for (let i = 0; i < raw.length; i++) {
-            value |= BigInt(raw[i]) << BigInt(i * 8);
-        }
-    } else {
-        for (const b of raw) {
-            value = (value << 8n) | BigInt(b);
-        }
-    }
-
+    const value = bytesToValue(raw, first.endian);
     const hex = value.toString(16).toUpperCase().padStart(raw.length * 2, '0');
     return `0x${hex} (${value.toString(10)})`;
 }
@@ -1534,6 +1533,7 @@ function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
         bytesHex: first.bytesHex,
         decoded: first.decoded,
         hasData: first.hasData,
+        endian: first.endian,
     };
 }
 

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -38,8 +38,8 @@ const _expandedArrayElements = new Set<string>();
 type ColType = 'hex' | 'dec' | 'ascii' | 'bin' | 'bin-sliced' | 'ieee';
 /** Default display type for value cells (per-field default). */
 let _defaultValType: ColType = 'hex';
-/** Per-field display override keyed by absolute byte-start address. */
-const _fieldValTypes = new Map<number, ColType>();
+/** Per-value display override keyed by stable row identity. */
+const _fieldValTypes = new Map<string, ColType>();
 /** Whether the inline add-instance form is open. */
 let _addingPin = false;
 /** Byte start address of the currently highlighted field row. */
@@ -112,6 +112,18 @@ function renderBitSpan(bit: string, idx: number, selected: boolean): string {
 
 function makeBitRowKey(byteStart: number, bitStart: number, bitWidth: number): string {
     return `${byteStart}:${bitStart}:${bitWidth}`;
+}
+
+function scalarValKey(byteStart: number): string {
+    return `byte:${byteStart}`;
+}
+
+function bitChildValKey(byteStart: number, bitStart: number, bitWidth: number): string {
+    return `bit:${makeBitRowKey(byteStart, bitStart, bitWidth)}`;
+}
+
+function bitUnitValKey(byteStart: number): string {
+    return `bitunit:${byteStart}`;
 }
 
 function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
@@ -1364,7 +1376,10 @@ const TYPE_ABBREV: Record<string, string> = {
 function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: string): string {
     const nd  = !r.hasData ? ' si-no-data' : '';
     const ptr = r.type === 'pointer';
-    let t = _fieldValTypes.get(bs);
+    const valKey = isBitFieldRow(r)
+        ? bitChildValKey(bs, r.bitOffset ?? 0, r.bitWidth ?? 0)
+        : scalarValKey(bs);
+    let t = _fieldValTypes.get(valKey);
     if (!t) {
         // Prefer decimal view for floating-point fields by default
         if (isBitFieldRow(r)) { t = 'bin'; }
@@ -1373,7 +1388,7 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: strin
         else { t = _defaultValType; }
     }
     const v   = getValForType(r, t);
-    const valHtml = (t === 'bin' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
+    const valHtml = (t === 'bin' || t === 'bin-sliced' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
     const byteCount = r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : bc;
     const abbrevBase = TYPE_ABBREV[r.type] ?? r.type;
     const abbrev = isBitFieldRow(r)
@@ -1387,7 +1402,7 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: strin
         : `+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
     return (
         `<div class="si-field${nd}${ptr ? ' si-ptr-field' : ''}" ` +
-        `data-byte-start="${bs}" data-byte-cnt="${bc}"` +
+        `data-byte-start="${bs}" data-byte-cnt="${bc}" data-val-key="${esc(valKey)}"` +
         (isBitFieldRow(r) ? ` data-bit-start="${r.bitOffset ?? 0}" data-bit-width="${r.bitWidth ?? 0}"` : '') +
         `>` +
         `<span class="si-f-off">${offsetLabel}</span>` +
@@ -1396,7 +1411,7 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: strin
         `<span class="si-f-body">` +
         `<span class="si-f-name">${esc(displayName ?? leafName(r.fieldName))}</span>` +
         `<span class="si-f-lead"></span>` +
-        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${bs}">${valHtml}</span>` +
+        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${bs}" data-val-key="${esc(valKey)}">${valHtml}</span>` +
         `</span>` +
         `</div>`
     );
@@ -1482,22 +1497,23 @@ function bitUnitHeaderHtml(
     const headerName = headerNameOverride ?? groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''));
     const headerClass = kind === 'element' ? 'si-arr-el-hdr' : 'si-arr-grp-hdr';
     const buttonClass = kind === 'element' ? 'si-arr-el-exp-btn' : 'si-arr-exp-btn';
+    const valKey = bitUnitValKey(start);
     if (!agg) {
         return (
-            `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+            `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}" data-val-key="${esc(valKey)}">` +
             `<span class="si-f-off">+000</span>` +
             `<span class="si-f-type">u8</span>` +
             `<button class="${buttonClass}">${isOpen ? '▾' : '▸'}</button>` +
             `<span class="si-f-body">` +
             `<span class="si-f-name">${esc(headerName)}</span>` +
             `<span class="si-f-lead"></span>` +
-            `<span class="si-f-val si-f-pri" data-val-type="hex" data-bs="${start}">??</span>` +
+            `<span class="si-f-val si-f-pri" data-val-type="hex" data-bs="${start}" data-val-key="${esc(valKey)}">??</span>` +
             `</span>` +
             `</div>`
         );
     }
 
-    let t = _fieldValTypes.get(start);
+    let t = _fieldValTypes.get(valKey);
     if (!t) { t = 'bin'; }
 
     const activeRange = (() => {
@@ -1527,14 +1543,14 @@ function bitUnitHeaderHtml(
     const offsetLabel = `+${agg.byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
 
     return (
-        `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+        `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}" data-val-key="${esc(valKey)}">` +
         `<span class="si-f-off">${offsetLabel}</span>` +
         `<span class="si-f-type" title="${esc(fullTypeLabel)}">${abbrev}</span>` +
         `<button class="${buttonClass}">${isOpen ? '▾' : '▸'}</button>` +
         `<span class="si-f-body">` +
         `<span class="si-f-name">${esc(headerName)}</span>` +
         `<span class="si-f-lead"></span>` +
-        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${start}">${valHtml}</span>` +
+        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${start}" data-val-key="${esc(valKey)}">${valHtml}</span>` +
         `</span>` +
         `</div>`
     );
@@ -2324,7 +2340,8 @@ function wireInstanceCards(sec: HTMLElement): void {
             const isPointer = valCell?.classList.contains('si-f-ptr');
             const isBitUnitHeader = row.classList.contains('si-bitunit-hdr');
             // Only allow per-element change, not group, for array elements
-            showFieldValMenu(ev.clientX, ev.clientY, start, undefined, pinIdx, { isPointer, isBitUnitHeader });
+            const valKey = row.dataset.valKey ?? scalarValKey(start);
+            showFieldValMenu(ev.clientX, ev.clientY, start, undefined, pinIdx, { isPointer, isBitUnitHeader, valKey });
         });
     });
 
@@ -2335,12 +2352,30 @@ function wireInstanceCards(sec: HTMLElement): void {
             if (hdr.classList.contains('si-bitunit-hdr')) { return; }
             ev.preventDefault(); ev.stopPropagation();
             const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
-            const bsList = Array.from(grp.querySelectorAll<HTMLElement>('.si-field'))
-                .map(r => parseInt(r.dataset.byteStart!));
+            const body = Array.from(grp.children).find(child =>
+                child.classList.contains('si-arr-grp-body')
+            ) as HTMLElement | undefined;
+            const directValueRows = body
+                ? Array.from(body.children).flatMap(child => {
+                    const childEl = child as HTMLElement;
+                    if (childEl.classList.contains('si-field')) { return [childEl]; }
+                    if (childEl.classList.contains('si-arr-el-grp')) {
+                        const hdr = Array.from(child.children).find(grandchild =>
+                            grandchild.classList.contains('si-arr-el-hdr') &&
+                            grandchild.classList.contains('si-field')
+                        ) as HTMLElement | undefined;
+                        return hdr ? [hdr] : [];
+                    }
+                    return [];
+                })
+                : [];
+            const bsList = directValueRows.map(r => parseInt(r.dataset.byteStart!));
+            const keyList = directValueRows.map(r => r.dataset.valKey ?? scalarValKey(parseInt(r.dataset.byteStart!)));
             const card = hdr.closest<HTMLElement>('.si-card');
             const pinIdx = card ? parseInt(card.dataset.idx!) : -1;
             const start = bsList[0];
-            showFieldValMenu(ev.clientX, ev.clientY, start, bsList, pinIdx, { isArrayHeader: true });
+            if (start === undefined) { return; }
+            showFieldValMenu(ev.clientX, ev.clientY, start, bsList, pinIdx, { isArrayHeader: true, keyList });
         });
     });
 
@@ -2454,7 +2489,20 @@ function hideFieldValMenu(): void {
     if (_valMenuEl) { _valMenuEl.remove(); _valMenuEl = null; }
     document.removeEventListener('click', hideFieldValMenu);
 }
-function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], pinIdx?: number, opts?: { isPointer?: boolean, isArrayHeader?: boolean, isBitUnitHeader?: boolean }): void {
+function showFieldValMenu(
+    x: number,
+    y: number,
+    bs: number,
+    bsList?: number[],
+    pinIdx?: number,
+    opts?: {
+        isPointer?: boolean,
+        isArrayHeader?: boolean,
+        isBitUnitHeader?: boolean,
+        valKey?: string,
+        keyList?: string[],
+    },
+): void {
     hideFieldValMenu();
     // Determine candidate display types based on the field's native type.
     const sampleAddr = (bsList && bsList.length > 0) ? bsList[0] : bs;
@@ -2482,7 +2530,9 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
     const isBitSample = sampleField ? isBitFieldRow(sampleField) : false;
     const isFloatSample = sampleType === 'float32' || sampleType === 'float64';
     const isAsciiSample = sampleType === 'ascii';
-    const types: ColType[] = opts?.isBitUnitHeader
+    const key = opts?.valKey ?? scalarValKey(bs);
+    const arrayHasBitUnits = opts?.isArrayHeader && opts.keyList?.some(k => k.startsWith('bitunit:'));
+    const types: ColType[] = opts?.isBitUnitHeader || arrayHasBitUnits
         ? ['bin', 'bin-sliced', 'hex', 'dec']
         : isFloatSample
         ? ['hex', 'dec', 'ieee', 'bin']
@@ -2493,11 +2543,19 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
                 : ['hex', 'dec', 'bin', 'ascii'];
     let cur: ColType | null = null;
     if (bsList && bsList.length > 0) {
-        const vals = bsList.map(b => _fieldValTypes.get(b) ?? _defaultValType);
+        const vals = bsList.map((b, idx) => {
+            const listKey = opts?.keyList?.[idx] ?? scalarValKey(b);
+            const field = findFieldAt(b);
+            const ft = field?.type ?? null;
+            const implicit = (listKey.startsWith('bitunit:') || (field && isBitFieldRow(field)))
+                ? 'bin'
+                : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
+            return _fieldValTypes.get(listKey) ?? implicit;
+        });
         const allSame = vals.every(v => v === vals[0]);
         cur = allSame ? (vals[0] as ColType) : null;
     } else {
-        cur = _fieldValTypes.get(bs) ?? ((isBitSample || opts?.isBitUnitHeader) ? 'bin' : _defaultValType);
+        cur = _fieldValTypes.get(key) ?? ((isBitSample || opts?.isBitUnitHeader) ? 'bin' : _defaultValType);
     }
 
     // Helpers for menu
@@ -2553,14 +2611,15 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
                 }
                 if (cmd.startsWith('disp-') && bsList && bsList.length > 0) {
                     const t = cmd.replace('disp-', '') as ColType;
-                    bsList.forEach(b => {
+                    bsList.forEach((b, idx) => {
+                        const listKey = opts?.keyList?.[idx] ?? scalarValKey(b);
                         const field = findFieldAt(b);
                         const ft = field?.type ?? null;
-                        const implicit = field && isBitFieldRow(field)
+                        const implicit = (listKey.startsWith('bitunit:') || (field && isBitFieldRow(field)))
                             ? 'bin'
                             : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
-                        if (t === implicit) { _fieldValTypes.delete(b); }
-                        else { _fieldValTypes.set(b, t); }
+                        if (t === implicit) { _fieldValTypes.delete(listKey); }
+                        else { _fieldValTypes.set(listKey, t); }
                     });
                     hideFieldValMenu();
                     renderStructPins();
@@ -2705,8 +2764,8 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
                 const implicit = opts?.isBitUnitHeader || (field && isBitFieldRow(field))
                     ? 'bin'
                     : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
-                if (t === implicit) { _fieldValTypes.delete(bs); }
-                else { _fieldValTypes.set(bs, t); }
+                if (t === implicit) { _fieldValTypes.delete(key); }
+                else { _fieldValTypes.set(key, t); }
                 hideFieldValMenu();
                 renderStructPins();
                 return;

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -147,7 +147,9 @@ function applyBitHighlightsInPlace(sec: HTMLElement): void {
         if (!range) { return; }
         const parentVal = sec.querySelector<HTMLElement>(
             `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin"], ` +
-            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin-sliced"]`
+            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin-sliced"], ` +
+            `.si-arr-el-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin"], ` +
+            `.si-arr-el-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin-sliced"]`
         );
         if (!parentVal) { return; }
         for (let i = range.startBit; i <= range.endBit; i++) {
@@ -2305,7 +2307,7 @@ function wireInstanceCards(sec: HTMLElement): void {
                 _selectedArrKey = null;
                 _selectedArrElemKey = null;
                 clearSelRow();
-                // Do NOT add si-selected class to bit-field child rows
+                row.classList.add('si-selected');
                 applyBitHighlightsInPlace(sec);
                 return;
             }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1359,8 +1359,7 @@ function isBitUnitGroup(rows: DecodedField[]): boolean {
 }
 
 function groupHeaderName(baseName: string, rows: DecodedField[]): string {
-    if (!isBitUnitGroup(rows)) { return leafName(baseName); }
-    return 'BitField';
+    return leafName(baseName);
 }
 
 function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
@@ -1406,15 +1405,19 @@ function bitUnitHeaderHtml(
     start: number,
     cnt: number,
     isOpen: boolean,
+    headerNameOverride?: string,
+    kind: 'group' | 'element' = 'group',
 ): string {
     const agg = buildBitUnitAggregateRow(rows);
-    const headerName = groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''), rows);
+    const headerName = headerNameOverride ?? groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''), rows);
+    const headerClass = kind === 'element' ? 'si-arr-el-hdr' : 'si-arr-grp-hdr';
+    const buttonClass = kind === 'element' ? 'si-arr-el-exp-btn' : 'si-arr-exp-btn';
     if (!agg) {
         return (
-            `<div class="si-arr-grp-hdr si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+            `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
             `<span class="si-f-off">+000</span>` +
             `<span class="si-f-type">u8</span>` +
-            `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+            `<button class="${buttonClass}">${isOpen ? '▾' : '▸'}</button>` +
             `<span class="si-f-body">` +
             `<span class="si-f-name">${esc(headerName)}</span>` +
             `<span class="si-f-lead"></span>` +
@@ -1452,10 +1455,10 @@ function bitUnitHeaderHtml(
     const offsetLabel = `+${agg.byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
 
     return (
-        `<div class="si-arr-grp-hdr si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+        `<div class="${headerClass} si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
         `<span class="si-f-off">${offsetLabel}</span>` +
         `<span class="si-f-type" title="${esc(fullTypeLabel)}">${abbrev}</span>` +
-        `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+        `<button class="${buttonClass}">${isOpen ? '▾' : '▸'}</button>` +
         `<span class="si-f-body">` +
         `<span class="si-f-name">${esc(headerName)}</span>` +
         `<span class="si-f-lead"></span>` +
@@ -1518,7 +1521,6 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             unitRows: DecodedField[],
             baseName: string,
             parentKey: string,
-            typeLabel: string,
         ): string => {
             type ElementGroup = { idx: number; rows: DecodedField[] };
             const elements: ElementGroup[] = [];
@@ -1538,16 +1540,7 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const elementRowsHtml = renderBitUnitLeafRows(element.rows);
                 return (
                     `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
-                    `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
-                    `<span class="si-node-pad" aria-hidden="true"></span>` +
-                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                    `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
-                    `<span class="si-f-body">` +
-                    `<span class="si-f-name">[${element.idx}]</span>` +
-                    `<span class="si-f-lead"></span>` +
-                    `<span class="si-arr-addr">${esc(typeLabel)}</span>` +
-                    `</span>` +
-                    `</div>` +
+                    bitUnitHeaderHtml(element.rows, elementByteStart, elementByteCnt, isElementOpen, `[${element.idx}]`, 'element') +
                     `<div class="si-arr-el-body"${isElementOpen ? '' : ' style=\"display:none\"'}>${elementRowsHtml}</div>` +
                     `</div>`
                 );
@@ -1641,7 +1634,6 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                         ng.rows,
                         ng.fullBase,
                         nestedKey,
-                        nestedTypeAbbrev,
                     );
                 } else if (nestedIsStruct && nestedCount === 1) {
                     nestedBodyHtml = renderStructChildren(ng.rows, ng.fullBase, nestedKey);
@@ -1761,7 +1753,7 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                         }).join('');
                     }
                 } else if (isBitUnit && isArray) {
-                    elHtml = renderBitUnitArrayElements(g.rows, g.baseName, key, scalarType);
+                    elHtml = renderBitUnitArrayElements(g.rows, g.baseName, key);
                 } else if (isStruct && !isArray) {
                     elHtml = renderStructChildren(g.rows, g.baseName, key);
                 } else if (isBitUnit) {

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1609,6 +1609,45 @@ function bitUnitArrayBaseName(fieldPath: string): string {
     return fieldPath.replace(/\[\d+\]$/, '');
 }
 
+function offsetLabel(byteOffset: number): string {
+    return `+${byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
+}
+
+function compositeHeaderPrefixHtml(isOpen: boolean, byteOffset: number): string {
+    if (isOpen) {
+        return (
+            `<span class="si-node-pad" aria-hidden="true"></span>` +
+            `<span class="si-node-type-pad" aria-hidden="true"></span>`
+        );
+    }
+    return (
+        `<span class="si-f-off">${offsetLabel(byteOffset)}</span>` +
+        `<span class="si-node-type-pad" aria-hidden="true"></span>`
+    );
+}
+
+function syncCompositeHeaderOffset(hdr: HTMLElement, isOpen: boolean): void {
+    if (hdr.classList.contains('si-bitunit-hdr')) { return; }
+
+    const existingOffset = hdr.querySelector<HTMLElement>(':scope > .si-f-off');
+    const existingPad = hdr.querySelector<HTMLElement>(':scope > .si-node-pad');
+    const typePad = hdr.querySelector<HTMLElement>(':scope > .si-node-type-pad');
+    if (isOpen) {
+        existingOffset?.remove();
+        if (!existingPad && typePad) {
+            typePad.insertAdjacentHTML('beforebegin', '<span class="si-node-pad" aria-hidden="true"></span>');
+        }
+        return;
+    }
+
+    const label = hdr.dataset.offsetLabel;
+    if (!label) { return; }
+    existingPad?.remove();
+    if (!existingOffset && typePad) {
+        typePad.insertAdjacentHTML('beforebegin', `<span class="si-f-off">${esc(label)}</span>`);
+    }
+}
+
 function buildInstanceCard(pin: StructPin, i: number): string {
     const def        = allStructs().find(d => d.id === pin.structId);
     const defName    = def ? def.name : '?';
@@ -1730,9 +1769,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                         );
                         return (
                             `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
-                            `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
-                            `<span class="si-node-pad" aria-hidden="true"></span>` +
-                            `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                            `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}" data-offset-label="${offsetLabel(first.byteOffset)}">` +
+                            compositeHeaderPrefixHtml(isElementOpen, first.byteOffset) +
                             `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
                             `<span class="si-f-body">` +
                             `<span class="si-f-name">[${element.idx}]</span>` +
@@ -1769,16 +1807,18 @@ function buildInstanceCard(pin: StructPin, i: number): string {
 
                 return (
                     `<div class="si-arr-grp${nestedOpen ? ' open' : ''}" data-arr-key="${esc(nestedKey)}">` +
-                    `<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
-                    `<span class="si-node-pad" aria-hidden="true"></span>` +
-                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                    `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
-                    `<span class="si-f-body">` +
-                    `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel))}</span>` +
-                    `<span class="si-f-lead"></span>` +
-                    `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
-                    `</span>` +
-                    `</div>` +
+                    (nestedIsBitUnit && nestedCount === 1
+                        ? bitUnitHeaderHtml(ng.rows, nestedStart, nestedCnt, nestedOpen, groupHeaderName(ng.baseRel))
+                        : `<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}" data-offset-label="${offsetLabel(ng.rows[0].byteOffset)}">` +
+                          compositeHeaderPrefixHtml(nestedOpen, ng.rows[0].byteOffset) +
+                          `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
+                          `<span class="si-f-body">` +
+                          `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel))}</span>` +
+                          `<span class="si-f-lead"></span>` +
+                          `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
+                          `</span>` +
+                          `</div>`
+                    ) +
                     `<div class="si-arr-grp-body"${nestedOpen ? '' : ' style=\"display:none\"'}>${nestedBodyHtml}</div>` +
                     `</div>`
                 );
@@ -1852,9 +1892,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                             );
                             return (
                                 `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
-                                `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
-                                `<span class="si-node-pad" aria-hidden="true"></span>` +
-                                `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                                `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}" data-offset-label="${offsetLabel(first.byteOffset)}">` +
+                                compositeHeaderPrefixHtml(isElementOpen, first.byteOffset) +
                                 `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
                                 `<span class="si-f-body">` +
                                 `<span class="si-f-name">[${element.idx}]</span>` +
@@ -1883,9 +1922,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 (isBitUnit && !isArray
                     ? bitUnitHeaderHtml(g.rows, byteStart, totalCnt, isOpen)
                     : `<div class="si-arr-grp-hdr" ` +
-                      `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
-                      `<span class="si-node-pad" aria-hidden="true"></span>` +
-                      `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                      `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}" data-offset-label="${offsetLabel(r0.byteOffset)}">` +
+                      compositeHeaderPrefixHtml(isOpen, r0.byteOffset) +
                       `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
                       `<span class="si-f-body">` +
                       `<span class="si-f-name">${esc(groupHeaderName(g.baseName))}</span>` +
@@ -2109,11 +2147,13 @@ function wireInstanceCards(sec: HTMLElement): void {
                 grp.classList.remove('open');
                 body.style.display = 'none';
                 expBtn.textContent = '▸';
+                syncCompositeHeaderOffset(hdr, false);
             } else {
                 _expandedArrayFields.add(key);
                 grp.classList.add('open');
                 body.style.display = '';
                 expBtn.textContent = '▾';
+                syncCompositeHeaderOffset(hdr, true);
             }
         });
 
@@ -2191,11 +2231,13 @@ function wireInstanceCards(sec: HTMLElement): void {
                 grp.classList.remove('open');
                 body.style.display = 'none';
                 expBtn.textContent = '▸';
+                syncCompositeHeaderOffset(hdr, false);
             } else {
                 _expandedArrayElements.add(key);
                 grp.classList.add('open');
                 body.style.display = '';
                 expBtn.textContent = '▾';
+                syncCompositeHeaderOffset(hdr, true);
             }
         });
 
@@ -2509,8 +2551,17 @@ function wireInstanceCards(sec: HTMLElement): void {
 let _valMenuEl: HTMLElement | null = null;
 function hideFieldValMenu(): void {
     if (_valMenuEl) { _valMenuEl.remove(); _valMenuEl = null; }
+    if (typeof document === 'undefined') { return; }
     document.removeEventListener('click', hideFieldValMenu);
 }
+
+function addFieldValMenuClickAway(): void {
+    setTimeout(() => {
+        if (typeof document === 'undefined') { return; }
+        document.addEventListener('click', hideFieldValMenu);
+    }, 0);
+}
+
 function showFieldValMenu(
     x: number,
     y: number,
@@ -2603,7 +2654,7 @@ function showFieldValMenu(
 
     // Array header: copy start address + view-as for all elements
     if (opts?.isArrayHeader) {
-        const TYPE_LABELS_FULL: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit field sliced)', ascii: 'ASCII', ieee: 'IEEE754' };
+        const TYPE_LABELS_FULL: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit fields only)', ascii: 'ASCII', ieee: 'IEEE754' };
         const dispMenu = types.map(t =>
             `<div class="ctx-row${t === cur ? ' active' : ''}" data-cmd="disp-${t}">` +
             `<span class="ctx-label">${TYPE_LABELS_FULL[t]}</span>` +
@@ -2657,7 +2708,7 @@ function showFieldValMenu(
             });
         });
         wireStructSubmenus(el);
-        setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+        addFieldValMenuClickAway();
         _valMenuEl = el;
         return;
     }
@@ -2708,12 +2759,12 @@ function showFieldValMenu(
                 return;
             });
         });
-        setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+        addFieldValMenuClickAway();
         _valMenuEl = el;
         return;
     }
 
-    const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit field sliced)', ascii: 'ASCII', ieee: 'IEEE754' };
+    const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit fields only)', ascii: 'ASCII', ieee: 'IEEE754' };
 
     // Copy submenu
     const copyMenu = types.map(t =>
@@ -2807,7 +2858,7 @@ function showFieldValMenu(
     wireStructSubmenus(el);
 
     // Hide when clicking outside
-    setTimeout(() => document.addEventListener('click', hideFieldValMenu), 0);
+    addFieldValMenuClickAway();
     _valMenuEl = el;
 }
 function wireStructSubmenus(menuEl: HTMLElement): void {
@@ -2853,6 +2904,7 @@ function wireStructSubmenus(menuEl: HTMLElement): void {
 
 /** Called when the user's byte selection changes. Fills the add-form address if open. */
 export function onSelectionChangeForStruct(): void {
+    if (typeof document === 'undefined') { return; }
     clearArrSep();
     clearSelRow();
     _selectedFieldAddr = null;
@@ -2861,7 +2913,6 @@ export function onSelectionChangeForStruct(): void {
     _selectedPinId     = null;
     if (S.selStart === null) { return; }
     S.activeStructAddr = S.selStart;
-    if (typeof document === 'undefined') { return; }
     if (S.sidebarTab === 'struct') {
         const addrHex = S.selStart.toString(16).toUpperCase().padStart(8, '0');
         if (_addingPin) {

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -110,6 +110,15 @@ function renderBitSpan(bit: string, idx: number, selected: boolean): string {
     return `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}${sel}" data-bit-idx="${idx}">${bit}</span>`;
 }
 
+function allocationBitIndexForDisplayedBit(byteIdx: number, bitInByte: number, bitCount: number): number {
+    const numericBitIdx = S.endian === 'le'
+        ? byteIdx * 8 + bitInByte
+        : bitCount - (byteIdx * 8 + (8 - bitInByte));
+    return S.bitFieldAllocation === 'lsb'
+        ? numericBitIdx
+        : bitCount - numericBitIdx - 1;
+}
+
 function makeBitRowKey(byteStart: number, bitStart: number, bitWidth: number): string {
     return `${byteStart}:${bitStart}:${bitWidth}`;
 }
@@ -219,12 +228,12 @@ function renderBinaryFromBitRows(
         }
         const unitBits = raw.length * 8;
         const mask = (1n << BigInt(usedWidth)) - 1n;
-        const slicedValue = S.endian === 'le'
+        const slicedValue = S.bitFieldAllocation === 'lsb'
             ? value & mask
             : (value >> BigInt(Math.max(0, unitBits - usedWidth))) & mask;
         const bits = slicedValue.toString(2).padStart(usedWidth, '0');
         const spans = [...bits].map((bit, displayIdx) => {
-            const bitIdx = S.endian === 'le' ? usedWidth - displayIdx - 1 : displayIdx;
+            const bitIdx = S.bitFieldAllocation === 'lsb' ? usedWidth - displayIdx - 1 : displayIdx;
             const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
             return renderBitSpan(bit, bitIdx, selected);
         });
@@ -233,7 +242,7 @@ function renderBinaryFromBitRows(
 
     const spans: string[] = [];
     for (let displayIdx = 0; displayIdx < usedWidth; displayIdx++) {
-        const bitIdx = S.endian === 'le' ? usedWidth - displayIdx - 1 : displayIdx;
+        const bitIdx = S.bitFieldAllocation === 'lsb' ? usedWidth - displayIdx - 1 : displayIdx;
         const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
         const sel = selected ? ' sel' : '';
         spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`);
@@ -251,7 +260,9 @@ function renderBinaryStorageUnit(
         const byteCount = r.bitStorageByteSize ?? (rawParts.length || 1);
         const bitCount = byteCount * 8;
         const spans = Array.from({ length: bitCount }, (_, displayIdx) => {
-            const bitIdx = bitCount - displayIdx - 1;
+            const byteIdx = Math.floor(displayIdx / 8);
+            const bitInByte = 7 - (displayIdx % 8);
+            const bitIdx = allocationBitIndexForDisplayedBit(byteIdx, bitInByte, bitCount);
             const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
             const sel = selected ? ' sel' : '';
             return `<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`;
@@ -266,9 +277,7 @@ function renderBinaryStorageUnit(
         const byte = bytes[byteIdx];
         for (let bitInByte = 7; bitInByte >= 0; bitInByte--) {
             const bit = ((byte >> bitInByte) & 1).toString();
-            const storageBitIdx = S.endian === 'le'
-                ? byteIdx * 8 + bitInByte
-                : bitCount - (byteIdx * 8 + (8 - bitInByte));
+            const storageBitIdx = allocationBitIndexForDisplayedBit(byteIdx, bitInByte, bitCount);
             const selected = !!selectedRange && storageBitIdx >= selectedRange.startBit && storageBitIdx <= selectedRange.endBit;
             spans.push(renderBitSpan(bit, storageBitIdx, selected));
         }
@@ -958,9 +967,19 @@ export function renderStructPins(): void {
         `<div class="si-main-panel">` +
         `<div class="si-hdr-row">` +
         `<span class="sb-hdr" style="margin:0">Struct Instances ${instBadge}</span>` +
+        `<div class="si-toggle-group" title="Byte endianness: how multi-byte scalar values are interpreted">` +
+        `<span class="si-toggle-label">Endian</span>` +
         `<div class="endian-tabs sa-endian-tabs">` +
-        `<button id="sa-btn-le" class="${S.endian === 'le' ? 'active' : ''}">LE</button>` +
-        `<button id="sa-btn-be" class="${S.endian === 'be' ? 'active' : ''}">BE</button>` +
+        `<button id="sa-btn-le" class="${S.endian === 'le' ? 'active' : ''}" title="Interpret multi-byte scalar values as little-endian">LE</button>` +
+        `<button id="sa-btn-be" class="${S.endian === 'be' ? 'active' : ''}" title="Interpret multi-byte scalar values as big-endian">BE</button>` +
+        `</div>` +
+        `</div>` +
+        `<div class="si-toggle-group" title="Bit-field allocation: which side receives the first declared bit field">` +
+        `<span class="si-toggle-label">Bit Layout</span>` +
+        `<div class="endian-tabs sa-bit-order-tabs">` +
+        `<button id="sa-btn-bit-lsb" class="${S.bitFieldAllocation === 'lsb' ? 'active' : ''}" title="Bit-field allocation: first declared bit field starts at the least significant bit">LSB</button>` +
+        `<button id="sa-btn-bit-msb" class="${S.bitFieldAllocation === 'msb' ? 'active' : ''}" title="Bit-field allocation: first declared bit field starts at the most significant bit">MSB</button>` +
+        `</div>` +
         `</div>` +
         `<button id="si-add-btn" class="si-add-btn"${_addingPin ? ' disabled' : ''}>\uff0b Add</button>` +
         `<button id="si-types-btn" class="si-icon-btn" title="Manage types">&#9776;</button>` +
@@ -1118,7 +1137,7 @@ export function renderStructPins(): void {
         });
     }
 
-    // ── Endian tabs ──
+    // ── Byte endianness tabs ──
     document.getElementById('sa-btn-le')?.addEventListener('click', () => {
         S.endian = 'le';
         document.getElementById('sa-btn-le')?.classList.add('active');
@@ -1129,6 +1148,20 @@ export function renderStructPins(): void {
         S.endian = 'be';
         document.getElementById('sa-btn-be')?.classList.add('active');
         document.getElementById('sa-btn-le')?.classList.remove('active');
+        if (_expanded.size > 0) { renderStructPins(); }
+    });
+
+    // ── Bit-field allocation tabs ──
+    document.getElementById('sa-btn-bit-lsb')?.addEventListener('click', () => {
+        S.bitFieldAllocation = 'lsb';
+        document.getElementById('sa-btn-bit-lsb')?.classList.add('active');
+        document.getElementById('sa-btn-bit-msb')?.classList.remove('active');
+        if (_expanded.size > 0) { renderStructPins(); }
+    });
+    document.getElementById('sa-btn-bit-msb')?.addEventListener('click', () => {
+        S.bitFieldAllocation = 'msb';
+        document.getElementById('sa-btn-bit-msb')?.classList.add('active');
+        document.getElementById('sa-btn-bit-lsb')?.classList.remove('active');
         if (_expanded.size > 0) { renderStructPins(); }
     });
 
@@ -1654,7 +1687,7 @@ function buildInstanceCard(pin: StructPin, i: number): string {
 
     let bodyHtml = '';
     if (expanded && def) {
-        const rows = decodeStruct(def, pin.addr, getByte, S.endian);
+        const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
         const rowByteCnt = (r: DecodedField) => {
             if (isBitFieldRow(r)) { return r.bitStorageByteSize ?? 1; }
             return r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
@@ -2591,7 +2624,7 @@ function showFieldValMenu(
         if (!pin) { return []; }
         const def = allDefs.find(d => d.id === pin.structId);
         if (!def) { return []; }
-        const rows = decodeStruct(def, pin.addr, getByte, S.endian);
+        const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
         return rows.filter(rr => pin!.addr + rr.byteOffset === addr);
     };
     const findFieldAt = (addr: number): DecodedField | null => {
@@ -2738,7 +2771,7 @@ function showFieldValMenu(
                 if (!pin) { hideFieldValMenu(); return; }
                 const def = all.find(d => d.id === pin!.structId);
                 if (!def) { hideFieldValMenu(); return; }
-                const rows = decodeStruct(def, pin.addr, getByte, S.endian);
+                const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
                 const r = rows.find(rr => pin!.addr + rr.byteOffset === bs);
                 const toCopy = r ? getCopyText(r, 'hex') : '??';
                 if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -2810,7 +2843,7 @@ function showFieldValMenu(
                 if (!pin) { hideFieldValMenu(); return; }
                 const def = all.find(d => d.id === pin!.structId);
                 if (!def) { hideFieldValMenu(); return; }
-                const rows = decodeStruct(def, pin.addr, getByte, S.endian);
+                const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
                 const toCopy = (bsList && bsList.length > 0)
                     ? bsList.map(b => {
                         const r = rows.find(rr => pin!.addr + rr.byteOffset === b);

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -35,7 +35,7 @@ const _expandedArrayFields = new Set<string>();
 /** Nested element groups that are expanded. Key: `${pinId}::${baseName}::${idx}`. Collapsed by default. */
 const _expandedArrayElements = new Set<string>();
 
-type ColType = 'hex' | 'dec' | 'ascii' | 'bin' | 'ieee';
+type ColType = 'hex' | 'dec' | 'ascii' | 'bin' | 'bin-sliced' | 'ieee';
 /** Default display type for value cells (per-field default). */
 let _defaultValType: ColType = 'hex';
 /** Per-field display override keyed by absolute byte-start address. */
@@ -134,7 +134,8 @@ function applyBitHighlightsInPlace(sec: HTMLElement): void {
     ) => {
         if (!range) { return; }
         const parentVal = sec.querySelector<HTMLElement>(
-            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin"]`
+            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin"], ` +
+            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin-sliced"]`
         );
         if (!parentVal) { return; }
         for (let i = range.startBit; i <= range.endBit; i++) {
@@ -150,26 +151,91 @@ function renderBinaryFromBitRows(
     rows: DecodedField[],
     selectedRange?: { startBit: number; endBit: number } | null,
 ): string {
-    const spans: string[] = [];
-    let idx = 0;
-    for (const r of rows) {
-        const w = r.bitWidth ?? 0;
-        if (w <= 0) { continue; }
-        if (!r.hasData) {
-            for (let i = 0; i < w; i++) {
-                const selected = !!selectedRange && idx >= selectedRange.startBit && idx <= selectedRange.endBit;
-                const sel = selected ? ' sel' : '';
-                spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${idx}">?</span>`);
-                idx += 1;
+    const usedWidth = rows.reduce((sum, r) => sum + Math.max(0, r.bitWidth ?? 0), 0);
+    const first = rows[0];
+    if (!first || usedWidth <= 0) {
+        return '<span class="si-bin-wrap"></span>';
+    }
+    const rawParts = first.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
+    const missing = rawParts.length === 0 || rawParts.some(p => p === '??') || !first.hasData;
+    if (!missing) {
+        const raw = rawParts.map(h => parseInt(h, 16));
+        let value = 0n;
+        if (S.endian === 'le') {
+            for (let i = 0; i < raw.length; i++) {
+                value |= BigInt(raw[i]) << BigInt(i * 8);
             }
-            continue;
+        } else {
+            for (const b of raw) {
+                value = (value << 8n) | BigInt(b);
+            }
         }
-        const v = BigInt(r.bitValueUnsigned ?? '0');
-        const bits = v.toString(2).padStart(w, '0');
-        for (const bit of bits) {
-            const selected = !!selectedRange && idx >= selectedRange.startBit && idx <= selectedRange.endBit;
-            spans.push(renderBitSpan(bit, idx, selected));
-            idx += 1;
+        const unitBits = raw.length * 8;
+        const mask = (1n << BigInt(usedWidth)) - 1n;
+        const slicedValue = S.endian === 'le'
+            ? value & mask
+            : (value >> BigInt(Math.max(0, unitBits - usedWidth))) & mask;
+        const bits = slicedValue.toString(2).padStart(usedWidth, '0');
+        const spans = [...bits].map((bit, displayIdx) => {
+            const bitIdx = S.endian === 'le' ? usedWidth - displayIdx - 1 : displayIdx;
+            const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
+            return renderBitSpan(bit, bitIdx, selected);
+        });
+        const groups: string[] = [];
+        for (let i = 0; i < spans.length; i += 4) {
+            groups.push(spans.slice(i, i + 4).join(''));
+        }
+        return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+    }
+
+    const spans: string[] = [];
+    for (let displayIdx = 0; displayIdx < usedWidth; displayIdx++) {
+        const bitIdx = S.endian === 'le' ? usedWidth - displayIdx - 1 : displayIdx;
+        const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
+        const sel = selected ? ' sel' : '';
+        spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`);
+    }
+
+    const groups: string[] = [];
+    for (let i = 0; i < spans.length; i += 4) {
+        groups.push(spans.slice(i, i + 4).join(''));
+    }
+    return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+}
+
+function renderBinaryStorageUnit(
+    r: DecodedField,
+    selectedRange?: { startBit: number; endBit: number } | null,
+): string {
+    const rawParts = r.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
+    if (rawParts.length === 0 || rawParts.some(p => p === '??')) {
+        const byteCount = r.bitStorageByteSize ?? (rawParts.length || 1);
+        const bitCount = byteCount * 8;
+        const spans = Array.from({ length: bitCount }, (_, displayIdx) => {
+            const bitIdx = bitCount - displayIdx - 1;
+            const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
+            const sel = selected ? ' sel' : '';
+            return `<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`;
+        });
+        const groups: string[] = [];
+        for (let i = 0; i < spans.length; i += 4) {
+            groups.push(spans.slice(i, i + 4).join(''));
+        }
+        return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+    }
+
+    const bytes = rawParts.map(h => parseInt(h, 16));
+    const bitCount = bytes.length * 8;
+    const spans: string[] = [];
+    for (let byteIdx = 0; byteIdx < bytes.length; byteIdx++) {
+        const byte = bytes[byteIdx];
+        for (let bitInByte = 7; bitInByte >= 0; bitInByte--) {
+            const bit = ((byte >> bitInByte) & 1).toString();
+            const storageBitIdx = S.endian === 'le'
+                ? byteIdx * 8 + bitInByte
+                : bitCount - (byteIdx * 8 + (8 - bitInByte));
+            const selected = !!selectedRange && storageBitIdx >= selectedRange.startBit && storageBitIdx <= selectedRange.endBit;
+            spans.push(renderBitSpan(bit, storageBitIdx, selected));
         }
     }
 
@@ -1068,7 +1134,7 @@ function getValForType(r: DecodedField, valType: ColType): string {
         if (valType === 'hex') {
             return formatHexHtml(formatHex(v, Math.max(1, Math.ceil(width / 4))));
         }
-        if (valType === 'bin') {
+        if (valType === 'bin' || valType === 'bin-sliced') {
             const bits = v.toString(2).padStart(width, '0');
             const groups = bits.match(/.{1,4}/g) || [];
             const html = groups.map(g => [...g].map(bit =>
@@ -1112,11 +1178,11 @@ function getValForType(r: DecodedField, valType: ColType): string {
             const hex = bytes.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join('');
             return formatHexHtml(`0x${hex}`);
         }
-        if (valType === 'bin') { return binFn(); }
+        if (valType === 'bin' || valType === 'bin-sliced') { return binFn(); }
         const s = r.decoded === '??' ? '' : r.decoded;
         return `'${s}'`;
     }
-    if (valType === 'bin') { return binFn(); }
+    if (valType === 'bin' || valType === 'bin-sliced') { return binFn(); }
     if (valType === 'ieee') {
         if (r.type !== 'float32' && r.type !== 'float64') { return r.decoded; }
         const parts = getFloatParts(bytes, r.type as 'float32' | 'float64', S.endian);
@@ -1220,7 +1286,7 @@ function getCopyText(r: DecodedField, valType: ColType): string {
         if (valType === 'hex') {
             return `0x${v.toString(16).toUpperCase().padStart(Math.max(1, Math.ceil(width / 4)), '0')}`;
         }
-        if (valType === 'bin') {
+        if (valType === 'bin' || valType === 'bin-sliced') {
             const bits = v.toString(2).padStart(width, '0');
             const groups = bits.match(/.{1,4}/g) || [];
             return groups.join(' ');
@@ -1239,7 +1305,7 @@ function getCopyText(r: DecodedField, valType: ColType): string {
         const v = dv.getUint32(0, le) >>> 0;
         return hexPad(v, 8);
     }
-    if (valType === 'bin') {
+    if (valType === 'bin' || valType === 'bin-sliced') {
         const bitSeq = bytes.map(b => b.toString(2).padStart(8, '0')).join('');
         const groups = bitSeq.match(/.{1,4}/g) || [];
         return groups.join(' ');
@@ -1445,13 +1511,15 @@ function bitUnitHeaderHtml(
     })();
 
     const v = t === 'bin'
+        ? renderBinaryStorageUnit(agg, activeRange)
+        : t === 'bin-sliced'
         ? renderBinaryFromBitRows(
             rows,
             activeRange,
         )
         : getValForType(agg, t);
     const ptr = agg.type === 'pointer';
-    const valHtml = (t === 'bin' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
+    const valHtml = (t === 'bin' || t === 'bin-sliced' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
     const byteCount = agg.bytesHex.length > 0 ? agg.bytesHex.split(' ').length : cnt;
     const abbrevBase = TYPE_ABBREV[agg.type] ?? agg.type;
     const abbrev = agg.type === 'ascii' ? `${abbrevBase}[${byteCount}]` : abbrevBase;
@@ -2254,8 +2322,9 @@ function wireInstanceCards(sec: HTMLElement): void {
             // Determine if this is a pointer field
             const valCell = row.querySelector<HTMLElement>('.si-f-val');
             const isPointer = valCell?.classList.contains('si-f-ptr');
+            const isBitUnitHeader = row.classList.contains('si-bitunit-hdr');
             // Only allow per-element change, not group, for array elements
-            showFieldValMenu(ev.clientX, ev.clientY, start, undefined, pinIdx, { isPointer });
+            showFieldValMenu(ev.clientX, ev.clientY, start, undefined, pinIdx, { isPointer, isBitUnitHeader });
         });
     });
 
@@ -2385,7 +2454,7 @@ function hideFieldValMenu(): void {
     if (_valMenuEl) { _valMenuEl.remove(); _valMenuEl = null; }
     document.removeEventListener('click', hideFieldValMenu);
 }
-function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], pinIdx?: number, opts?: { isPointer?: boolean, isArrayHeader?: boolean }): void {
+function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], pinIdx?: number, opts?: { isPointer?: boolean, isArrayHeader?: boolean, isBitUnitHeader?: boolean }): void {
     hideFieldValMenu();
     // Determine candidate display types based on the field's native type.
     const sampleAddr = (bsList && bsList.length > 0) ? bsList[0] : bs;
@@ -2413,7 +2482,9 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
     const isBitSample = sampleField ? isBitFieldRow(sampleField) : false;
     const isFloatSample = sampleType === 'float32' || sampleType === 'float64';
     const isAsciiSample = sampleType === 'ascii';
-    const types: ColType[] = isFloatSample
+    const types: ColType[] = opts?.isBitUnitHeader
+        ? ['bin', 'bin-sliced', 'hex', 'dec']
+        : isFloatSample
         ? ['hex', 'dec', 'ieee', 'bin']
         : isAsciiSample
             ? ['ascii', 'hex', 'bin']
@@ -2426,7 +2497,7 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
         const allSame = vals.every(v => v === vals[0]);
         cur = allSame ? (vals[0] as ColType) : null;
     } else {
-        cur = _fieldValTypes.get(bs) ?? (isBitSample ? 'bin' : _defaultValType);
+        cur = _fieldValTypes.get(bs) ?? ((isBitSample || opts?.isBitUnitHeader) ? 'bin' : _defaultValType);
     }
 
     // Helpers for menu
@@ -2444,7 +2515,7 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
 
     // Array header: copy start address + view-as for all elements
     if (opts?.isArrayHeader) {
-        const TYPE_LABELS_FULL: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', ascii: 'ASCII', ieee: 'IEEE754' };
+        const TYPE_LABELS_FULL: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit field sliced)', ascii: 'ASCII', ieee: 'IEEE754' };
         const dispMenu = types.map(t =>
             `<div class="ctx-row${t === cur ? ' active' : ''}" data-cmd="disp-${t}">` +
             `<span class="ctx-label">${TYPE_LABELS_FULL[t]}</span>` +
@@ -2553,7 +2624,7 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
         return;
     }
 
-    const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', ascii: 'ASCII', ieee: 'IEEE754' };
+    const TYPE_LABELS: Record<ColType, string> = { hex: 'Hex', dec: 'Decimal', bin: 'Binary', 'bin-sliced': 'Binary (bit field sliced)', ascii: 'ASCII', ieee: 'IEEE754' };
 
     // Copy submenu
     const copyMenu = types.map(t =>
@@ -2631,7 +2702,7 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
                 const t = cmd.replace('disp-', '') as ColType;
                 const field = findFieldAt(bs);
                 const ft = field?.type ?? null;
-                const implicit = field && isBitFieldRow(field)
+                const implicit = opts?.isBitUnitHeader || (field && isBitFieldRow(field))
                     ? 'bin'
                     : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
                 if (t === implicit) { _fieldValTypes.delete(bs); }

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -146,6 +146,19 @@ function binaryGroupsLowBitsFirst(bits: string): string[] {
     return groups;
 }
 
+function renderBinarySpanLines(spans: string[]): string {
+    const groups: string[] = [];
+    for (let i = 0; i < spans.length; i += 4) {
+        groups.push(spans.slice(i, i + 4).join(''));
+    }
+
+    const lines: string[] = [];
+    for (let i = 0; i < groups.length; i += 4) {
+        lines.push(groups.slice(i, i + 4).join(' '));
+    }
+    return `<span class="si-bin-wrap">${lines.join('<br>')}</span>`;
+}
+
 function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
     const byteStart = parseInt(row.dataset.byteStart ?? '', 10);
     const bitStart = parseInt(row.dataset.bitStart ?? '', 10);
@@ -215,11 +228,7 @@ function renderBinaryFromBitRows(
             const selected = !!selectedRange && bitIdx >= selectedRange.startBit && bitIdx <= selectedRange.endBit;
             return renderBitSpan(bit, bitIdx, selected);
         });
-        const groups: string[] = [];
-        for (let i = 0; i < spans.length; i += 4) {
-            groups.push(spans.slice(i, i + 4).join(''));
-        }
-        return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+        return renderBinarySpanLines(spans);
     }
 
     const spans: string[] = [];
@@ -230,11 +239,7 @@ function renderBinaryFromBitRows(
         spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`);
     }
 
-    const groups: string[] = [];
-    for (let i = 0; i < spans.length; i += 4) {
-        groups.push(spans.slice(i, i + 4).join(''));
-    }
-    return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+    return renderBinarySpanLines(spans);
 }
 
 function renderBinaryStorageUnit(
@@ -251,11 +256,7 @@ function renderBinaryStorageUnit(
             const sel = selected ? ' sel' : '';
             return `<span class="si-bit unknown${sel}" data-bit-idx="${bitIdx}">?</span>`;
         });
-        const groups: string[] = [];
-        for (let i = 0; i < spans.length; i += 4) {
-            groups.push(spans.slice(i, i + 4).join(''));
-        }
-        return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+        return renderBinarySpanLines(spans);
     }
 
     const bytes = rawParts.map(h => parseInt(h, 16));
@@ -273,11 +274,7 @@ function renderBinaryStorageUnit(
         }
     }
 
-    const groups: string[] = [];
-    for (let i = 0; i < spans.length; i += 4) {
-        groups.push(spans.slice(i, i + 4).join(''));
-    }
-    return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+    return renderBinarySpanLines(spans);
 }
 
 function fieldRowHtml(

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -84,11 +84,6 @@ function sanitizeCIdent(raw: string): string {
     return raw.replace(/[^A-Za-z0-9_]/g, '').replace(/^(\d)/, '_$1');
 }
 
-function isBitCapableType(type: StructFieldType): boolean {
-    return type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64' ||
-        type === 'int8' || type === 'int16' || type === 'int32' || type === 'int64';
-}
-
 function isBitFieldRow(r: DecodedField): boolean {
     return r.isBitField === true && typeof r.bitWidth === 'number';
 }
@@ -99,12 +94,6 @@ function usedBitsInContainer(f: import('./types').StructField): number {
         return 0;
     }
     return f.bitFields.reduce((sum, child) => sum + child.bitWidth, 0);
-}
-
-/** Get maximum bit capacity for a field type (for bit-field containers). */
-function getMaxBitsForType(type: import('./types').StructFieldType): number {
-    const typeSize = fieldByteSize(type as any);
-    return typeSize ? typeSize * 8 : 8;
 }
 
 /** Calculate available bits remaining in a bit-field container. */
@@ -214,15 +203,12 @@ function fieldRowHtml(
     const isArr = f.count > 1;
     const isUnsigned = isUnsignedScalarType(f.type);
     const isBitContainer = isUnsigned && Array.isArray(f.bitFields) && f.bitFields.length > 0;
-    const bitToggled = isUnsigned && ((isBitContainer) || (typeof f.bitWidth === 'number' && f.bitWidth > 0));
-    const bitCapable = isBitCapableType(f.type);
-    const hasLegacyBit = bitCapable && typeof f.bitWidth === 'number' && f.bitWidth > 0;
+    const bitToggled = isUnsigned && isBitContainer;
     const delCell = isOnly
         ? `<span class="sfe-del-placeholder"></span>`
         : `<button class="sfe-del-btn" title="Remove field">\u2715</button>`;
     const upDis  = i === 0         ? ' disabled' : '';
     const dnDis  = i === total - 1 ? ' disabled' : '';
-    const bfCollapsed = f.bitFieldsCollapsed === true;
 
     // ── Child bitfield rows ──
     let childrenHtml = '';
@@ -233,12 +219,10 @@ function fieldRowHtml(
         const addBtnDisabled = !canAddMore ? ' disabled' : '';
         const addBtnTitle = canAddMore ? 'Add bit-field child' : 'No bits remaining in parent';
         childrenHtml =
-            `<div class="sfe-bf-children"${bfCollapsed ? ' style="display:none"' : ''}>` +
+            `<div class="sfe-bf-children"${f.bitFieldsCollapsed === true ? ' style="display:none"' : ''}>` +
             childRows +
             `<button class="sfe-bf-add-child" title="${addBtnTitle}"${addBtnDisabled}>+ Add bit</button>` +
             `</div>`;
-    } else if (hasLegacyBit) {
-        // Legacy single-bitWidth: auto-migrate will happen on save
     }
 
     // :N toggle button
@@ -252,7 +236,7 @@ function fieldRowHtml(
                `placeholder="fieldName" spellcheck="false" autocomplete="off">` +
         `<button class="sfe-bit-btn${bitBtnClass}" title="Toggle bit-field details"${bitBtnDisabled}>:N</button>` +
         `<div class="sfe-arr-cell${isArr ? ' is-array' : ''}">` +
-         `<button class="sfe-arr-toggle${isArr ? ' active' : ''}" title="${isArr ? 'Remove array' : 'Make array'}"${bitToggled ? ' disabled' : ''}>[ ]</button>` +
+         `<button class="sfe-arr-toggle${isArr ? ' active' : ''}" title="${isArr ? 'Remove array' : 'Make array'}">[ ]</button>` +
         `<input class="sfe-count-inp" type="text" inputmode="numeric" ` +
                `value="${isArr ? f.count : ''}" placeholder="N" maxlength="3">` +
         `</div>` +
@@ -438,7 +422,6 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
 
         // Parse child bit-field rows if toggled on and unsigned
         let bitFields: import('./types').BitFieldChild[] | undefined;
-        let bitWidth: number | undefined;
         if (bitBtnOn && isUnsigned && childrenContainer) {
             const childRows = childrenContainer.querySelectorAll<HTMLElement>('.sfe-bf-child-row');
             const childArray: import('./types').BitFieldChild[] = Array.from(childRows).map(childRow => {
@@ -452,29 +435,13 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
                     bitWidth: Number.isInteger(childWidth) && childWidth > 0 ? Math.min(childWidth, 64) : 1,
                 };
             });
-            // Validate: sum of child widths must fit in parent type
-            // Auto-create one child if empty
             if (childArray.length === 0) {
-                const unitBits = fieldByteSize(type as import('./types').StructScalarFieldType) * 8;
-                childArray.push({ name: 'bit0', bitWidth: unitBits });
+                childArray.push({ name: 'bit0', bitWidth: 1 });
             }
             bitFields = childArray;
-            // Keep the collapsed state
-            const collapsed = childrenContainer.style.display === 'none';
-            const bfCollapsed = collapsed || undefined;
         }
-
-        if (!bitFields) {
-            // Check for legacy single bitWidth — migrated from old data
-            // For backward compat: read from bitWidth in the field if saved
-        }
-
-        const bitCollapsed = bitBtnOn && isUnsigned && childrenContainer
-            ? (childrenContainer.style.display === 'none') || undefined
-            : undefined;
 
         const count = (() => {
-            if (bitFields) { return (row.dataset as { arrSfe?: string }).arrSfe === 'true' ? (parseInt((row.querySelector('.sfe-count-inp') as HTMLInputElement).value) || 1) : 1; }
             const cell = row.querySelector<HTMLElement>('.sfe-arr-cell')!;
             if (!cell.classList.contains('is-array')) { return 1; }
             const v = parseInt((row.querySelector('.sfe-count-inp') as HTMLInputElement).value);
@@ -490,7 +457,7 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
         };
         if (bitFields && bitFields.length > 0) {
             result.bitFields = bitFields;
-            if (bitCollapsed) { result.bitFieldsCollapsed = true; }
+            if (childrenContainer?.style.display === 'none') { result.bitFieldsCollapsed = true; }
         }
         return result;
     });
@@ -498,7 +465,7 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
 
 function wireEditorInSec(sec: HTMLElement): void {
     if (!_editingType) { return; }
-    const { draft, existing } = _editingType;
+    const { draft } = _editingType;
 
     sec.querySelector('#se-packed')!.addEventListener('click', () => {
         const btn = sec.querySelector('#se-packed')!;
@@ -557,7 +524,6 @@ function wireEditorInSec(sec: HTMLElement): void {
 
     sec.querySelectorAll<HTMLElement>('.sfe-arr-toggle').forEach(btn => {
         btn.addEventListener('click', () => {
-            if ((btn as HTMLButtonElement).disabled) { return; }
             const cell = btn.closest<HTMLElement>('.sfe-arr-cell')!;
             const nowArr = !cell.classList.contains('is-array');
             cell.classList.toggle('is-array', nowArr);
@@ -593,25 +559,15 @@ function wireEditorInSec(sec: HTMLElement): void {
                 btn.classList.remove('sfe-bit-btn-on');
                 delete f.bitFields;
                 delete f.bitFieldsCollapsed;
-                f.bitWidth = undefined;
                 const children = row.querySelector<HTMLElement>('.sfe-bf-children');
                 if (children) { children.remove(); }
                 row.classList.remove('has-bit-children');
-                // Re-enable array toggle
-                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
-                if (arrBtn) { arrBtn.disabled = false; }
             } else {
                 // Toggle ON: create default first child with 1 bit width
                 btn.classList.add('sfe-bit-btn-on');
                 row.classList.add('has-bit-children');
                 f.bitFields = [{ name: 'bit0', bitWidth: 1 }];
                 f.bitFieldsCollapsed = undefined;
-                // Disable array toggle
-                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
-                if (arrBtn) { arrBtn.disabled = true; }
-                const arrCell = row.querySelector<HTMLElement>('.sfe-arr-cell');
-                if (arrCell) { arrCell.classList.remove('is-array'); }
-                f.count = 1;
             }
             // Update preview without re-syncing (refreshEditorPreview would overwrite our changes)
             const pre = sec.querySelector<HTMLElement>('#se-preview pre');
@@ -647,12 +603,8 @@ function wireEditorInSec(sec: HTMLElement): void {
             const ci = parseInt(childRow.dataset.childIdx!);
             f.bitFields.splice(ci, 1);
             if (f.bitFields.length === 0) {
-                // No children left → toggle bit mode off
-                const bitBtn = parentRow.querySelector<HTMLElement>('.sfe-bit-btn');
-                if (bitBtn) { bitBtn.classList.remove('sfe-bit-btn-on'); }
-                parentRow.classList.remove('has-bit-children');
-                delete f.bitFields;
-                delete f.bitFieldsCollapsed;
+                // Empty containers auto-recover with a 1-bit child.
+                f.bitFields.push({ name: 'bit0', bitWidth: 1 });
             }
             renderStructPins();
         });
@@ -706,8 +658,6 @@ function wireEditorInSec(sec: HTMLElement): void {
             const row = sel.closest<HTMLElement>('.struct-field-row');
             if (row) {
                 const bitBtn = row.querySelector<HTMLElement>('.sfe-bit-btn');
-                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
-                const arrCell = row.querySelector<HTMLElement>('.sfe-arr-cell');
                 const rawType = sel.value;
                 const isStruct = rawType.startsWith('struct:');
                 const isUnsigned = !isStruct && (rawType === 'uint8' || rawType === 'uint16' || rawType === 'uint32' || rawType === 'uint64');
@@ -722,11 +672,8 @@ function wireEditorInSec(sec: HTMLElement): void {
                     syncEditorDraft(sec, draft);
                     const idx = parseInt(row.dataset.idx!);
                     const f = draft.fields[idx];
-                    if (f) { delete f.bitFields; delete f.bitFieldsCollapsed; f.bitWidth = undefined; }
-                    (arrBtn as HTMLButtonElement).disabled = false;
+                    if (f) { delete f.bitFields; delete f.bitFieldsCollapsed; }
                 }
-                if (arrBtn) { (arrBtn as HTMLButtonElement).disabled = bitToggled || !isUnsigned && false; }
-                if (bitToggled && arrCell) { arrCell.classList.remove('is-array'); }
             }
             refreshEditorPreview(sec, draft);
         });
@@ -1397,17 +1344,6 @@ function parseArrayIndex(fieldPath: string, baseName: string): number | null {
     return isNaN(idx) ? null : idx;
 }
 
-function indexedLeafName(fieldPath: string, baseName: string, idx: number): string {
-    const prefix = `${baseName}[${idx}].`;
-    if (fieldPath.startsWith(prefix)) {
-        const nested = fieldPath.slice(prefix.length);
-        const parts = nested.split('.').filter(Boolean);
-        return parts.length > 0 ? parts[parts.length - 1] : nested;
-    }
-    const parts = fieldPath.split('.').filter(Boolean);
-    return parts.length > 0 ? parts[parts.length - 1] : fieldPath;
-}
-
 function indexOnlyName(fieldPath: string, baseName: string): string {
     const idx = parseArrayIndex(fieldPath, baseName);
     return idx === null ? leafName(fieldPath) : `[${idx}]`;
@@ -1571,6 +1507,53 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             return r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
         };
 
+        const renderBitUnitLeafRows = (unitRows: DecodedField[]): string => {
+            const labels = disambiguateLeafNames(unitRows.map(r => leafName(r.fieldName)));
+            return unitRows.map((r, idx) =>
+                mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), labels[idx])
+            ).join('');
+        };
+
+        const renderBitUnitArrayElements = (
+            unitRows: DecodedField[],
+            baseName: string,
+            parentKey: string,
+            typeLabel: string,
+        ): string => {
+            type ElementGroup = { idx: number; rows: DecodedField[] };
+            const elements: ElementGroup[] = [];
+            for (const r of unitRows) {
+                const idx = parseArrayIndex(r.fieldName, baseName);
+                if (idx === null) { continue; }
+                const last = elements[elements.length - 1];
+                if (last && last.idx === idx) { last.rows.push(r); }
+                else { elements.push({ idx, rows: [r] }); }
+            }
+            return elements.map(element => {
+                const first = element.rows[0];
+                const elementByteStart = pin.addr + first.byteOffset;
+                const elementByteCnt = rowByteCnt(first);
+                const elementKey = `${parentKey}::${element.idx}`;
+                const isElementOpen = _expandedArrayElements.has(elementKey);
+                const elementRowsHtml = renderBitUnitLeafRows(element.rows);
+                return (
+                    `<div class="si-arr-el-grp${isElementOpen ? ' open' : ''}" data-arr-el-key="${esc(elementKey)}">` +
+                    `<div class="si-arr-el-hdr" data-arr-el-key="${esc(elementKey)}" data-byte-start="${elementByteStart}" data-byte-cnt="${elementByteCnt}">` +
+                    `<span class="si-node-pad" aria-hidden="true"></span>` +
+                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                    `<button class="si-arr-el-exp-btn">${isElementOpen ? '▾' : '▸'}</button>` +
+                    `<span class="si-f-body">` +
+                    `<span class="si-f-name">[${element.idx}]</span>` +
+                    `<span class="si-f-lead"></span>` +
+                    `<span class="si-arr-addr">${esc(typeLabel)}</span>` +
+                    `</span>` +
+                    `</div>` +
+                    `<div class="si-arr-el-body"${isElementOpen ? '' : ' style=\"display:none\"'}>${elementRowsHtml}</div>` +
+                    `</div>`
+                );
+            }).join('');
+        };
+
         const renderStructChildren = (structRows: DecodedField[], structBase: string, parentKey: string): string => {
             const structPrefix = `${structBase}.`;
             const nestedGroups: Array<{ baseRel: string; fullBase: string; rows: DecodedField[] }> = [];
@@ -1605,12 +1588,14 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const nestedSummary = nestedIsStruct
                     ? (nestedCount > 1 ? `${nestedStructName}[${nestedCount}]` : nestedStructName)
                     : `${nestedTypeAbbrev}[${nestedCount}]`;
-                const nestedSummaryLabel = groupSummaryLabel(ng.rows, nestedSummary);
+                const nestedSummaryLabel = nestedIsBitUnit && nestedCount > 1
+                    ? nestedSummary
+                    : groupSummaryLabel(ng.rows, nestedSummary);
                 const nestedKey = `${parentKey}::${ng.baseRel}`;
                 const nestedOpen = _expandedArrayFields.has(nestedKey);
                 const nestedStart = pin.addr + ng.rows[0].byteOffset;
-                const nestedCnt = nestedIsBitUnit
-                    ? rowByteCnt(ng.rows[0])
+                const nestedCnt = nestedIsBitUnit && nestedCount > 1
+                    ? rowByteCnt(ng.rows[0]) * nestedCount
                     : ng.rows.reduce((s, r) => s + rowByteCnt(r), 0);
 
                 let nestedBodyHtml = '';
@@ -1651,15 +1636,17 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                             `</div>`
                         );
                     }).join('');
+                } else if (nestedIsBitUnit && nestedCount > 1) {
+                    nestedBodyHtml = renderBitUnitArrayElements(
+                        ng.rows,
+                        ng.fullBase,
+                        nestedKey,
+                        nestedTypeAbbrev,
+                    );
                 } else if (nestedIsStruct && nestedCount === 1) {
                     nestedBodyHtml = renderStructChildren(ng.rows, ng.fullBase, nestedKey);
                 } else if (nestedIsBitUnit) {
-                    const nestedLeafNames = disambiguateLeafNames(
-                        ng.rows.map(r => leafName(r.fieldName))
-                    );
-                    nestedBodyHtml = ng.rows.map((r, idx) =>
-                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), nestedLeafNames[idx])
-                    ).join('');
+                    nestedBodyHtml = renderBitUnitLeafRows(ng.rows);
                 } else if (!nestedIsStruct && nestedCount > 1 && !nestedIsString) {
                     nestedBodyHtml = ng.rows.map(r =>
                         mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, ng.fullBase))
@@ -1675,19 +1662,16 @@ function buildInstanceCard(pin: StructPin, i: number): string {
 
                 return (
                     `<div class="si-arr-grp${nestedOpen ? ' open' : ''}" data-arr-key="${esc(nestedKey)}">` +
-                    (nestedIsBitUnit
-                        ? bitUnitHeaderHtml(ng.rows, nestedStart, nestedCnt, nestedOpen)
-                        : (`<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
-                           `<span class="si-node-pad" aria-hidden="true"></span>` +
-                           `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                           `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
-                           `<span class="si-f-body">` +
-                           `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel, ng.rows))}</span>` +
-                           `<span class="si-f-lead"></span>` +
-                           `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
-                           `</span>` +
-                           `</div>`)
-                    ) +
+                    `<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
+                    `<span class="si-node-pad" aria-hidden="true"></span>` +
+                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                    `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
+                    `<span class="si-f-body">` +
+                    `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel, ng.rows))}</span>` +
+                    `<span class="si-f-lead"></span>` +
+                    `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
+                    `</span>` +
+                    `</div>` +
                     `<div class="si-arr-grp-body"${nestedOpen ? '' : ' style=\"display:none\"'}>${nestedBodyHtml}</div>` +
                     `</div>`
                 );
@@ -1724,16 +1708,18 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             const key     = `${pin.id}::${g.baseName}`;
             const isOpen  = _expandedArrayFields.has(key);
             const byteStart = pin.addr + r0.byteOffset;
-            const totalCnt  = isBitUnit
-                ? rowByteCnt(g.rows[0])
+            const totalCnt  = isBitUnit && isArray
+                ? rowByteCnt(g.rows[0]) * declaredCount
                 : g.rows.reduce((s, r) => s + rowByteCnt(r), 0);
-            let elHtml     = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r))).join('');
                 const structName = declared?.structName ?? 'struct';
                 const scalarType = TYPE_ABBREV[declaredType] ?? declaredType;
                 const nodeSummary = isStruct
                     ? (isArray ? `${structName}[${declaredCount}]` : structName)
                     : `${scalarType}[${declaredCount}]`;
-                const nodeSummaryFull = groupSummaryLabel(g.rows, nodeSummary);
+                const nodeSummaryFull = isBitUnit && isArray
+                    ? nodeSummary
+                    : groupSummaryLabel(g.rows, nodeSummary);
+            let elHtml = '';
 
                 if (isStruct && isArray) {
                     type ElementGroup = { idx: number; rows: DecodedField[] };
@@ -1774,13 +1760,12 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                             );
                         }).join('');
                     }
+                } else if (isBitUnit && isArray) {
+                    elHtml = renderBitUnitArrayElements(g.rows, g.baseName, key, scalarType);
                 } else if (isStruct && !isArray) {
                     elHtml = renderStructChildren(g.rows, g.baseName, key);
                 } else if (isBitUnit) {
-                    const labels = disambiguateLeafNames(g.rows.map(r => leafName(r.fieldName)));
-                    elHtml = g.rows.map((r, idx) =>
-                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), labels[idx])
-                    ).join('');
+                    elHtml = renderBitUnitLeafRows(g.rows);
                 } else if (!isStruct && isArray) {
                     elHtml = g.rows.map(r =>
                         mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, g.baseName))
@@ -1788,19 +1773,19 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 }
             return (
                 `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
-                (isBitUnit
+                (isBitUnit && !isArray
                     ? bitUnitHeaderHtml(g.rows, byteStart, totalCnt, isOpen)
-                    : (`<div class="si-arr-grp-hdr" ` +
-                       `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
-                       `<span class="si-node-pad" aria-hidden="true"></span>` +
-                       `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                       `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
-                       `<span class="si-f-body">` +
-                       `<span class="si-f-name">${esc(groupHeaderName(g.baseName, g.rows))}</span>` +
-                       `<span class="si-f-lead"></span>` +
-                       `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummaryFull)}</span>` +
-                       `</span>` +
-                       `</div>`)
+                    : `<div class="si-arr-grp-hdr" ` +
+                      `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
+                      `<span class="si-node-pad" aria-hidden="true"></span>` +
+                      `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                      `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+                      `<span class="si-f-body">` +
+                      `<span class="si-f-name">${esc(groupHeaderName(g.baseName, g.rows))}</span>` +
+                      `<span class="si-f-lead"></span>` +
+                      `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummaryFull)}</span>` +
+                      `</span>` +
+                      `</div>`
                 ) +
                 `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
                 `</div>`

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -126,6 +126,26 @@ function bitUnitValKey(byteStart: number): string {
     return `bitunit:${byteStart}`;
 }
 
+function bitRowWidth(row: DecodedField | null | undefined): number {
+    return isBitFieldRow(row as DecodedField) ? row?.bitWidth ?? 0 : 0;
+}
+
+function bitUnitUsesFullStorage(rows: DecodedField[]): boolean {
+    const first = rows[0];
+    if (!first || !isBitFieldRow(first)) { return false; }
+    const usedBits = rows.reduce((sum, row) => sum + bitRowWidth(row), 0);
+    const storageBits = (first.bitStorageByteSize ?? fieldByteSize(first.type)) * 8;
+    return usedBits >= storageBits;
+}
+
+function binaryGroupsLowBitsFirst(bits: string): string[] {
+    const groups: string[] = [];
+    for (let end = bits.length; end > 0; end -= 4) {
+        groups.unshift(bits.slice(Math.max(0, end - 4), end));
+    }
+    return groups;
+}
+
 function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
     const byteStart = parseInt(row.dataset.byteStart ?? '', 10);
     const bitStart = parseInt(row.dataset.bitStart ?? '', 10);
@@ -1150,7 +1170,7 @@ function getValForType(r: DecodedField, valType: ColType): string {
         }
         if (valType === 'bin' || valType === 'bin-sliced') {
             const bits = v.toString(2).padStart(width, '0');
-            const groups = bits.match(/.{1,4}/g) || [];
+            const groups = binaryGroupsLowBitsFirst(bits);
             const html = groups.map(g => [...g].map(bit =>
                 `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}">${bit}</span>`
             ).join('')).join(' ');
@@ -1302,7 +1322,7 @@ function getCopyText(r: DecodedField, valType: ColType): string {
         }
         if (valType === 'bin' || valType === 'bin-sliced') {
             const bits = v.toString(2).padStart(width, '0');
-            const groups = bits.match(/.{1,4}/g) || [];
+            const groups = binaryGroupsLowBitsFirst(bits);
             return groups.join(' ');
         }
         return v.toString(10);
@@ -2509,7 +2529,7 @@ function showFieldValMenu(
     // Determine candidate display types based on the field's native type.
     const sampleAddr = (bsList && bsList.length > 0) ? bsList[0] : bs;
     const allDefs = allStructs();
-    const findFieldAt = (addr: number): DecodedField | null => {
+    const findRowsAt = (addr: number): DecodedField[] => {
         let pin: StructPin | undefined;
         if (typeof pinIdx === 'number' && pinIdx >= 0) { pin = S.structPins[pinIdx]; }
         else {
@@ -2520,12 +2540,14 @@ function showFieldValMenu(
                 return addr >= p.addr && addr < p.addr + size;
             });
         }
-        if (!pin) { return null; }
+        if (!pin) { return []; }
         const def = allDefs.find(d => d.id === pin.structId);
-        if (!def) { return null; }
+        if (!def) { return []; }
         const rows = decodeStruct(def, pin.addr, getByte, S.endian);
-        const r = rows.find(rr => pin!.addr + rr.byteOffset === addr);
-        return r ?? null;
+        return rows.filter(rr => pin!.addr + rr.byteOffset === addr);
+    };
+    const findFieldAt = (addr: number): DecodedField | null => {
+        return findRowsAt(addr)[0] ?? null;
     };
     const sampleField = findFieldAt(sampleAddr);
     const sampleType = sampleField?.type ?? null;
@@ -2534,15 +2556,21 @@ function showFieldValMenu(
     const isAsciiSample = sampleType === 'ascii';
     const key = opts?.valKey ?? scalarValKey(bs);
     const arrayHasBitUnits = opts?.isArrayHeader && opts.keyList?.some(k => k.startsWith('bitunit:'));
-    const types: ColType[] = opts?.isBitUnitHeader || arrayHasBitUnits
-        ? ['bin', 'bin-sliced', 'hex', 'dec']
-        : isFloatSample
-        ? ['hex', 'dec', 'ieee', 'bin']
-        : isAsciiSample
-            ? ['ascii', 'hex', 'bin']
-            : isBitSample
-                ? ['bin', 'hex', 'dec']
-                : ['hex', 'dec', 'bin', 'ascii'];
+    const bitUnitTypes = (addresses: number[]): ColType[] => {
+        const hasPartialUnit = addresses.some(addr => !bitUnitUsesFullStorage(findRowsAt(addr)));
+        return hasPartialUnit ? ['bin', 'bin-sliced', 'hex', 'dec'] : ['bin', 'hex', 'dec'];
+    };
+    const types: ColType[] = opts?.isBitUnitHeader
+        ? bitUnitTypes([bs])
+        : arrayHasBitUnits
+            ? bitUnitTypes(bsList ?? [bs])
+            : isFloatSample
+                ? ['hex', 'dec', 'ieee', 'bin']
+                : isAsciiSample
+                    ? ['ascii', 'hex', 'bin']
+                    : isBitSample
+                        ? ['bin', 'hex', 'dec']
+                        : ['hex', 'dec', 'bin', 'ascii'];
     let cur: ColType | null = null;
     if (bsList && bsList.length > 0) {
         const vals = bsList.map((b, idx) => {
@@ -2833,6 +2861,7 @@ export function onSelectionChangeForStruct(): void {
     _selectedPinId     = null;
     if (S.selStart === null) { return; }
     S.activeStructAddr = S.selStart;
+    if (typeof document === 'undefined') { return; }
     if (S.sidebarTab === 'struct') {
         const addrHex = S.selStart.toString(16).toUpperCase().padStart(8, '0');
         if (_addingPin) {

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1,7 +1,7 @@
-﻿// ── Struct Overlay — UI layer ─────────────────────────────────────
-// Single section rendered into #s-struct-pins.
-// Type management (create / edit / delete) is inline within that section.
-// Pure codec logic lives in struct-codec.ts.
+﻿/** Struct Overlay — UI layer
+Single section rendered into #s-struct-pins.
+Type management (create / edit / delete) is inline within that section.
+Pure codec logic lives in struct-codec.ts. */
 
 import { S }        from './state';
 import { esc, actionBtnsHtml, wireActionBtns, formatDecimal, formatHex, formatHexHtml, getBigUint64, getBigInt64, asUint64 } from './utils';
@@ -48,6 +48,14 @@ let _selectedFieldAddr: number | null = null;
 let _selectedArrKey: string | null = null;
 /** Nested array element key of the currently highlighted element header. */
 let _selectedArrElemKey: string | null = null;
+/** Selected bit-field range to highlight on its parent bit-unit value. */
+let _selectedBitRange: { parentByteStart: number; startBit: number; endBit: number } | null = null;
+/** Hovered bit-field range to preview highlight on parent bit-unit value. */
+let _hoveredBitRange: { parentByteStart: number; startBit: number; endBit: number } | null = null;
+/** Selected bit-field child row identity: `${byteStart}:${bitStart}:${bitWidth}`. */
+let _selectedBitRowKey: string | null = null;
+/** Hovered bit-field child row identity: `${byteStart}:${bitStart}:${bitWidth}`. */
+let _hoveredBitRowKey: string | null = null;
 /** Byte start addresses marked with struct-arr-sep in the hex view. */
 const _arrSepAddrs: number[] = [];
 /** Pin id of the currently selected instance card. */
@@ -76,6 +84,113 @@ function sanitizeCIdent(raw: string): string {
     return raw.replace(/[^A-Za-z0-9_]/g, '').replace(/^(\d)/, '_$1');
 }
 
+function isBitCapableType(type: StructFieldType): boolean {
+    return type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64' ||
+        type === 'int8' || type === 'int16' || type === 'int32' || type === 'int64';
+}
+
+function isBitFieldRow(r: DecodedField): boolean {
+    return r.isBitField === true && typeof r.bitWidth === 'number';
+}
+
+/** Calculate total bits used by all children in a bit-field container. */
+function usedBitsInContainer(f: import('./types').StructField): number {
+    if (!Array.isArray(f.bitFields)) {
+        return 0;
+    }
+    return f.bitFields.reduce((sum, child) => sum + child.bitWidth, 0);
+}
+
+/** Get maximum bit capacity for a field type (for bit-field containers). */
+function getMaxBitsForType(type: import('./types').StructFieldType): number {
+    const typeSize = fieldByteSize(type as any);
+    return typeSize ? typeSize * 8 : 8;
+}
+
+/** Calculate available bits remaining in a bit-field container. */
+function availableBitsInContainer(f: import('./types').StructField): number {
+    if (!isUnsignedScalarType(f.type)) { return 0; }
+    const typeBytes = fieldByteSize(f.type);
+    const totalBits = typeBytes * 8;
+    const usedBits = usedBitsInContainer(f);
+    return totalBits - usedBits;
+}
+
+function renderBitSpan(bit: string, idx: number, selected: boolean): string {
+    const sel = selected ? ' sel' : '';
+    return `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}${sel}" data-bit-idx="${idx}">${bit}</span>`;
+}
+
+function makeBitRowKey(byteStart: number, bitStart: number, bitWidth: number): string {
+    return `${byteStart}:${bitStart}:${bitWidth}`;
+}
+
+function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
+    const byteStart = parseInt(row.dataset.byteStart ?? '', 10);
+    const bitStart = parseInt(row.dataset.bitStart ?? '', 10);
+    const bitWidth = parseInt(row.dataset.bitWidth ?? '', 10);
+    if (!Number.isFinite(byteStart) || !Number.isFinite(bitStart) || !Number.isFinite(bitWidth) || bitWidth <= 0) {
+        return null;
+    }
+    return { byteStart, bitStart, bitWidth };
+}
+
+function applyBitHighlightsInPlace(sec: HTMLElement): void {
+    sec.querySelectorAll<HTMLElement>('.si-bit.hov').forEach(el => el.classList.remove('hov'));
+    sec.querySelectorAll<HTMLElement>('.si-bit.sel').forEach(el => el.classList.remove('sel'));
+
+    const applyRange = (
+        range: { parentByteStart: number; startBit: number; endBit: number } | null,
+        cls: 'sel' | 'hov',
+    ) => {
+        if (!range) { return; }
+        const parentVal = sec.querySelector<HTMLElement>(
+            `.si-arr-grp-hdr.si-bitunit-hdr[data-byte-start="${range.parentByteStart}"] .si-f-val[data-val-type="bin"]`
+        );
+        if (!parentVal) { return; }
+        for (let i = range.startBit; i <= range.endBit; i++) {
+            parentVal.querySelector<HTMLElement>(`.si-bit[data-bit-idx="${i}"]`)?.classList.add(cls);
+        }
+    };
+
+    applyRange(_selectedBitRange, 'sel');
+    applyRange(_hoveredBitRange, 'hov');
+}
+
+function renderBinaryFromBitRows(
+    rows: DecodedField[],
+    selectedRange?: { startBit: number; endBit: number } | null,
+): string {
+    const spans: string[] = [];
+    let idx = 0;
+    for (const r of rows) {
+        const w = r.bitWidth ?? 0;
+        if (w <= 0) { continue; }
+        if (!r.hasData) {
+            for (let i = 0; i < w; i++) {
+                const selected = !!selectedRange && idx >= selectedRange.startBit && idx <= selectedRange.endBit;
+                const sel = selected ? ' sel' : '';
+                spans.push(`<span class="si-bit unknown${sel}" data-bit-idx="${idx}">?</span>`);
+                idx += 1;
+            }
+            continue;
+        }
+        const v = BigInt(r.bitValueUnsigned ?? '0');
+        const bits = v.toString(2).padStart(w, '0');
+        for (const bit of bits) {
+            const selected = !!selectedRange && idx >= selectedRange.startBit && idx <= selectedRange.endBit;
+            spans.push(renderBitSpan(bit, idx, selected));
+            idx += 1;
+        }
+    }
+
+    const groups: string[] = [];
+    for (let i = 0; i < spans.length; i += 4) {
+        groups.push(spans.slice(i, i + 4).join(''));
+    }
+    return `<span class="si-bin-wrap">${groups.join(' ')}</span>`;
+}
+
 function fieldRowHtml(
     f: import('./types').StructField,
     i: number,
@@ -97,18 +212,47 @@ function fieldRowHtml(
         `<optgroup label="Scalar">${scalarOptions}</optgroup>` +
         (structOptions ? `<optgroup label="Struct">${structOptions}</optgroup>` : '');
     const isArr = f.count > 1;
+    const isUnsigned = isUnsignedScalarType(f.type);
+    const isBitContainer = isUnsigned && Array.isArray(f.bitFields) && f.bitFields.length > 0;
+    const bitToggled = isUnsigned && ((isBitContainer) || (typeof f.bitWidth === 'number' && f.bitWidth > 0));
+    const bitCapable = isBitCapableType(f.type);
+    const hasLegacyBit = bitCapable && typeof f.bitWidth === 'number' && f.bitWidth > 0;
     const delCell = isOnly
         ? `<span class="sfe-del-placeholder"></span>`
         : `<button class="sfe-del-btn" title="Remove field">\u2715</button>`;
     const upDis  = i === 0         ? ' disabled' : '';
     const dnDis  = i === total - 1 ? ' disabled' : '';
+    const bfCollapsed = f.bitFieldsCollapsed === true;
+
+    // ── Child bitfield rows ──
+    let childrenHtml = '';
+    if (isBitContainer) {
+        const childRows = f.bitFields!.map((child, ci) => childFieldRowHtml(child, ci, f.bitFields!.length)).join('');
+        const remainingBits = availableBitsInContainer(f);
+        const canAddMore = remainingBits > 0;
+        const addBtnDisabled = !canAddMore ? ' disabled' : '';
+        const addBtnTitle = canAddMore ? 'Add bit-field child' : 'No bits remaining in parent';
+        childrenHtml =
+            `<div class="sfe-bf-children"${bfCollapsed ? ' style="display:none"' : ''}>` +
+            childRows +
+            `<button class="sfe-bf-add-child" title="${addBtnTitle}"${addBtnDisabled}>+ Add bit</button>` +
+            `</div>`;
+    } else if (hasLegacyBit) {
+        // Legacy single-bitWidth: auto-migrate will happen on save
+    }
+
+    // :N toggle button
+    const bitBtnClass = bitToggled ? ' sfe-bit-btn-on' : '';
+    const bitBtnDisabled = !isUnsigned ? ' disabled' : '';
+
     return (
-        `<div class="struct-field-row" data-idx="${i}">` +
+        `<div class="struct-field-row${isBitContainer ? ' has-bit-children' : ''}" data-idx="${i}">` +
         `<select class="sfe-type-sel">${typeOpts}</select>` +
         `<input class="sfe-name-inp" type="text" value="${esc(f.name)}" maxlength="64" ` +
                `placeholder="fieldName" spellcheck="false" autocomplete="off">` +
+        `<button class="sfe-bit-btn${bitBtnClass}" title="Toggle bit-field details"${bitBtnDisabled}>:N</button>` +
         `<div class="sfe-arr-cell${isArr ? ' is-array' : ''}">` +
-        `<button class="sfe-arr-toggle${isArr ? ' active' : ''}" title="${isArr ? 'Remove array' : 'Make array'}">[ ]</button>` +
+         `<button class="sfe-arr-toggle${isArr ? ' active' : ''}" title="${isArr ? 'Remove array' : 'Make array'}"${bitToggled ? ' disabled' : ''}>[ ]</button>` +
         `<input class="sfe-count-inp" type="text" inputmode="numeric" ` +
                `value="${isArr ? f.count : ''}" placeholder="N" maxlength="3">` +
         `</div>` +
@@ -117,8 +261,43 @@ function fieldRowHtml(
         `<button class="sfe-move-btn sfe-move-dn" title="Move down"${dnDis}>&#x2192;</button>` +
         `</div>` +
         delCell +
+        childrenHtml +
         `</div>`
     );
+}
+
+/** Render a single bit-field child row inside a bit-field container parent. */
+function childFieldRowHtml(child: import('./types').BitFieldChild, ci: number, total: number): string {
+    const upDis  = ci === 0        ? ' disabled' : '';
+    const dnDis  = ci === total - 1 ? ' disabled' : '';
+    const delCell = total <= 1
+        ? `<span class="sfe-del-placeholder"></span>`
+        : `<button class="sfe-bf-del-child" title="Remove child">\u2715</button>`;
+    return (
+        `<div class="sfe-bf-child-row" data-child-idx="${ci}">` +
+        `<span class="sfe-bf-child-indent"></span>` +
+        `<input class="sfe-bf-child-name" type="text" value="${esc(child.name)}" maxlength="64" ` +
+               `placeholder="bit${ci}" spellcheck="false" autocomplete="off">` +
+        `<input class="sfe-bf-child-width" type="text" inputmode="numeric" value="${child.bitWidth}" ` +
+               `placeholder="N" maxlength="2">` +
+        `<span class="sfe-bf-child-unit">bit</span>` +
+        `<div class="sfe-bf-child-move">` +
+        `<button class="sfe-move-btn sfe-move-up" title="Move up"${upDis}>&#x2192;</button>` +
+        `<button class="sfe-move-btn sfe-move-dn" title="Move down"${dnDis}>&#x2192;</button>` +
+        `</div>` +
+        delCell +
+        `</div>`
+    );
+}
+
+/** Check if a field type is an unsigned scalar (eligible for bit-field container). */
+function isUnsignedScalarType(type: import('./types').StructFieldType): type is import('./types').StructScalarFieldType {
+    return type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64';
+}
+
+/** Get bit capacity for a parent field type. */
+function getParentBitCapacity(type: import('./types').StructFieldType): number {
+    return fieldByteSize(type as any) * 8;
 }
 
 // ── C syntax-highlighted struct preview ─────────────────────────────────────
@@ -230,7 +409,7 @@ function editorHtml(draft: StructDef, existing: StructDef | null): string {
                `maxlength="64" placeholder="TypeName" spellcheck="false" autocomplete="off">` +
         `<button id="se-packed" class="se-packed-btn${draft.packed ? ' active' : ''}" ` +
                `title="Toggle packed struct">__attribute__((packed))</button>` +
-        `<div class="se-field-hdr"><span>Type</span><span>Name</span><span>[ ]</span><span></span></div>` +
+         `<div class="se-field-hdr"><span>Type</span><span>Name</span><span>Bits</span><span>[ ]</span><span></span></div>` +
         `<div id="se-fields">${fieldRows}</div>` +
         `<button id="se-add" class="struct-add-field-btn">+ Add Field</button>` +
         errorHtml +
@@ -253,18 +432,67 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
         const isStruct = rawType.startsWith('struct:');
         const refStructId = isStruct ? rawType.slice('struct:'.length) : undefined;
         const type = (isStruct ? 'struct' : rawType) as StructFieldType;
-        return {
+        const bitBtnOn = row.querySelector('.sfe-bit-btn')?.classList.contains('sfe-bit-btn-on') ?? false;
+        const isUnsigned = !isStruct && (type === 'uint8' || type === 'uint16' || type === 'uint32' || type === 'uint64');
+        const childrenContainer = row.querySelector<HTMLElement>('.sfe-bf-children');
+
+        // Parse child bit-field rows if toggled on and unsigned
+        let bitFields: import('./types').BitFieldChild[] | undefined;
+        let bitWidth: number | undefined;
+        if (bitBtnOn && isUnsigned && childrenContainer) {
+            const childRows = childrenContainer.querySelectorAll<HTMLElement>('.sfe-bf-child-row');
+            const childArray: import('./types').BitFieldChild[] = Array.from(childRows).map(childRow => {
+                const childName = sanitizeCIdent(
+                    (childRow.querySelector('.sfe-bf-child-name') as HTMLInputElement).value
+                ) || `bit${childRow.dataset.childIdx || '0'}`;
+                const childWidthRaw = (childRow.querySelector('.sfe-bf-child-width') as HTMLInputElement).value;
+                const childWidth = parseInt(childWidthRaw, 10);
+                return {
+                    name: childName,
+                    bitWidth: Number.isInteger(childWidth) && childWidth > 0 ? Math.min(childWidth, 64) : 1,
+                };
+            });
+            // Validate: sum of child widths must fit in parent type
+            // Auto-create one child if empty
+            if (childArray.length === 0) {
+                const unitBits = fieldByteSize(type as import('./types').StructScalarFieldType) * 8;
+                childArray.push({ name: 'bit0', bitWidth: unitBits });
+            }
+            bitFields = childArray;
+            // Keep the collapsed state
+            const collapsed = childrenContainer.style.display === 'none';
+            const bfCollapsed = collapsed || undefined;
+        }
+
+        if (!bitFields) {
+            // Check for legacy single bitWidth — migrated from old data
+            // For backward compat: read from bitWidth in the field if saved
+        }
+
+        const bitCollapsed = bitBtnOn && isUnsigned && childrenContainer
+            ? (childrenContainer.style.display === 'none') || undefined
+            : undefined;
+
+        const count = (() => {
+            if (bitFields) { return (row.dataset as { arrSfe?: string }).arrSfe === 'true' ? (parseInt((row.querySelector('.sfe-count-inp') as HTMLInputElement).value) || 1) : 1; }
+            const cell = row.querySelector<HTMLElement>('.sfe-arr-cell')!;
+            if (!cell.classList.contains('is-array')) { return 1; }
+            const v = parseInt((row.querySelector('.sfe-count-inp') as HTMLInputElement).value);
+            return isNaN(v) || v < 1 ? 1 : Math.min(v, 256);
+        })();
+
+        const result: import('./types').StructField = {
             name: sanitizeCIdent((row.querySelector('.sfe-name-inp') as HTMLInputElement).value),
             type,
             refStructId,
-            count: (() => {
-                const cell = row.querySelector<HTMLElement>('.sfe-arr-cell')!;
-                if (!cell.classList.contains('is-array')) { return 1; }
-                const v = parseInt((row.querySelector('.sfe-count-inp') as HTMLInputElement).value);
-                return isNaN(v) || v < 1 ? 1 : Math.min(v, 256);
-            })(),
+            count,
             endian: 'inherit',
         };
+        if (bitFields && bitFields.length > 0) {
+            result.bitFields = bitFields;
+            if (bitCollapsed) { result.bitFieldsCollapsed = true; }
+        }
+        return result;
     });
 }
 
@@ -329,6 +557,7 @@ function wireEditorInSec(sec: HTMLElement): void {
 
     sec.querySelectorAll<HTMLElement>('.sfe-arr-toggle').forEach(btn => {
         btn.addEventListener('click', () => {
+            if ((btn as HTMLButtonElement).disabled) { return; }
             const cell = btn.closest<HTMLElement>('.sfe-arr-cell')!;
             const nowArr = !cell.classList.contains('is-array');
             cell.classList.toggle('is-array', nowArr);
@@ -350,6 +579,119 @@ function wireEditorInSec(sec: HTMLElement): void {
         });
     });
 
+    // ── Bit-field :N toggle button ─────────────────────────────────
+    sec.querySelectorAll<HTMLElement>('.sfe-bit-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest<HTMLElement>('.struct-field-row')!;
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(row.dataset.idx!);
+            const f = draft.fields[idx];
+            if (!f) { return; }
+            const isOn = btn.classList.contains('sfe-bit-btn-on');
+            if (isOn) {
+                // Toggle OFF: remove bitFields
+                btn.classList.remove('sfe-bit-btn-on');
+                delete f.bitFields;
+                delete f.bitFieldsCollapsed;
+                f.bitWidth = undefined;
+                const children = row.querySelector<HTMLElement>('.sfe-bf-children');
+                if (children) { children.remove(); }
+                row.classList.remove('has-bit-children');
+                // Re-enable array toggle
+                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
+                if (arrBtn) { arrBtn.disabled = false; }
+            } else {
+                // Toggle ON: create default first child with 1 bit width
+                btn.classList.add('sfe-bit-btn-on');
+                row.classList.add('has-bit-children');
+                f.bitFields = [{ name: 'bit0', bitWidth: 1 }];
+                f.bitFieldsCollapsed = undefined;
+                // Disable array toggle
+                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
+                if (arrBtn) { arrBtn.disabled = true; }
+                const arrCell = row.querySelector<HTMLElement>('.sfe-arr-cell');
+                if (arrCell) { arrCell.classList.remove('is-array'); }
+                f.count = 1;
+            }
+            // Update preview without re-syncing (refreshEditorPreview would overwrite our changes)
+            const pre = sec.querySelector<HTMLElement>('#se-preview pre');
+            if (pre) { renderStructCPreview(pre, draft); }
+            renderStructPins();  // Re-render to show/hide child rows
+        });
+    });
+
+    // ── Bit-field child: add ────────────────────────────────────
+    sec.querySelectorAll<HTMLElement>('.sfe-bf-add-child').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest<HTMLElement>('.struct-field-row')!;
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(row.dataset.idx!);
+            const f = draft.fields[idx];
+            if (!f) { return; }
+            if (!f.bitFields) { f.bitFields = []; }
+            const nextIdx = f.bitFields.length;
+            f.bitFields.push({ name: `bit${nextIdx}`, bitWidth: 1 });
+            renderStructPins();
+        });
+    });
+
+    // ── Bit-field child: delete ─────────────────────────────────
+    sec.querySelectorAll<HTMLElement>('.sfe-bf-del-child').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const childRow = btn.closest<HTMLElement>('.sfe-bf-child-row')!;
+            const parentRow = childRow.closest<HTMLElement>('.struct-field-row')!;
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(parentRow.dataset.idx!);
+            const f = draft.fields[idx];
+            if (!f?.bitFields) { return; }
+            const ci = parseInt(childRow.dataset.childIdx!);
+            f.bitFields.splice(ci, 1);
+            if (f.bitFields.length === 0) {
+                // No children left → toggle bit mode off
+                const bitBtn = parentRow.querySelector<HTMLElement>('.sfe-bit-btn');
+                if (bitBtn) { bitBtn.classList.remove('sfe-bit-btn-on'); }
+                parentRow.classList.remove('has-bit-children');
+                delete f.bitFields;
+                delete f.bitFieldsCollapsed;
+            }
+            renderStructPins();
+        });
+    });
+
+    // ── Bit-field child: reorder up ─────────────────────────────
+    sec.querySelectorAll<HTMLElement>('.sfe-bf-child-row .sfe-move-up').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const childRow = btn.closest<HTMLElement>('.sfe-bf-child-row')!;
+            const parentRow = childRow.closest<HTMLElement>('.struct-field-row')!;
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(parentRow.dataset.idx!);
+            const f = draft.fields[idx];
+            if (!f?.bitFields) { return; }
+            const ci = parseInt(childRow.dataset.childIdx!);
+            if (ci > 0) {
+                [f.bitFields[ci - 1], f.bitFields[ci]] = [f.bitFields[ci], f.bitFields[ci - 1]];
+                renderStructPins();
+            }
+        });
+    });
+
+    // ── Bit-field child: reorder down ───────────────────────────
+    sec.querySelectorAll<HTMLElement>('.sfe-bf-child-row .sfe-move-dn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const childRow = btn.closest<HTMLElement>('.sfe-bf-child-row')!;
+            const parentRow = childRow.closest<HTMLElement>('.struct-field-row')!;
+            syncEditorDraft(sec, draft);
+            const idx = parseInt(parentRow.dataset.idx!);
+            const f = draft.fields[idx];
+            if (!f?.bitFields) { return; }
+            const ci = parseInt(childRow.dataset.childIdx!);
+            if (ci < f.bitFields.length - 1) {
+                [f.bitFields[ci], f.bitFields[ci + 1]] = [f.bitFields[ci + 1], f.bitFields[ci]];
+                renderStructPins();
+            }
+        });
+    });
+
     sec.querySelectorAll<HTMLInputElement>('.sfe-name-inp').forEach(inp => {
         inp.addEventListener('input', () => { refreshEditorPreview(sec, draft); });
         inp.addEventListener('blur', () => {
@@ -360,7 +702,41 @@ function wireEditorInSec(sec: HTMLElement): void {
     });
 
     sec.querySelectorAll<HTMLSelectElement>('.sfe-type-sel').forEach(sel => {
-        sel.addEventListener('change', () => { refreshEditorPreview(sec, draft); });
+        sel.addEventListener('change', () => {
+            const row = sel.closest<HTMLElement>('.struct-field-row');
+            if (row) {
+                const bitBtn = row.querySelector<HTMLElement>('.sfe-bit-btn');
+                const arrBtn = row.querySelector<HTMLButtonElement>('.sfe-arr-toggle');
+                const arrCell = row.querySelector<HTMLElement>('.sfe-arr-cell');
+                const rawType = sel.value;
+                const isStruct = rawType.startsWith('struct:');
+                const isUnsigned = !isStruct && (rawType === 'uint8' || rawType === 'uint16' || rawType === 'uint32' || rawType === 'uint64');
+                const bitToggled = bitBtn?.classList.contains('sfe-bit-btn-on') ?? false;
+                if (bitBtn) { (bitBtn as HTMLButtonElement).disabled = !isUnsigned; }
+                // If bit-mode was on and type changed to non-unsigned, turn off bit-mode
+                if (bitToggled && !isUnsigned) {
+                    bitBtn?.classList.remove('sfe-bit-btn-on');
+                    row.classList.remove('has-bit-children');
+                    const children = row.querySelector<HTMLElement>('.sfe-bf-children');
+                    if (children) { children.remove(); }
+                    syncEditorDraft(sec, draft);
+                    const idx = parseInt(row.dataset.idx!);
+                    const f = draft.fields[idx];
+                    if (f) { delete f.bitFields; delete f.bitFieldsCollapsed; f.bitWidth = undefined; }
+                    (arrBtn as HTMLButtonElement).disabled = false;
+                }
+                if (arrBtn) { (arrBtn as HTMLButtonElement).disabled = bitToggled || !isUnsigned && false; }
+                if (bitToggled && arrCell) { arrCell.classList.remove('is-array'); }
+            }
+            refreshEditorPreview(sec, draft);
+        });
+    });
+
+    // ── Bit-field child name/width input live refresh ───────────
+    sec.querySelectorAll<HTMLInputElement>('.sfe-bf-child-name, .sfe-bf-child-width').forEach(inp => {
+        inp.addEventListener('input', () => {
+            refreshEditorPreview(sec, draft);
+        });
     });
 
     sec.querySelector<HTMLInputElement>('#se-name')!.addEventListener('input', () => {
@@ -729,12 +1105,32 @@ export function resetStructViewState(): void {
     _editingPinId            = null;
     _editingPinDraftStructId = null;
     _selectedArrElemKey      = null;
+    _selectedBitRange        = null;
+    _hoveredBitRange         = null;
+    _selectedBitRowKey       = null;
+    _hoveredBitRowKey        = null;
     renderStructPins();
 }
 
 /** Get a display string for a field given the requested column display type. */
 function getValForType(r: DecodedField, valType: ColType): string {
     if (!r.hasData) { return '??'; }
+    if (isBitFieldRow(r)) {
+        const width = r.bitWidth ?? 1;
+        const v = BigInt(r.bitValueUnsigned ?? '0');
+        if (valType === 'hex') {
+            return formatHexHtml(formatHex(v, Math.max(1, Math.ceil(width / 4))));
+        }
+        if (valType === 'bin') {
+            const bits = v.toString(2).padStart(width, '0');
+            const groups = bits.match(/.{1,4}/g) || [];
+            const html = groups.map(g => [...g].map(bit =>
+                `<span class="si-bit ${bit === '1' ? 'one' : 'zero'}">${bit}</span>`
+            ).join('')).join(' ');
+            return `<span class="si-bin-wrap">${html}</span>`;
+        }
+        return v.toString(10);
+    }
     const bytes = r.bytesHex.split(' ').map(h => parseInt(h, 16));
     const buf   = new ArrayBuffer(bytes.length);
     const dv    = new DataView(buf);
@@ -871,6 +1267,19 @@ function getFloatParts(bytes: number[], type: 'float32' | 'float64', endian: 'le
 /** Get a plain-text representation suitable for copying. */
 function getCopyText(r: DecodedField, valType: ColType): string {
     if (!r.hasData) { return '??'; }
+    if (isBitFieldRow(r)) {
+        const width = r.bitWidth ?? 1;
+        const v = BigInt(r.bitValueUnsigned ?? '0');
+        if (valType === 'hex') {
+            return `0x${v.toString(16).toUpperCase().padStart(Math.max(1, Math.ceil(width / 4)), '0')}`;
+        }
+        if (valType === 'bin') {
+            const bits = v.toString(2).padStart(width, '0');
+            const groups = bits.match(/.{1,4}/g) || [];
+            return groups.join(' ');
+        }
+        return v.toString(10);
+    }
     if (r.type === 'ascii') { return r.decoded; }
     const bytes = r.bytesHex.split(' ').map(h => parseInt(h, 16));
     const le    = S.endian === 'le';
@@ -945,7 +1354,8 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: strin
     let t = _fieldValTypes.get(bs);
     if (!t) {
         // Prefer decimal view for floating-point fields by default
-        if (r.type === 'float32' || r.type === 'float64') { t = 'dec'; }
+        if (isBitFieldRow(r)) { t = 'bin'; }
+        else if (r.type === 'float32' || r.type === 'float64') { t = 'dec'; }
         else if (r.type === 'ascii') { t = 'ascii'; }
         else { t = _defaultValType; }
     }
@@ -953,12 +1363,21 @@ function mkFieldRow(r: DecodedField, bs: number, bc: number, displayName?: strin
     const valHtml = (t === 'bin' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
     const byteCount = r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : bc;
     const abbrevBase = TYPE_ABBREV[r.type] ?? r.type;
-    const abbrev  = r.type === 'ascii' ? `${abbrevBase}[${byteCount}]` : abbrevBase;
-    const fullTypeLabel = r.type === 'ascii' ? `ascii[${byteCount}]` : r.type;
+    const abbrev = isBitFieldRow(r)
+        ? `bit:${r.bitWidth}`
+        : (r.type === 'ascii' ? `${abbrevBase}[${byteCount}]` : abbrevBase);
+    const fullTypeLabel = isBitFieldRow(r)
+        ? `bit:${r.bitWidth}`
+        : (r.type === 'ascii' ? `ascii[${byteCount}]` : r.type);
+    const offsetLabel = isBitFieldRow(r)
+        ? `.${String(r.bitOffset ?? 0)}`
+        : `+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
     return (
         `<div class="si-field${nd}${ptr ? ' si-ptr-field' : ''}" ` +
-        `data-byte-start="${bs}" data-byte-cnt="${bc}">` +
-        `<span class="si-f-off">+${r.byteOffset.toString(16).toUpperCase().padStart(3, '0')}</span>` +
+        `data-byte-start="${bs}" data-byte-cnt="${bc}"` +
+        (isBitFieldRow(r) ? ` data-bit-start="${r.bitOffset ?? 0}" data-bit-width="${r.bitWidth ?? 0}"` : '') +
+        `>` +
+        `<span class="si-f-off">${offsetLabel}</span>` +
         `<span class="si-f-type" title="${esc(fullTypeLabel)}">${abbrev}</span>` +
         `<span class="si-toggle-pad" aria-hidden="true"></span>` +
         `<span class="si-f-body">` +
@@ -999,6 +1418,117 @@ function leafName(fieldPath: string): string {
     return parts.length > 0 ? parts[parts.length - 1] : fieldPath;
 }
 
+function isBitUnitGroup(rows: DecodedField[]): boolean {
+    return rows.length > 0 && rows.every(r => isBitFieldRow(r));
+}
+
+function groupHeaderName(baseName: string, rows: DecodedField[]): string {
+    if (!isBitUnitGroup(rows)) { return leafName(baseName); }
+    return 'BitField';
+}
+
+function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
+    if (!isBitUnitGroup(rows)) { return fallback; }
+    const first = rows[0];
+    if (!first) { return fallback; }
+    const rawParts = first.bytesHex.split(' ').map(p => p.trim()).filter(Boolean);
+    if (rawParts.length === 0 || rawParts.some(p => p === '??')) { return '??'; }
+    const raw = rawParts.map(h => parseInt(h, 16));
+    if (raw.some(v => !Number.isFinite(v) || v < 0 || v > 0xFF)) { return '??'; }
+
+    let value = 0n;
+    if (S.endian === 'le') {
+        for (let i = 0; i < raw.length; i++) {
+            value |= BigInt(raw[i]) << BigInt(i * 8);
+        }
+    } else {
+        for (const b of raw) {
+            value = (value << 8n) | BigInt(b);
+        }
+    }
+
+    const hex = value.toString(16).toUpperCase().padStart(raw.length * 2, '0');
+    return `0x${hex} (${value.toString(10)})`;
+}
+
+function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
+    const first = rows[0];
+    if (!first) { return null; }
+    return {
+        fieldName: 'BitField',
+        type: first.type,
+        arrayIdx: 0,
+        byteOffset: first.byteOffset,
+        bytesHex: first.bytesHex,
+        decoded: first.decoded,
+        hasData: first.hasData,
+    };
+}
+
+function bitUnitHeaderHtml(
+    rows: DecodedField[],
+    start: number,
+    cnt: number,
+    isOpen: boolean,
+): string {
+    const agg = buildBitUnitAggregateRow(rows);
+    const headerName = groupHeaderName(arrayGroupBaseName(rows[0]?.fieldName ?? ''), rows);
+    if (!agg) {
+        return (
+            `<div class="si-arr-grp-hdr si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+            `<span class="si-f-off">+000</span>` +
+            `<span class="si-f-type">u8</span>` +
+            `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+            `<span class="si-f-body">` +
+            `<span class="si-f-name">${esc(headerName)}</span>` +
+            `<span class="si-f-lead"></span>` +
+            `<span class="si-f-val si-f-pri" data-val-type="hex" data-bs="${start}">??</span>` +
+            `</span>` +
+            `</div>`
+        );
+    }
+
+    let t = _fieldValTypes.get(start);
+    if (!t) { t = 'bin'; }
+
+    const activeRange = (() => {
+        if (_selectedBitRange && _selectedBitRange.parentByteStart === start) {
+            return { startBit: _selectedBitRange.startBit, endBit: _selectedBitRange.endBit };
+        }
+        if (_hoveredBitRange && _hoveredBitRange.parentByteStart === start) {
+            return { startBit: _hoveredBitRange.startBit, endBit: _hoveredBitRange.endBit };
+        }
+        return null;
+    })();
+
+    const v = t === 'bin'
+        ? renderBinaryFromBitRows(
+            rows,
+            activeRange,
+        )
+        : getValForType(agg, t);
+    const ptr = agg.type === 'pointer';
+    const valHtml = (t === 'bin' || t === 'ieee' || t === 'hex' || ptr) ? v : esc(v);
+    const byteCount = agg.bytesHex.length > 0 ? agg.bytesHex.split(' ').length : cnt;
+    const abbrevBase = TYPE_ABBREV[agg.type] ?? agg.type;
+    const abbrev = agg.type === 'ascii' ? `${abbrevBase}[${byteCount}]` : abbrevBase;
+    const fullTypeLabel = agg.type === 'ascii' ? `ascii[${byteCount}]` : agg.type;
+    const offsetLabel = `+${agg.byteOffset.toString(16).toUpperCase().padStart(3, '0')}`;
+
+    return (
+        `<div class="si-arr-grp-hdr si-bitunit-hdr si-field" data-byte-start="${start}" data-byte-cnt="${cnt}">` +
+        `<span class="si-f-off">${offsetLabel}</span>` +
+        `<span class="si-f-type" title="${esc(fullTypeLabel)}">${abbrev}</span>` +
+        `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+        `<span class="si-f-body">` +
+        `<span class="si-f-name">${esc(headerName)}</span>` +
+        `<span class="si-f-lead"></span>` +
+        `<span class="si-f-val si-f-pri${ptr ? ' si-f-ptr' : ''}" data-val-type="${t}" data-bs="${start}">${valHtml}</span>` +
+        `</span>` +
+        `</div>`
+    );
+}
+
 function disambiguateLeafNames(names: string[]): string[] {
     const seen = new Map<string, number>();
     return names.map(name => {
@@ -1036,7 +1566,10 @@ function buildInstanceCard(pin: StructPin, i: number): string {
     let bodyHtml = '';
     if (expanded && def) {
         const rows = decodeStruct(def, pin.addr, getByte, S.endian);
-        const rowByteCnt = (r: DecodedField) => r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
+        const rowByteCnt = (r: DecodedField) => {
+            if (isBitFieldRow(r)) { return r.bitStorageByteSize ?? 1; }
+            return r.bytesHex.length > 0 ? r.bytesHex.split(' ').length : fieldByteSize(r.type);
+        };
 
         const renderStructChildren = (structRows: DecodedField[], structBase: string, parentKey: string): string => {
             const structPrefix = `${structBase}.`;
@@ -1058,7 +1591,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const nestedCount = nestedDeclared?.field.count ?? ng.rows.length;
                 const nestedIsStruct = nestedType === 'struct';
                 const nestedIsString = nestedType === 'ascii';
-                const nestedIsComposite = nestedIsStruct || (nestedCount > 1 && !nestedIsString);
+                const nestedIsBitUnit = isBitUnitGroup(ng.rows);
+                const nestedIsComposite = nestedIsBitUnit || nestedIsStruct || (nestedCount > 1 && !nestedIsString);
                 if (!nestedIsComposite) {
                     const labels = disambiguateLeafNames(ng.rows.map(r => leafName(r.fieldName)));
                     return ng.rows.map((r, idx) =>
@@ -1071,10 +1605,13 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 const nestedSummary = nestedIsStruct
                     ? (nestedCount > 1 ? `${nestedStructName}[${nestedCount}]` : nestedStructName)
                     : `${nestedTypeAbbrev}[${nestedCount}]`;
+                const nestedSummaryLabel = groupSummaryLabel(ng.rows, nestedSummary);
                 const nestedKey = `${parentKey}::${ng.baseRel}`;
                 const nestedOpen = _expandedArrayFields.has(nestedKey);
                 const nestedStart = pin.addr + ng.rows[0].byteOffset;
-                const nestedCnt = ng.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+                const nestedCnt = nestedIsBitUnit
+                    ? rowByteCnt(ng.rows[0])
+                    : ng.rows.reduce((s, r) => s + rowByteCnt(r), 0);
 
                 let nestedBodyHtml = '';
                 if (nestedIsStruct && nestedCount > 1) {
@@ -1116,6 +1653,13 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                     }).join('');
                 } else if (nestedIsStruct && nestedCount === 1) {
                     nestedBodyHtml = renderStructChildren(ng.rows, ng.fullBase, nestedKey);
+                } else if (nestedIsBitUnit) {
+                    const nestedLeafNames = disambiguateLeafNames(
+                        ng.rows.map(r => leafName(r.fieldName))
+                    );
+                    nestedBodyHtml = ng.rows.map((r, idx) =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), nestedLeafNames[idx])
+                    ).join('');
                 } else if (!nestedIsStruct && nestedCount > 1 && !nestedIsString) {
                     nestedBodyHtml = ng.rows.map(r =>
                         mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, ng.fullBase))
@@ -1131,16 +1675,19 @@ function buildInstanceCard(pin: StructPin, i: number): string {
 
                 return (
                     `<div class="si-arr-grp${nestedOpen ? ' open' : ''}" data-arr-key="${esc(nestedKey)}">` +
-                    `<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
-                    `<span class="si-node-pad" aria-hidden="true"></span>` +
-                    `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                    `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
-                    `<span class="si-f-body">` +
-                    `<span class="si-f-name">${esc(leafName(ng.baseRel))}</span>` +
-                    `<span class="si-f-lead"></span>` +
-                    `<span class="si-arr-addr">${esc(nestedSummary)}</span>` +
-                    `</span>` +
-                    `</div>` +
+                    (nestedIsBitUnit
+                        ? bitUnitHeaderHtml(ng.rows, nestedStart, nestedCnt, nestedOpen)
+                        : (`<div class="si-arr-grp-hdr" data-byte-start="${nestedStart}" data-byte-cnt="${nestedCnt}">` +
+                           `<span class="si-node-pad" aria-hidden="true"></span>` +
+                           `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                           `<button class="si-arr-exp-btn">${nestedOpen ? '▾' : '▸'}</button>` +
+                           `<span class="si-f-body">` +
+                           `<span class="si-f-name">${esc(groupHeaderName(ng.baseRel, ng.rows))}</span>` +
+                           `<span class="si-f-lead"></span>` +
+                           `<span class="si-arr-addr">${esc(nestedSummaryLabel)}</span>` +
+                           `</span>` +
+                           `</div>`)
+                    ) +
                     `<div class="si-arr-grp-body"${nestedOpen ? '' : ' style=\"display:none\"'}>${nestedBodyHtml}</div>` +
                     `</div>`
                 );
@@ -1164,7 +1711,8 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             const isStruct = declaredType === 'struct';
             const isArray = declaredCount > 1;
             const isString = declaredType === 'ascii';
-            const isComposite = isStruct || (isArray && !isString);
+            const isBitUnit = isBitUnitGroup(g.rows);
+            const isComposite = isBitUnit || isStruct || (isArray && !isString);
 
             if (!isComposite) {
                 // Scalar leaf field(s) — render flat using local labels.
@@ -1176,14 +1724,16 @@ function buildInstanceCard(pin: StructPin, i: number): string {
             const key     = `${pin.id}::${g.baseName}`;
             const isOpen  = _expandedArrayFields.has(key);
             const byteStart = pin.addr + r0.byteOffset;
-            const totalCnt  = g.rows.reduce((s, r) => s + rowByteCnt(r), 0);
+            const totalCnt  = isBitUnit
+                ? rowByteCnt(g.rows[0])
+                : g.rows.reduce((s, r) => s + rowByteCnt(r), 0);
             let elHtml     = g.rows.map(r => mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r))).join('');
                 const structName = declared?.structName ?? 'struct';
                 const scalarType = TYPE_ABBREV[declaredType] ?? declaredType;
                 const nodeSummary = isStruct
                     ? (isArray ? `${structName}[${declaredCount}]` : structName)
                     : `${scalarType}[${declaredCount}]`;
-                const nodeSummaryFull = nodeSummary;
+                const nodeSummaryFull = groupSummaryLabel(g.rows, nodeSummary);
 
                 if (isStruct && isArray) {
                     type ElementGroup = { idx: number; rows: DecodedField[] };
@@ -1226,6 +1776,11 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                     }
                 } else if (isStruct && !isArray) {
                     elHtml = renderStructChildren(g.rows, g.baseName, key);
+                } else if (isBitUnit) {
+                    const labels = disambiguateLeafNames(g.rows.map(r => leafName(r.fieldName)));
+                    elHtml = g.rows.map((r, idx) =>
+                        mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), labels[idx])
+                    ).join('');
                 } else if (!isStruct && isArray) {
                     elHtml = g.rows.map(r =>
                         mkFieldRow(r, pin.addr + r.byteOffset, rowByteCnt(r), indexOnlyName(r.fieldName, g.baseName))
@@ -1233,17 +1788,20 @@ function buildInstanceCard(pin: StructPin, i: number): string {
                 }
             return (
                 `<div class="si-arr-grp${isOpen ? ' open' : ''}" data-arr-key="${esc(key)}">` +
-                `<div class="si-arr-grp-hdr" ` +
-                `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
-                `<span class="si-node-pad" aria-hidden="true"></span>` +
-                `<span class="si-node-type-pad" aria-hidden="true"></span>` +
-                `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
-                `<span class="si-f-body">` +
-                `<span class="si-f-name">${esc(leafName(g.baseName))}</span>` +
-                `<span class="si-f-lead"></span>` +
-                `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummary)}</span>` +
-                `</span>` +
-                `</div>` +
+                (isBitUnit
+                    ? bitUnitHeaderHtml(g.rows, byteStart, totalCnt, isOpen)
+                    : (`<div class="si-arr-grp-hdr" ` +
+                       `data-byte-start="${byteStart}" data-byte-cnt="${totalCnt}">` +
+                       `<span class="si-node-pad" aria-hidden="true"></span>` +
+                       `<span class="si-node-type-pad" aria-hidden="true"></span>` +
+                       `<button class="si-arr-exp-btn">${isOpen ? '▾' : '▸'}</button>` +
+                       `<span class="si-f-body">` +
+                       `<span class="si-f-name">${esc(groupHeaderName(g.baseName, g.rows))}</span>` +
+                       `<span class="si-f-lead"></span>` +
+                       `<span class="si-arr-addr" title="${esc(nodeSummaryFull)}">${esc(nodeSummaryFull)}</span>` +
+                       `</span>` +
+                       `</div>`)
+                ) +
                 `<div class="si-arr-grp-body"${isOpen ? '' : ' style=\"display:none\"'}>${elHtml}</div>` +
                 `</div>`
             );
@@ -1406,6 +1964,33 @@ function applyTreeDepthStyles(sec: HTMLElement): void {
 function wireInstanceCards(sec: HTMLElement): void {
     applyTreeDepthStyles(sec);
 
+    // Keep bit hover highlight strictly tied to the current pointer target.
+    sec.onmousemove = (ev: MouseEvent) => {
+        const target = ev.target as HTMLElement | null;
+        const bitRow = target?.closest<HTMLElement>('.si-field[data-bit-start][data-bit-width]') ?? null;
+        let next: { parentByteStart: number; startBit: number; endBit: number } | null = null;
+        let nextKey: string | null = null;
+        if (bitRow) {
+            const meta = parseBitRowMeta(bitRow);
+            if (meta) {
+                next = { parentByteStart: meta.byteStart, startBit: meta.bitStart, endBit: meta.bitStart + meta.bitWidth - 1 };
+                nextKey = makeBitRowKey(meta.byteStart, meta.bitStart, meta.bitWidth);
+            }
+        }
+        if (_hoveredBitRowKey !== nextKey) {
+            _hoveredBitRange = next;
+            _hoveredBitRowKey = nextKey;
+            applyBitHighlightsInPlace(sec);
+        }
+    };
+    sec.onmouseleave = () => {
+        if (_hoveredBitRange !== null || _hoveredBitRowKey !== null) {
+            _hoveredBitRange = null;
+            _hoveredBitRowKey = null;
+            applyBitHighlightsInPlace(sec);
+        }
+    };
+
     sec.querySelectorAll<HTMLElement>('.si-expand-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             const id = btn.dataset.pinId!;
@@ -1419,6 +2004,7 @@ function wireInstanceCards(sec: HTMLElement): void {
         const expBtn = hdr.querySelector<HTMLElement>('.si-arr-exp-btn')!;
         const start  = parseInt(hdr.dataset.byteStart!);
         const cnt    = parseInt(hdr.dataset.byteCnt!);
+        const isBitUnitHdr = hdr.classList.contains('si-bitunit-hdr');
 
         expBtn.addEventListener('click', e => {
             e.stopPropagation();
@@ -1453,8 +2039,13 @@ function wireInstanceCards(sec: HTMLElement): void {
 
         hdr.addEventListener('click', e => {
             if ((e.target as HTMLElement).closest('.si-arr-exp-btn')) { return; }
+            if (isBitUnitHdr) { return; }
             clearArrSep();
             clearSelRow();
+            _selectedBitRange = null;
+            _hoveredBitRange = null;
+            _selectedBitRowKey = null;
+            _hoveredBitRowKey = null;
             if (isNaN(start) || isNaN(cnt)) { return; }
             const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
             _selectedArrKey    = grp.dataset.arrKey!;
@@ -1532,6 +2123,10 @@ function wireInstanceCards(sec: HTMLElement): void {
             if ((e.target as HTMLElement).closest('.si-arr-el-exp-btn')) { return; }
             clearArrSep();
             clearSelRow();
+            _selectedBitRange = null;
+            _hoveredBitRange = null;
+            _selectedBitRowKey = null;
+            _hoveredBitRowKey = null;
             if (isNaN(start) || isNaN(cnt)) { return; }
             _selectedArrElemKey = hdr.dataset.arrElKey!;
             _selectedArrKey = null;
@@ -1549,6 +2144,10 @@ function wireInstanceCards(sec: HTMLElement): void {
             if ((e.target as HTMLElement).closest('.si-expand-btn, .si-card-actions, .si-type-btn')) { return; }
             clearArrSep();
             clearSelRow();
+            _selectedBitRange = null;
+            _hoveredBitRange = null;
+            _selectedBitRowKey = null;
+            _hoveredBitRowKey = null;
             _selectedFieldAddr = null;
             _selectedArrKey    = null;
             _selectedArrElemKey = null;
@@ -1600,8 +2199,12 @@ function wireInstanceCards(sec: HTMLElement): void {
     sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
         const start = parseInt(row.dataset.byteStart!);
         const cnt   = parseInt(row.dataset.byteCnt!);
+        const bitStartRaw = row.dataset.bitStart;
+        const bitWidthRaw = row.dataset.bitWidth;
+        const isBitRow = bitStartRaw !== undefined && bitWidthRaw !== undefined;
 
         row.addEventListener('mouseenter', () => {
+            if (isBitRow) { return; }
             for (let i = 0; i < cnt; i++) {
                 const ah = (start + i).toString(16).toUpperCase().padStart(8, '0');
                 document.querySelectorAll<HTMLElement>(`[data-addr="${ah}"]`)
@@ -1610,14 +2213,38 @@ function wireInstanceCards(sec: HTMLElement): void {
         });
 
         row.addEventListener('mouseleave', () => {
+            if (isBitRow) { return; }
             document.querySelectorAll<HTMLElement>('.struct-h')
                 .forEach(el => el.classList.remove('struct-h'));
         });
 
         row.addEventListener('click', () => {
             if (isNaN(start) || isNaN(cnt)) { return; }
+            if (isBitRow) {
+                const meta = parseBitRowMeta(row);
+                if (meta) {
+                    _selectedBitRange = { parentByteStart: meta.byteStart, startBit: meta.bitStart, endBit: meta.bitStart + meta.bitWidth - 1 };
+                    _selectedBitRowKey = makeBitRowKey(meta.byteStart, meta.bitStart, meta.bitWidth);
+                } else {
+                    _selectedBitRange = null;
+                    _selectedBitRowKey = null;
+                }
+                _hoveredBitRange = null;
+                _hoveredBitRowKey = null;
+                _selectedFieldAddr = null;
+                _selectedArrKey = null;
+                _selectedArrElemKey = null;
+                clearSelRow();
+                // Do NOT add si-selected class to bit-field child rows
+                applyBitHighlightsInPlace(sec);
+                return;
+            }
             clearArrSep();
             clearSelRow();
+            _selectedBitRange = null;
+            _hoveredBitRange = null;
+            _selectedBitRowKey = null;
+            _hoveredBitRowKey = null;
             S.selStart = start;
             S.selEnd   = start + cnt - 1;
             row.classList.add('si-selected');
@@ -1626,6 +2253,7 @@ function wireInstanceCards(sec: HTMLElement): void {
             _selectedArrElemKey = null;
             import('./memoryView.js').then(m => { m.applySel(); m.scrollTo(start); });
             import('./sidebar.js').then(m => m.updateInspector());
+            renderStructPins();
         });
     });
 
@@ -1649,6 +2277,7 @@ function wireInstanceCards(sec: HTMLElement): void {
     // entire group (child elements).
     sec.querySelectorAll<HTMLElement>('.si-arr-grp-hdr').forEach(hdr => {
         hdr.addEventListener('contextmenu', ev => {
+            if (hdr.classList.contains('si-bitunit-hdr')) { return; }
             ev.preventDefault(); ev.stopPropagation();
             const grp = hdr.closest<HTMLElement>('.si-arr-grp')!;
             const bsList = Array.from(grp.querySelectorAll<HTMLElement>('.si-field'))
@@ -1723,6 +2352,8 @@ function wireInstanceCards(sec: HTMLElement): void {
         }
     }
 
+    applyBitHighlightsInPlace(sec);
+
     // Re-apply selection highlight after DOM rebuild
     if (_selectedPinId !== null) {
         sec.querySelectorAll<HTMLElement>('.si-card').forEach(card => {
@@ -1731,7 +2362,16 @@ function wireInstanceCards(sec: HTMLElement): void {
             }
         });
     }
-    if (_selectedFieldAddr !== null) {
+    if (_selectedBitRowKey !== null) {
+        sec.querySelectorAll<HTMLElement>('.si-field[data-bit-start][data-bit-width]').forEach(row => {
+            const meta = parseBitRowMeta(row);
+            if (!meta) { return; }
+            const key = makeBitRowKey(meta.byteStart, meta.bitStart, meta.bitWidth);
+            if (key === _selectedBitRowKey) {
+                row.classList.add('si-selected');
+            }
+        });
+    } else if (_selectedFieldAddr !== null) {
         sec.querySelectorAll<HTMLElement>('.si-field').forEach(row => {
             if (parseInt(row.dataset.byteStart!) === _selectedFieldAddr) {
                 row.classList.add('si-selected');
@@ -1764,7 +2404,7 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
     // Determine candidate display types based on the field's native type.
     const sampleAddr = (bsList && bsList.length > 0) ? bsList[0] : bs;
     const allDefs = allStructs();
-    const findFieldTypeAt = (addr: number) => {
+    const findFieldAt = (addr: number): DecodedField | null => {
         let pin: StructPin | undefined;
         if (typeof pinIdx === 'number' && pinIdx >= 0) { pin = S.structPins[pinIdx]; }
         else {
@@ -1780,23 +2420,27 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
         if (!def) { return null; }
         const rows = decodeStruct(def, pin.addr, getByte, S.endian);
         const r = rows.find(rr => pin!.addr + rr.byteOffset === addr);
-        return r ? r.type : null;
+        return r ?? null;
     };
-    const sampleType = findFieldTypeAt(sampleAddr);
+    const sampleField = findFieldAt(sampleAddr);
+    const sampleType = sampleField?.type ?? null;
+    const isBitSample = sampleField ? isBitFieldRow(sampleField) : false;
     const isFloatSample = sampleType === 'float32' || sampleType === 'float64';
     const isAsciiSample = sampleType === 'ascii';
     const types: ColType[] = isFloatSample
         ? ['hex', 'dec', 'ieee', 'bin']
         : isAsciiSample
             ? ['ascii', 'hex', 'bin']
-            : ['hex', 'dec', 'bin', 'ascii'];
+            : isBitSample
+                ? ['bin', 'hex', 'dec']
+                : ['hex', 'dec', 'bin', 'ascii'];
     let cur: ColType | null = null;
     if (bsList && bsList.length > 0) {
         const vals = bsList.map(b => _fieldValTypes.get(b) ?? _defaultValType);
         const allSame = vals.every(v => v === vals[0]);
         cur = allSame ? (vals[0] as ColType) : null;
     } else {
-        cur = _fieldValTypes.get(bs) ?? _defaultValType;
+        cur = _fieldValTypes.get(bs) ?? (isBitSample ? 'bin' : _defaultValType);
     }
 
     // Helpers for menu
@@ -1853,8 +2497,11 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
                 if (cmd.startsWith('disp-') && bsList && bsList.length > 0) {
                     const t = cmd.replace('disp-', '') as ColType;
                     bsList.forEach(b => {
-                        const ft = findFieldTypeAt(b);
-                        const implicit = (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
+                        const field = findFieldAt(b);
+                        const ft = field?.type ?? null;
+                        const implicit = field && isBitFieldRow(field)
+                            ? 'bin'
+                            : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
                         if (t === implicit) { _fieldValTypes.delete(b); }
                         else { _fieldValTypes.set(b, t); }
                     });
@@ -1996,8 +2643,11 @@ function showFieldValMenu(x: number, y: number, bs: number, bsList?: number[], p
             // Display type actions
             if (cmd.startsWith('disp-')) {
                 const t = cmd.replace('disp-', '') as ColType;
-                const ft = findFieldTypeAt(bs);
-                const implicit = (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
+                const field = findFieldAt(bs);
+                const ft = field?.type ?? null;
+                const implicit = field && isBitFieldRow(field)
+                    ? 'bin'
+                    : (ft === 'float32' || ft === 'float64') ? 'dec' : (ft === 'ascii' ? 'ascii' : _defaultValType);
                 if (t === implicit) { _fieldValTypes.delete(bs); }
                 else { _fieldValTypes.set(bs, t); }
                 hideFieldValMenu();

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -206,11 +206,11 @@ function renderPlainBinaryBits(bits: string): string {
 
 function formatPlainBinaryBits(bits: string): string {
     const groups = bits.match(/.{1,4}/g) || [];
-    const lines: string[] = [];
-    for (let i = 0; i < groups.length; i += 4) {
-        lines.push(groups.slice(i, i + 4).join(' '));
-    }
-    return lines.join('\n');
+    return groups.join(' ');
+}
+
+function singleLineCopyText(text: string): string {
+    return text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
 function parseBitRowMeta(row: HTMLElement): { byteStart: number; bitStart: number; bitWidth: number } | null {
@@ -1380,6 +1380,9 @@ function getCopyText(r: DecodedField, valType: ColType): string {
         const v = dv.getUint32(0, le) >>> 0;
         return hexPad(v, 8);
     }
+    if (valType === 'bin-sliced' && typeof r.bitWidth === 'number' && r.bitValueUnsigned !== undefined) {
+        return formatPlainBinaryBits(BigInt(r.bitValueUnsigned).toString(2).padStart(r.bitWidth, '0'));
+    }
     if (valType === 'bin' || valType === 'bin-sliced') {
         return formatPlainBinaryBits(binaryBitsForValue(bytes, endian));
     }
@@ -1525,6 +1528,19 @@ function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
 function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
     const first = rows[0];
     if (!first) { return null; }
+    const usedWidth = rows.reduce((sum, row) => sum + bitRowWidth(row), 0);
+    let slicedValue: string | undefined;
+    const rawParts = byteHexParts(first.bytesHex);
+    if (usedWidth > 0 && !hasMissingByte(rawParts) && first.hasData) {
+        const raw = bytesFromHexParts(rawParts);
+        const value = bytesToValue(raw, first.endian);
+        const unitBits = raw.length * 8;
+        const mask = (1n << BigInt(usedWidth)) - 1n;
+        const sliced = S.bitFieldAllocation === 'lsb'
+            ? value & mask
+            : (value >> BigInt(Math.max(0, unitBits - usedWidth))) & mask;
+        slicedValue = sliced.toString(10);
+    }
     return {
         fieldName: 'BitField',
         type: first.type,
@@ -1534,6 +1550,9 @@ function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
         decoded: first.decoded,
         hasData: first.hasData,
         endian: first.endian,
+        bitWidth: usedWidth,
+        bitStorageByteSize: first.bitStorageByteSize,
+        bitValueUnsigned: slicedValue,
     };
 }
 
@@ -2791,7 +2810,7 @@ function showFieldValMenu(
                 if (!def) { hideFieldValMenu(); return; }
                 const rows = decodeStruct(def, pin.addr, getByte, S.endian, S.bitFieldAllocation);
                 const r = findFieldForKey(rows, bs - pin.addr, opts?.valKey);
-                const toCopy = r ? getCopyText(r, 'hex') : '??';
+                const toCopy = r ? singleLineCopyText(getCopyText(r, 'hex')) : '??';
                 if (navigator.clipboard && navigator.clipboard.writeText) {
                     navigator.clipboard.writeText(toCopy).catch(() => {
                         const ta = document.createElement('textarea');
@@ -2866,11 +2885,11 @@ function showFieldValMenu(
                     ? bsList.map((b, idx) => {
                         const listKey = opts?.keyList?.[idx];
                         const r = findFieldForKey(rows, b - pin!.addr, listKey);
-                        return r ? getCopyText(r, t) : '??';
-                      }).join('\n')
+                        return r ? singleLineCopyText(getCopyText(r, t)) : '??';
+                      }).join('; ')
                     : (() => {
                         const r = findFieldForKey(rows, bs - pin!.addr, opts?.valKey);
-                        return r ? getCopyText(r, t) : '??';
+                        return r ? singleLineCopyText(getCopyText(r, t)) : '??';
                       })();
                 if (navigator.clipboard && navigator.clipboard.writeText) {
                     navigator.clipboard.writeText(toCopy).catch(() => {

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -40,6 +40,7 @@ export interface SegmentLabel {
 
 export type SearchMode = 'bytes' | 'value' | 'ascii' | 'addr';
 export type SearchEndianness = 'auto' | 'be' | 'le';
+export type BitFieldAllocation = 'lsb' | 'msb';
 
 export type MemRow =
     | { type: 'data'; address: number }

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -58,14 +58,27 @@ export type StructFieldType = StructScalarFieldType | 'struct';
 
 export type StructFieldEndian = 'le' | 'be' | 'inherit';
 
+/** A single named child of a BitField container field. */
+export interface BitFieldChild {
+    name: string;
+    bitWidth: number;
+}
+
 export interface StructField {
     name: string;
     type: StructFieldType;
     /** Required when type === 'struct'; references StructDef.id. */
     refStructId?: string;
+    /** Named bit-field children. When present, this field is a BitField container.
+     *  Only valid for unsigned integer base types (uint8/16/32/64). */
+    bitFields?: BitFieldChild[];
+    /** @deprecated Legacy single bit-field width. Prefer bitFields[]. */
+    bitWidth?: number;
     /** Array element count; 1 for a scalar field. */
     count: number;
     endian: StructFieldEndian;
+    /** Whether the bit-field detail editor is collapsed. Only applies to BitField containers. */
+    bitFieldsCollapsed?: boolean;
 }
 
 export interface StructDef {


### PR DESCRIPTION
Add support for bit fields in Struct Overlay

### Struct type definition
- Add `:N` button enabled for all unsigned data types (`u8`,`u16`,...) creating child rows for bit-field name and bit length
<img width="586" height="289" alt="image" src="https://github.com/user-attachments/assets/329fb4d6-03e7-4720-943f-b80e41e83307" />

- Nested struct definition for bit fields in C struct preview
```c
typedef struct {
    uint8_t field0;                         /* +  0  1B */
    struct {
        uint8_t bit0:2;                     /*  0.. 1 */
        uint8_t bit1:3;                     /*  2.. 4 */
        uint8_t bit2:3;                     /*  5.. 7 */
    } field1;
    uint8_t field2;                         /* +  2  1B */
} MyStruct;                                 /* 3B, align=1 */
```

### Struct instance decode UI
- Treat the bit field overall value as a scalar field with bit fields as children
- Show the start bit position (`.N`) and bit length (`bit:N`) for each bit field
- **_(applicable when viewed as binary)_** Highlight the corresponding bits in the overall value when a child row is selected or hovered
<img width="566" height="99" alt="image" src="https://github.com/user-attachments/assets/4b8d93c6-b8ec-4275-aa2d-71552473c0c6" />
