### PR TITLE
fix: ignore .github directory in vsce packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,4 +14,4 @@ vsc-extension-quickstart.md
 **/*.ts
 **/.vscode-test.*
 sample/**
-github/**
+.github/**


### PR DESCRIPTION
Exclude the `.github` directory from VSCE packaging to reduce the extension size