### PR TITLE
fix: Records View rendering and remove dynamic HTML sink

### DIFF
--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { JSDOM } from 'jsdom';
 
 import { esc, fmtB, byteClass } from '../webview/utils';
 import { S, BPR } from '../webview/state';
@@ -258,5 +259,73 @@ suite('buildMemRows()', () => {
             assert.ok(dataRows[i].type === 'data' && dataRows[i - 1].type === 'data');
             assert.ok(dataRows[i].address > dataRows[i - 1].address);
         }
+    });
+});
+
+suite('Record View rendering', () => {
+    let dom: JSDOM;
+
+    setup(() => {
+        resetState();
+        dom = new JSDOM('<!doctype html><html><body><div id="record-view"></div></body></html>');
+        Object.defineProperty(globalThis, 'window', {
+            value: dom.window,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'document', {
+            value: dom.window.document,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'acquireVsCodeApi', {
+            value: () => ({
+                postMessage: (_msg: unknown) => {},
+                getState: () => ({}),
+                setState: (_state: unknown) => {},
+            }),
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    teardown(() => {
+        resetState();
+        dom.window.close();
+        delete (globalThis as unknown as { window?: Window }).window;
+        delete (globalThis as unknown as { document?: Document }).document;
+        delete (globalThis as unknown as { acquireVsCodeApi?: () => unknown }).acquireVsCodeApi;
+    });
+
+    test('renders records as table rows instead of escaped markup text', async () => {
+        S.parseResult = {
+            records: [
+                {
+                    lineNumber: 1,
+                    raw: ':0400000001020304F2',
+                    byteCount: 4,
+                    address: 0,
+                    recordType: 0,
+                    data: [1, 2, 3, 4],
+                    checksum: 0xF2,
+                    checksumValid: true,
+                    resolvedAddress: 0x08000000,
+                },
+            ],
+            recordCount: 1,
+            segments: [{ startAddress: 0x08000000, data: [1, 2, 3, 4] }],
+            totalDataBytes: 4,
+            checksumErrors: 0,
+            malformedLines: 0,
+            format: 'ihex',
+        };
+
+        const { renderRecordView } = await import('../webview/hexViewer.js');
+        renderRecordView();
+
+        const rows = document.querySelectorAll('#record-view tbody tr');
+        assert.strictEqual(rows.length, 1, 'record view should render a real table row');
+        assert.strictEqual(document.querySelector('#record-view .raddr')?.textContent, '08000000');
+        assert.ok(!(document.getElementById('record-view')?.textContent ?? '').includes('<tr'), 'record markup should not be escaped as text');
     });
 });

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -643,7 +643,7 @@ function renderRecordViewImpl(el: HTMLElement): void {
             (isSrec  && r.recordType === 0)                         ? 'rb-ext'   :
             r.error                                                 ? 'rb-bad'   : 'rb-data';
         const lbl = TYPE_LABELS[r.recordType] ?? (isSrec ? `S${r.recordType}` : `TYPE ${r.recordType}`);
-        const ra   = r.resolvedAddress.toString(16).toUpperCase().padStart(8, '0');
+        const ra   = esc(r.resolvedAddress.toString(16).toUpperCase().padStart(8, '0'));
         const data = r.data.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join(' ');
         const dataCell = r.error
             ? `<td class="rdata rerr-msg">${esc(r.error)}</td>`

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -586,7 +586,7 @@ const RECORD_BUFFER_ROWS = 5;
 const RECORD_MAX_SPACER_PX = 1_000_000;
 let recordRenderSignature = '';
 
-function renderRecordView(): void {
+export function renderRecordView(): void {
     const el = document.getElementById('record-view');
     if (!el || !S.parseResult) { return; }
 
@@ -660,7 +660,7 @@ function renderRecordViewImpl(el: HTMLElement): void {
             : `<td class="raddr raddr-empty">—</td>`;
 
         rows.push(`<tr${rowClass}>
-            ${esc(addrCell)}
+            ${addrCell}
             <td><span class="rbadge ${badge}">${esc(lbl)}</span></td>
             <td class="rcnt">${esc(String(r.byteCount))}</td>
             ${dataCell}
@@ -673,7 +673,7 @@ function renderRecordViewImpl(el: HTMLElement): void {
         appendRecordSpacerRows(rows, bottomOffset);
     }
 
-    el.innerHTML = `<table class="rtbl"><thead>${header}</thead><tbody>${rows.map(esc).join('')}</tbody></table>`;
+    el.innerHTML = `<table class="rtbl"><thead>${header}</thead><tbody>${rows.join('')}</tbody></table>`;
 }
 
 function appendRecordSpacerRows(rows: string[], totalHeight: number): void {

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -591,7 +591,7 @@ export function renderRecordView(): void {
     if (!el || !S.parseResult) { return; }
 
     if (S.parseResult.records.length === 0) {
-        el.innerHTML = `<div class="raw-problems" style="margin:10px"><div class="raw-problems-hdr"><span class="raw-problems-title">Record View Unavailable</span></div><div style="padding:10px 12px">Record details are not loaded in the webview. Use Memory view for navigation and editing.</div></div>`;
+        el.replaceChildren(recordViewUnavailableNode());
         return;
     }
 
@@ -622,9 +622,19 @@ function renderRecordViewImpl(el: HTMLElement): void {
     const isSrec = S.parseResult.format === 'srec';
     const TYPE_LABELS = isSrec ? SREC_TYPE_LABELS : IHEX_TYPE_LABELS;
 
-    const header = `<tr><th>Addr</th><th>Type</th><th>Cnt</th><th>Data</th><th>CHK</th></tr>`;
+    const table = document.createElement('table');
+    table.className = 'rtbl';
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    ['Addr', 'Type', 'Cnt', 'Data', 'CHK'].forEach(label => {
+        const th = document.createElement('th');
+        th.textContent = label;
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
 
-    const rows: string[] = [];
+    const rows: HTMLTableRowElement[] = [];
 
     if (firstVisibleIdx > 0) {
         const topOffset = firstVisibleIdx * RECORD_ROW_HEIGHT;
@@ -643,29 +653,20 @@ function renderRecordViewImpl(el: HTMLElement): void {
             (isSrec  && r.recordType === 0)                         ? 'rb-ext'   :
             r.error                                                 ? 'rb-bad'   : 'rb-data';
         const lbl = TYPE_LABELS[r.recordType] ?? (isSrec ? `S${r.recordType}` : `TYPE ${r.recordType}`);
-        const ra   = esc(r.resolvedAddress.toString(16).toUpperCase().padStart(8, '0'));
+        const ra   = r.resolvedAddress.toString(16).toUpperCase().padStart(8, '0');
         const data = r.data.map(b => b.toString(16).toUpperCase().padStart(2, '0')).join(' ');
-        const dataCell = r.error
-            ? `<td class="rdata rerr-msg">${esc(r.error)}</td>`
-            : `<td class="rdata">${data || '—'}</td>`;
-        const checksumHex = esc(String(r.checksum.toString(16).toUpperCase().padStart(2, '0')));
-        const chk  = r.error
-            ? `<span class="rerr-dash">—</span>`
-            : r.checksumValid
-                ? `<span class="cok">${checksumHex}</span>`
-                : `<span class="cerr">${checksumHex}</span><span class="cerr-tag">checksum error</span>`;
-        const rowClass = (r.error || !r.checksumValid) ? ' class="rerr"' : '';
-        const addrCell = isData
-            ? `<td class="raddr">${ra}</td>`
-            : `<td class="raddr raddr-empty">—</td>`;
+        const checksumHex = String(r.checksum.toString(16).toUpperCase().padStart(2, '0'));
 
-        rows.push(`<tr${rowClass}>
-            ${addrCell}
-            <td><span class="rbadge ${badge}">${esc(lbl)}</span></td>
-            <td class="rcnt">${esc(String(r.byteCount))}</td>
-            ${dataCell}
-            <td>${chk}</td>
-        </tr>`);
+        const row = document.createElement('tr');
+        if (r.error || !r.checksumValid) { row.className = 'rerr'; }
+        row.append(
+            recordCellFromText(isData ? 'raddr' : 'raddr raddr-empty', isData ? ra : '—'),
+            recordTypeCell(badge, lbl),
+            recordCellFromText('rcnt', String(r.byteCount)),
+            recordCellFromText(r.error ? 'rdata rerr-msg' : 'rdata', r.error ? r.error : (data || '—')),
+            recordChecksumCell(!!r.error, r.checksumValid, checksumHex),
+        );
+        rows.push(row);
     }
 
     if (lastVisibleIdx < recordCount - 1) {
@@ -673,17 +674,88 @@ function renderRecordViewImpl(el: HTMLElement): void {
         appendRecordSpacerRows(rows, bottomOffset);
     }
 
-    el.innerHTML = `<table class="rtbl"><thead>${header}</thead><tbody>${rows.join('')}</tbody></table>`;
+    const tbody = document.createElement('tbody');
+    tbody.append(...rows);
+    table.appendChild(tbody);
+    el.replaceChildren(table);
 }
 
-function appendRecordSpacerRows(rows: string[], totalHeight: number): void {
+function appendRecordSpacerRows(rows: HTMLTableRowElement[], totalHeight: number): void {
     let remaining = totalHeight;
     while (remaining > 0) {
         const chunk = Math.min(remaining, RECORD_MAX_SPACER_PX);
         const safeChunk = Math.max(0, Math.floor(chunk));
-        rows.push(`<tr style="height:${safeChunk}px"><td colspan="5"></td></tr>`);
+        const row = document.createElement('tr');
+        row.style.height = `${safeChunk}px`;
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        row.appendChild(cell);
+        rows.push(row);
         remaining -= chunk;
     }
+}
+
+function recordCellFromText(className: string, text: string): HTMLTableCellElement {
+    const cell = document.createElement('td');
+    cell.className = className;
+    cell.textContent = text;
+    return cell;
+}
+
+function recordTypeCell(badgeClass: string, label: string): HTMLTableCellElement {
+    const cell = document.createElement('td');
+    const badge = document.createElement('span');
+    badge.className = `rbadge ${badgeClass}`;
+    badge.textContent = label;
+    cell.appendChild(badge);
+    return cell;
+}
+
+function recordChecksumCell(hasError: boolean, checksumValid: boolean, checksumHex: string): HTMLTableCellElement {
+    const cell = document.createElement('td');
+    if (hasError) {
+        const dash = document.createElement('span');
+        dash.className = 'rerr-dash';
+        dash.textContent = '—';
+        cell.appendChild(dash);
+        return cell;
+    }
+    if (checksumValid) {
+        const ok = document.createElement('span');
+        ok.className = 'cok';
+        ok.textContent = checksumHex;
+        cell.appendChild(ok);
+        return cell;
+    }
+
+    const bad = document.createElement('span');
+    bad.className = 'cerr';
+    bad.textContent = checksumHex;
+    const tag = document.createElement('span');
+    tag.className = 'cerr-tag';
+    tag.textContent = 'checksum error';
+    cell.append(bad, tag);
+    return cell;
+}
+
+function recordViewUnavailableNode(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'raw-problems';
+    wrapper.style.margin = '10px';
+
+    const header = document.createElement('div');
+    header.className = 'raw-problems-hdr';
+    const title = document.createElement('span');
+    title.className = 'raw-problems-title';
+    title.textContent = 'Record View Unavailable';
+    header.appendChild(title);
+
+    const body = document.createElement('div');
+    body.style.padding = '10px 12px';
+    body.textContent = 'Record details are not loaded in the webview. Use Memory view for navigation and editing.';
+
+    wrapper.append(header, body);
+    return wrapper;
 }
 
 // ── View switching ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes Records View rendering by preserving table row/cell markup while still escaping record content
Adds a regression test to ensure records render as real table rows instead of escaped HTML text