### PR TITLE
fix: restore large memory scrolling

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.7.2] - 2026-06-13
+
+### Fixed
+
+- Fixed Memory view scrolling near the end of large files, especially when VS Code is zoomed in
+- Fixed blank or missing rows that could appear even though valid memory data was loaded
+- Improved Record view scrolling for very large files and zoomed-in layouts
+
 ## [2.7.1] - 2026-06-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -4,6 +4,14 @@ import { JSDOM } from 'jsdom';
 import { esc, fmtB, byteClass } from '../webview/utils';
 import { S, BPR } from '../webview/state';
 import { initFlatBytes, buildMemRows, getByte } from '../webview/data';
+import {
+    calcRowOffset,
+    calcScrollLayout,
+    calcTotalHeight,
+    logicalToPhysicalScroll,
+    physicalToLogicalScroll,
+    type VirtualScrollState,
+} from '../webview/virtualScroll';
 
 function resetState(): void {
     S.parseResult  = null;
@@ -262,6 +270,56 @@ suite('buildMemRows()', () => {
             assert.ok(dataRows[i].type === 'data' && dataRows[i - 1].type === 'data');
             assert.ok(dataRows[i].address > dataRows[i - 1].address);
         }
+    });
+});
+
+suite('virtual scroll metrics', () => {
+    setup(resetState);
+
+    test('recalculates cached offsets when row heights change', () => {
+        S.memRows = [
+            { type: 'data', address: 0x0000 },
+            { type: 'gap', from: 0x0010, to: 0x001F, bytes: 16 },
+            { type: 'data', address: 0x0020 },
+        ];
+
+        const state: VirtualScrollState = {
+            containerHeight: 100,
+            rowHeight: 20,
+            gapHeight: 30,
+            scrollTop: 0,
+            bufferSize: 10,
+            visibleRowIndices: [0, 0],
+        };
+
+        assert.strictEqual(calcTotalHeight(state), 70);
+
+        state.rowHeight = 32;
+        state.gapHeight = 52;
+
+        assert.strictEqual(calcTotalHeight(state), 116);
+        assert.strictEqual(calcRowOffset(2, state), 84);
+    });
+
+    test('maps large logical scroll ranges onto capped physical height', () => {
+        S.memRows = Array.from({ length: 200_000 }, (_, i) => ({ type: 'data', address: i * BPR }));
+
+        const state: VirtualScrollState = {
+            containerHeight: 100,
+            rowHeight: 100,
+            gapHeight: 150,
+            scrollTop: 0,
+            bufferSize: 10,
+            visibleRowIndices: [0, 0],
+        };
+
+        const layout = calcScrollLayout(state);
+        assert.strictEqual(layout.totalHeight, 20_000_000);
+        assert.strictEqual(layout.physicalHeight, 16_000_000);
+        assert.strictEqual(layout.isCompressed, true);
+
+        assert.strictEqual(logicalToPhysicalScroll(layout.logicalScrollable, state), layout.physicalScrollable);
+        assert.strictEqual(physicalToLogicalScroll(layout.physicalScrollable, state), layout.logicalScrollable);
     });
 });
 

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -10,6 +10,7 @@ import { renderInspector, renderBits, renderLabels, updateInspector, updateLabel
 import { renderStructPins, onSelectionChangeForStruct, resetStructViewState } from './struct';
 import { initSearch, runSearch, clearSearch, nextMatch, prevMatch } from './searchEngine';
 import { initFlatBytes, buildMemRows, getByte }      from './data';
+import { MAX_VIRTUAL_SCROLL_HEIGHT }                 from './virtualScroll';
 
 vscode.postMessage({ type: 'ready' });
 
@@ -581,10 +582,61 @@ const SREC_TYPE_LABELS: Record<number, string> = {
     5: 'COUNT', 6: 'COUNT S6', 7: 'END S7', 8: 'END S8', 9: 'END S9',
 };
 
-const RECORD_ROW_HEIGHT = 28;
+const RECORD_FALLBACK_ROW_HEIGHT = 28;
 const RECORD_BUFFER_ROWS = 5;
 const RECORD_MAX_SPACER_PX = 1_000_000;
 let recordRenderSignature = '';
+
+interface RecordScrollLayout {
+    totalHeight: number;
+    physicalHeight: number;
+    logicalScrollable: number;
+    physicalScrollable: number;
+    isCompressed: boolean;
+}
+
+function calcRecordScrollLayout(recordCount: number, containerHeight: number, rowHeight: number): RecordScrollLayout {
+    const totalHeight = recordCount * rowHeight;
+    const physicalHeight = Math.min(totalHeight, MAX_VIRTUAL_SCROLL_HEIGHT);
+    const logicalScrollable = Math.max(0, totalHeight - containerHeight);
+    const physicalScrollable = Math.max(0, physicalHeight - containerHeight);
+
+    return {
+        totalHeight,
+        physicalHeight,
+        logicalScrollable,
+        physicalScrollable,
+        isCompressed: totalHeight > physicalHeight,
+    };
+}
+
+function recordPhysicalToLogicalScroll(physicalScrollTop: number, layout: RecordScrollLayout): number {
+    if (!layout.isCompressed || layout.physicalScrollable <= 0 || layout.logicalScrollable <= 0) {
+        return Math.max(0, Math.min(physicalScrollTop, layout.logicalScrollable));
+    }
+    const ratio = Math.max(0, Math.min(physicalScrollTop, layout.physicalScrollable)) / layout.physicalScrollable;
+    return ratio * layout.logicalScrollable;
+}
+
+function getRecordRowHeight(el: HTMLElement): number {
+    const table = document.createElement('table');
+    table.className = 'rtbl';
+    table.style.position = 'absolute';
+    table.style.visibility = 'hidden';
+    table.style.pointerEvents = 'none';
+    table.style.width = '100%';
+
+    const tbody = document.createElement('tbody');
+    const row = document.createElement('tr');
+    row.appendChild(recordCellFromText('raddr', '00000000'));
+    tbody.appendChild(row);
+    table.appendChild(tbody);
+    el.appendChild(table);
+
+    const height = row.getBoundingClientRect().height;
+    table.remove();
+    return height > 0 ? height : RECORD_FALLBACK_ROW_HEIGHT;
+}
 
 export function renderRecordView(): void {
     const el = document.getElementById('record-view');
@@ -611,11 +663,14 @@ function renderRecordViewImpl(el: HTMLElement): void {
 
     const recordCount = S.parseResult.records.length;
     const containerHeight = el.clientHeight;
-    const scrollTop = el.scrollTop;
+    const rowHeight = getRecordRowHeight(el);
+    const layout = calcRecordScrollLayout(recordCount, containerHeight, rowHeight);
+    const physicalScrollTop = el.scrollTop;
+    const scrollTop = recordPhysicalToLogicalScroll(physicalScrollTop, layout);
 
-    const firstVisibleIdx = Math.max(0, Math.floor(scrollTop / RECORD_ROW_HEIGHT) - RECORD_BUFFER_ROWS);
-    const lastVisibleIdx = Math.min(recordCount - 1, Math.ceil((scrollTop + containerHeight) / RECORD_ROW_HEIGHT) + RECORD_BUFFER_ROWS);
-    const signature = `${recordCount}:${firstVisibleIdx}:${lastVisibleIdx}`;
+    const firstVisibleIdx = Math.max(0, Math.floor(scrollTop / rowHeight) - RECORD_BUFFER_ROWS);
+    const lastVisibleIdx = Math.min(recordCount - 1, Math.ceil((scrollTop + containerHeight) / rowHeight) + RECORD_BUFFER_ROWS);
+    const signature = `${recordCount}:${firstVisibleIdx}:${lastVisibleIdx}:${layout.isCompressed ? Math.floor(physicalScrollTop) : ''}`;
     if (signature === recordRenderSignature) { return; }
     recordRenderSignature = signature;
 
@@ -637,8 +692,10 @@ function renderRecordViewImpl(el: HTMLElement): void {
     const rows: HTMLTableRowElement[] = [];
 
     if (firstVisibleIdx > 0) {
-        const topOffset = firstVisibleIdx * RECORD_ROW_HEIGHT;
-        appendRecordSpacerRows(rows, topOffset);
+        const topOffset = firstVisibleIdx * rowHeight;
+        if (!layout.isCompressed) {
+            appendRecordSpacerRows(rows, topOffset);
+        }
     }
 
     for (let i = Math.max(0, firstVisibleIdx); i <= lastVisibleIdx && i < recordCount; i++) {
@@ -670,14 +727,29 @@ function renderRecordViewImpl(el: HTMLElement): void {
     }
 
     if (lastVisibleIdx < recordCount - 1) {
-        const bottomOffset = (recordCount - 1 - lastVisibleIdx) * RECORD_ROW_HEIGHT;
-        appendRecordSpacerRows(rows, bottomOffset);
+        const bottomOffset = (recordCount - 1 - lastVisibleIdx) * rowHeight;
+        if (!layout.isCompressed) {
+            appendRecordSpacerRows(rows, bottomOffset);
+        }
     }
 
     const tbody = document.createElement('tbody');
     tbody.append(...rows);
     table.appendChild(tbody);
-    el.replaceChildren(table);
+
+    if (layout.isCompressed) {
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.height = `${layout.physicalHeight}px`;
+        const topOffset = firstVisibleIdx * rowHeight;
+        table.style.position = 'absolute';
+        table.style.top = `${physicalScrollTop + topOffset - scrollTop}px`;
+        table.style.left = '0';
+        wrapper.appendChild(table);
+        el.replaceChildren(wrapper);
+    } else {
+        el.replaceChildren(table);
+    }
 }
 
 function appendRecordSpacerRows(rows: HTMLTableRowElement[], totalHeight: number): void {

--- a/src/webview/memoryView.ts
+++ b/src/webview/memoryView.ts
@@ -6,22 +6,88 @@
 import { S, BPR } from './state';
 import { getByte } from './data';
 import { esc, fmtB, byteClass } from './utils';
-import { calcVisibleRange, calcTotalHeight, calcRowOffset, type VirtualScrollState } from './virtualScroll';
+import {
+    calcScrollLayout,
+    calcVisibleRange,
+    calcTotalHeight,
+    calcRowOffset,
+    logicalToPhysicalScroll,
+    physicalToLogicalScroll,
+    type VirtualScrollState,
+} from './virtualScroll';
 
 //  Virtual scroll state 
 let vscrollState: VirtualScrollState | null = null;
 let vscrollRenderedRange: [number, number] = [0, 0];
 
 const VIRTUAL_SCROLL_CONFIG = {
-    rowHeight: 20,   // CSS: var(--cell-size)  20px
-    gapHeight: 30,   // CSS: var(--cell-size) * 1.5  30px
-    bufferSize: 10,  // render 10 rows above/below viewport
+    fallbackRowHeight: 20.8,  // CSS fallback: 13px * 1.6
+    fallbackGapHeight: 35.2,  // CSS fallback: row * 1.5 + 2px vertical margins
+    bufferSize: 10,           // render 10 rows above/below viewport
 };
 
 function syncHeaderScroll(scrollLeft: number): void {
     const header = document.getElementById('mem-header');
     if (!header) { return; }
     header.scrollLeft = scrollLeft;
+}
+
+function parsePx(value: string | null | undefined): number | null {
+    if (!value) { return null; }
+    const n = parseFloat(value.trim());
+    return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function measureCssHeight(scrollContainer: HTMLElement, cssHeight: string, fallback: number): number {
+    const probe = document.createElement('div');
+    probe.style.position = 'absolute';
+    probe.style.visibility = 'hidden';
+    probe.style.pointerEvents = 'none';
+    probe.style.height = cssHeight;
+    probe.style.width = '0';
+    probe.style.margin = '0';
+    probe.style.padding = '0';
+    probe.style.border = '0';
+    scrollContainer.appendChild(probe);
+    const height = parsePx(getComputedStyle(probe).height) ?? probe.getBoundingClientRect().height;
+    probe.remove();
+    return height > 0 ? height : fallback;
+}
+
+function getVirtualScrollMetrics(scrollContainer: HTMLElement): { rowHeight: number; gapHeight: number } {
+    const rootStyle = getComputedStyle(document.documentElement);
+    const editorFontSize = parsePx(rootStyle.getPropertyValue('--vscode-editor-font-size'));
+
+    if (editorFontSize !== null) {
+        const rowHeight = editorFontSize * 1.6;
+        return {
+            rowHeight,
+            gapHeight: rowHeight * 1.5 + 4,
+        };
+    }
+
+    const rowHeight = measureCssHeight(scrollContainer, 'var(--cell-size)', VIRTUAL_SCROLL_CONFIG.fallbackRowHeight);
+    const gapBoxHeight = measureCssHeight(scrollContainer, 'calc(var(--cell-size) * 1.5)', rowHeight * 1.5);
+    return {
+        rowHeight,
+        gapHeight: gapBoxHeight + 4,
+    };
+}
+
+function syncVirtualScrollMetrics(scrollContainer: HTMLElement): void {
+    if (!vscrollState) { return; }
+    const { rowHeight, gapHeight } = getVirtualScrollMetrics(scrollContainer);
+    const containerHeight = scrollContainer.clientHeight;
+    if (
+        Math.abs(vscrollState.rowHeight - rowHeight) < 0.01 &&
+        Math.abs(vscrollState.gapHeight - gapHeight) < 0.01 &&
+        vscrollState.containerHeight === containerHeight
+    ) { return; }
+
+    vscrollState.rowHeight = rowHeight;
+    vscrollState.gapHeight = gapHeight;
+    vscrollState.containerHeight = containerHeight;
+    vscrollRenderedRange = [-1, -1];
 }
 
 //  Column header 
@@ -44,14 +110,17 @@ export function renderMemHeader(): void {
 function renderVisibleRows(): void {
     if (!vscrollState) { return; }
 
-    const [startIdx, endIdx] = calcVisibleRange(vscrollState);
-
-    // No change in rendered range? Skip
-    if (startIdx === vscrollRenderedRange[0] && endIdx === vscrollRenderedRange[1]) { return; }
-    vscrollRenderedRange = [startIdx, endIdx];
-
     const container = document.getElementById('mem-rows')!;
     const scrollContainer = document.getElementById('mem-scroll')!;
+    syncVirtualScrollMetrics(scrollContainer);
+
+    const [startIdx, endIdx] = calcVisibleRange(vscrollState);
+    const layout = calcScrollLayout(vscrollState);
+
+    // No change in rendered range? Skip
+    if (!layout.isCompressed && startIdx === vscrollRenderedRange[0] && endIdx === vscrollRenderedRange[1]) { return; }
+    vscrollRenderedRange = [startIdx, endIdx];
+
     const labelMap = buildLabelMap();
 
     // Calculate offset for top spacer
@@ -59,8 +128,16 @@ function renderVisibleRows(): void {
 
     const parts: string[] = [];
 
+    if (layout.isCompressed) {
+        container.style.position = 'relative';
+        container.style.height = `${layout.physicalHeight}px`;
+    } else {
+        container.style.position = '';
+        container.style.height = '';
+    }
+
     // Top spacer (invisible, maintains scroll height ratio)
-    if (topOffset > 0) {
+    if (!layout.isCompressed && topOffset > 0) {
         parts.push(`<div style="height:${topOffset}px"></div>`);
     }
 
@@ -89,11 +166,17 @@ function renderVisibleRows(): void {
     // Bottom spacer
     const totalHeight = calcTotalHeight(vscrollState);
     const bottomOffset = totalHeight - calcRowOffset(endIdx, vscrollState);
-    if (bottomOffset > 0) {
+    if (!layout.isCompressed && bottomOffset > 0) {
         parts.push(`<div style="height:${bottomOffset}px"></div>`);
     }
 
-    container.innerHTML = parts.join('');
+    if (layout.isCompressed) {
+        const physicalScrollTop = scrollContainer.scrollTop;
+        const windowTop = physicalScrollTop + topOffset - vscrollState.scrollTop;
+        container.innerHTML = `<div style="position:absolute;top:${windowTop}px;left:0;width:max-content;min-width:100%">${parts.join('')}</div>`;
+    } else {
+        container.innerHTML = parts.join('');
+    }
 
     // Re-attach interaction callbacks
     const onHexDown = (scrollContainer as any)._hexDownCallback;
@@ -138,11 +221,12 @@ export function renderMemBody(
 
     // Initialize virtual scroll state
     const scrollContainer = document.getElementById('mem-scroll')!;
+    const { rowHeight, gapHeight } = getVirtualScrollMetrics(scrollContainer);
 
     vscrollState = {
         containerHeight: scrollContainer.clientHeight,
-        rowHeight: VIRTUAL_SCROLL_CONFIG.rowHeight,
-        gapHeight: VIRTUAL_SCROLL_CONFIG.gapHeight,
+        rowHeight,
+        gapHeight,
         scrollTop: scrollContainer.scrollTop,
         bufferSize: VIRTUAL_SCROLL_CONFIG.bufferSize,
         visibleRowIndices: [0, 0],
@@ -188,8 +272,13 @@ export function renderMemBody(
         scrollContainer.dataset.vscrollInit = '1';
         scrollContainer.addEventListener('scroll', () => {
             if (!vscrollState) { return; }
-            vscrollState.scrollTop = scrollContainer.scrollTop;
+            vscrollState.scrollTop = physicalToLogicalScroll(scrollContainer.scrollTop, vscrollState);
             syncHeaderScroll(scrollContainer.scrollLeft);
+            renderVisibleRows();
+        });
+        window.addEventListener('resize', () => {
+            if (!vscrollState) { return; }
+            vscrollState.scrollTop = physicalToLogicalScroll(scrollContainer.scrollTop, vscrollState);
             renderVisibleRows();
         });
     }
@@ -405,13 +494,16 @@ export function scrollTo(addr: number): void {
     const rowIndex = findRowIndex(row);
     if (rowIndex < 0) { return; }
 
+    syncVirtualScrollMetrics(scrollContainer);
     const targetTop = Math.max(0, calcRowOffset(rowIndex, vscrollState) - vscrollState.rowHeight * 2);
+    const layout = calcScrollLayout(vscrollState);
+    const physicalTop = logicalToPhysicalScroll(targetTop, vscrollState);
     vscrollState.scrollTop = targetTop;
-    scrollContainer.scrollTop = targetTop;
+    scrollContainer.scrollTop = physicalTop;
     renderVisibleRows();
 
     const el = document.querySelector<HTMLElement>(`.data-row[data-row="${row}"]`);
-    if (el) { el.scrollIntoView({ block: 'nearest', behavior: 'smooth' }); }
+    if (el && !layout.isCompressed) { el.scrollIntoView({ block: 'nearest', behavior: 'smooth' }); }
 }
 
 function findRowIndex(rowBase: number): number {

--- a/src/webview/virtualScroll.ts
+++ b/src/webview/virtualScroll.ts
@@ -14,12 +14,29 @@ export interface VirtualScrollState {
     visibleRowIndices: [number, number];  // [start, end) indices into S.memRows
 }
 
+export interface VirtualScrollLayout {
+    totalHeight: number;
+    physicalHeight: number;
+    logicalScrollable: number;
+    physicalScrollable: number;
+    isCompressed: boolean;
+}
+
+export const MAX_VIRTUAL_SCROLL_HEIGHT = 16_000_000;
+
 let cacheLen = -1;
+let cacheRowHeight = -1;
+let cacheGapHeight = -1;
 let cumulativeHeights: number[] = [];
 let cachedTotalHeight = 0;
 
 function ensureHeightCache(state: VirtualScrollState): void {
-    if (cacheLen === S.memRows.length && cumulativeHeights.length === S.memRows.length + 1) { return; }
+    if (
+        cacheLen === S.memRows.length &&
+        cacheRowHeight === state.rowHeight &&
+        cacheGapHeight === state.gapHeight &&
+        cumulativeHeights.length === S.memRows.length + 1
+    ) { return; }
     cumulativeHeights = new Array<number>(S.memRows.length + 1);
     cumulativeHeights[0] = 0;
     for (let i = 0; i < S.memRows.length; i++) {
@@ -28,6 +45,8 @@ function ensureHeightCache(state: VirtualScrollState): void {
     }
     cachedTotalHeight = cumulativeHeights[S.memRows.length] ?? 0;
     cacheLen = S.memRows.length;
+    cacheRowHeight = state.rowHeight;
+    cacheGapHeight = state.gapHeight;
 }
 
 function lowerBound(values: number[], target: number): number {
@@ -85,4 +104,37 @@ export function calcRangeHeight(start: number, end: number, state: VirtualScroll
     const s = Math.max(0, Math.min(start, S.memRows.length));
     const e = Math.max(s, Math.min(end, S.memRows.length));
     return (cumulativeHeights[e] ?? 0) - (cumulativeHeights[s] ?? 0);
+}
+
+export function calcScrollLayout(state: VirtualScrollState, maxPhysicalHeight = MAX_VIRTUAL_SCROLL_HEIGHT): VirtualScrollLayout {
+    const totalHeight = calcTotalHeight(state);
+    const physicalHeight = Math.min(totalHeight, maxPhysicalHeight);
+    const logicalScrollable = Math.max(0, totalHeight - state.containerHeight);
+    const physicalScrollable = Math.max(0, physicalHeight - state.containerHeight);
+
+    return {
+        totalHeight,
+        physicalHeight,
+        logicalScrollable,
+        physicalScrollable,
+        isCompressed: totalHeight > physicalHeight,
+    };
+}
+
+export function physicalToLogicalScroll(physicalScrollTop: number, state: VirtualScrollState): number {
+    const layout = calcScrollLayout(state);
+    if (!layout.isCompressed || layout.physicalScrollable <= 0 || layout.logicalScrollable <= 0) {
+        return Math.max(0, Math.min(physicalScrollTop, layout.logicalScrollable));
+    }
+    const ratio = Math.max(0, Math.min(physicalScrollTop, layout.physicalScrollable)) / layout.physicalScrollable;
+    return ratio * layout.logicalScrollable;
+}
+
+export function logicalToPhysicalScroll(logicalScrollTop: number, state: VirtualScrollState): number {
+    const layout = calcScrollLayout(state);
+    if (!layout.isCompressed || layout.physicalScrollable <= 0 || layout.logicalScrollable <= 0) {
+        return Math.max(0, Math.min(logicalScrollTop, layout.physicalScrollable));
+    }
+    const ratio = Math.max(0, Math.min(logicalScrollTop, layout.logicalScrollable)) / layout.logicalScrollable;
+    return ratio * layout.physicalScrollable;
 }


### PR DESCRIPTION
- Fixed Memory view scrolling near the end of large files, especially when VS Code is zoomed in
- Fixed blank or missing rows that could appear even though valid memory data was loaded
- Improved Record view scrolling for very large files and zoomed-in layouts