### PR TITLE
feat: add integrity checks sidebar

### DIFF
--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -315,7 +315,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
         const cssFiles = [
             'base', 'toolbar', 'layout', 'sidebar',
-            'record-view', 'memory-view', 'context-menu', 'struct',
+            'record-view', 'memory-view', 'context-menu', 'struct', 'integrity',
         ];
         const cssLinks = cssFiles.map(name => {
             const uri = webview.asWebviewUri(

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+
+import {
+    calculateIntegrity,
+    collectIntegrityBytes,
+    parseIntegrityAddress,
+    type IntegrityAlgorithm,
+    validateIntegrityRange,
+} from '../webview/integrity';
+
+const VECTOR = new TextEncoder().encode('123456789');
+const EXPECTED: Record<IntegrityAlgorithm, string> = {
+    'crc16-ccitt-false': '29B1',
+    'crc32-iso-hdlc': 'CBF43926',
+    md5: '25F9E794323B453885F5181F1B624D0B',
+    'sha-1': 'F7C3BC1D808E04732ADF679965CCC34CA7AE3441',
+    'sha-256': '15E2B0D3C33891EBB0F1EF609EC419420C20E320CE94C65FBC8C3312448EB225',
+    'sha-512': 'D9E6762DD1C8EAF6D61B3C6192FC408D4D6D5F1176D0C29169BC24E71C3F274AD27FCD5811B313D681F7E55EC02D73D499C95455B6B5BB503ACF574FBA8FFE85',
+};
+
+suite('integrity algorithms', () => {
+    for (const [algorithm, expected] of Object.entries(EXPECTED) as Array<[IntegrityAlgorithm, string]>) {
+        test(`${algorithm} matches the 123456789 vector`, async () => {
+            const result = await calculateIntegrity(algorithm, VECTOR);
+            assert.strictEqual(result.value, expected);
+            assert.strictEqual(result.byteCount, 9);
+        });
+    }
+});
+
+suite('integrity range parsing', () => {
+    test('accepts optional 0x and case-insensitive hexadecimal', () => {
+        assert.deepStrictEqual(parseIntegrityAddress('0xAbCd', 'Start'), { ok: true, value: 0xABCD });
+        assert.deepStrictEqual(parseIntegrityAddress('abcd', 'Start'), { ok: true, value: 0xABCD });
+    });
+
+    test('uses inclusive start and end addresses', () => {
+        const request = validateIntegrityRange('1000', '1002', 'sha-256');
+        assert.strictEqual(request.ok, true);
+        if (!request.ok) { return; }
+        const bytes = collectIntegrityBytes(request.value, address => address - 0x1000 + 1);
+        assert.deepStrictEqual(bytes, { ok: true, value: new Uint8Array([1, 2, 3]) });
+    });
+
+    test('supports a single-byte range', () => {
+        const request = validateIntegrityRange('FFFFFFFF', '0xFFFFFFFF', 'crc32-iso-hdlc');
+        assert.strictEqual(request.ok, true);
+        if (!request.ok) { return; }
+        assert.deepStrictEqual(collectIntegrityBytes(request.value, () => 0xA5), {
+            ok: true,
+            value: new Uint8Array([0xA5]),
+        });
+    });
+
+    test('rejects empty, malformed, overflow, and reversed ranges', () => {
+        assert.strictEqual(validateIntegrityRange('', '10', 'md5').ok, false);
+        assert.strictEqual(validateIntegrityRange('xyz', '10', 'md5').ok, false);
+        assert.strictEqual(validateIntegrityRange('100000000', '100000000', 'md5').ok, false);
+        assert.strictEqual(validateIntegrityRange('20', '10', 'md5').ok, false);
+    });
+
+    test('reports first unmapped address', () => {
+        const request = validateIntegrityRange('1000', '1003', 'sha-1');
+        assert.strictEqual(request.ok, true);
+        if (!request.ok) { return; }
+        const bytes = collectIntegrityBytes(request.value, address => address === 0x1002 ? undefined : 0);
+        assert.deepStrictEqual(bytes, { ok: false, error: 'No mapped byte at 0x00001002.' });
+    });
+
+    test('read callback can apply pending edits over source bytes', () => {
+        const request = validateIntegrityRange('2000', '2002', 'crc16-ccitt-false');
+        assert.strictEqual(request.ok, true);
+        if (!request.ok) { return; }
+        const source = new Map([[0x2000, 1], [0x2001, 2], [0x2002, 3]]);
+        const edits = new Map([[0x2001, 0xFF]]);
+        const bytes = collectIntegrityBytes(request.value, address => edits.get(address) ?? source.get(address));
+        assert.deepStrictEqual(bytes, { ok: true, value: new Uint8Array([1, 0xFF, 3]) });
+    });
+});

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -508,3 +508,76 @@ suite('Record View rendering', () => {
         assert.ok(!(document.getElementById('record-view')?.textContent ?? '').includes('<tr'), 'record markup should not be escaped as text');
     });
 });
+
+suite('Integrity Checks sidebar', () => {
+    let dom: JSDOM;
+
+    setup(() => {
+        resetState();
+        dom = installWebviewDom('<!doctype html><html><body><div id="s-integrity"></div></body></html>');
+        S.parseResult = {
+            records: [],
+            segments: [{ startAddress: 0x1000, data: [1, 2, 3, 4] }],
+            totalDataBytes: 4,
+            checksumErrors: 0,
+            malformedLines: 0,
+            format: 'ihex',
+        };
+        initFlatBytes();
+        S.selStart = 0x1000;
+        S.selEnd = 0x1002;
+    });
+
+    teardown(() => cleanupWebviewDom(dom));
+
+    test('prefills once, recalculates visible bytes, clears invalid results, and copies', async () => {
+        const api = await import('../webview/api.js');
+        const originalPostMessage = api.vscode.postMessage;
+        const posted: unknown[] = [];
+        api.vscode.postMessage = msg => { posted.push(msg); };
+
+        try {
+            const view = await import('../webview/integrityView.js');
+            const { calculateIntegrity } = await import('../webview/integrity.js');
+            view.renderIntegrity();
+            view.activateIntegrity();
+
+            const start = document.getElementById('integrity-start') as HTMLInputElement;
+            const end = document.getElementById('integrity-end') as HTMLInputElement;
+            assert.strictEqual(start.value, '0x00001000');
+            assert.strictEqual(end.value, '0x00001002');
+
+            await new Promise(resolve => setTimeout(resolve, 300));
+            const expectedInitial = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([1, 2, 3]));
+            assert.strictEqual(document.getElementById('integrity-value')?.textContent, expectedInitial.value);
+
+            start.value = '1001';
+            start.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+            view.activateIntegrity();
+            assert.strictEqual(start.value, '1001', 'later activation must preserve user range');
+
+            S.edits.set(0x1001, 0xFF);
+            view.notifyIntegrityBytesChanged();
+            await new Promise(resolve => setTimeout(resolve, 300));
+            const expectedEdited = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
+            assert.strictEqual(document.getElementById('integrity-value')?.textContent, expectedEdited.value);
+
+            end.value = 'not-hex';
+            end.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+            assert.strictEqual((document.getElementById('integrity-result') as HTMLElement).hidden, true);
+            assert.match(document.getElementById('integrity-error')?.textContent ?? '', /hexadecimal/);
+
+            end.value = '1002';
+            end.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+            await new Promise(resolve => setTimeout(resolve, 300));
+            document.getElementById('integrity-copy')?.click();
+            assert.deepStrictEqual(posted.at(-1), {
+                type: 'copyText',
+                text: expectedEdited.value,
+                label: 'CRC32/ISO-HDLC',
+            });
+        } finally {
+            api.vscode.postMessage = originalPostMessage;
+        }
+    });
+});

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -509,6 +509,75 @@ suite('Record View rendering', () => {
     });
 });
 
+type IntegrityViewModule = typeof import('../webview/integrityView.js');
+type IntegrityCalculator = typeof import('../webview/integrity.js').calculateIntegrity;
+
+function integrityInputs(): { start: HTMLInputElement; end: HTMLInputElement } {
+    return {
+        start: document.getElementById('integrity-start') as HTMLInputElement,
+        end: document.getElementById('integrity-end') as HTMLInputElement,
+    };
+}
+
+function setIntegrityInput(input: HTMLInputElement, value: string, dom: JSDOM): void {
+    input.value = value;
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+}
+
+async function waitForIntegrityCalculation(): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 300));
+}
+
+async function verifyInitialIntegrityResult(
+    view: IntegrityViewModule,
+    calculateIntegrity: IntegrityCalculator,
+): Promise<void> {
+    view.renderIntegrity();
+    view.activateIntegrity();
+    const { start, end } = integrityInputs();
+    assert.strictEqual(start.value, '0x00001000');
+    assert.strictEqual(end.value, '0x00001002');
+    await waitForIntegrityCalculation();
+    const expected = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([1, 2, 3]));
+    assert.strictEqual(document.getElementById('integrity-value')!.textContent, expected.value);
+}
+
+async function verifyEditedIntegrityResult(
+    view: IntegrityViewModule,
+    calculateIntegrity: IntegrityCalculator,
+    dom: JSDOM,
+): Promise<string> {
+    const { start } = integrityInputs();
+    setIntegrityInput(start, '1001', dom);
+    view.activateIntegrity();
+    assert.strictEqual(start.value, '1001', 'later activation must preserve user range');
+    S.edits.set(0x1001, 0xFF);
+    view.notifyIntegrityBytesChanged();
+    await waitForIntegrityCalculation();
+    const expected = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
+    assert.strictEqual(document.getElementById('integrity-value')!.textContent, expected.value);
+    return expected.value;
+}
+
+function verifyInvalidIntegrityRange(dom: JSDOM): void {
+    const { end } = integrityInputs();
+    setIntegrityInput(end, 'not-hex', dom);
+    assert.strictEqual((document.getElementById('integrity-result') as HTMLElement).hidden, true);
+    assert.match(document.getElementById('integrity-error')!.textContent!, /hexadecimal/);
+}
+
+async function verifyIntegrityCopy(dom: JSDOM, expected: string, posted: unknown[]): Promise<void> {
+    const { end } = integrityInputs();
+    setIntegrityInput(end, '1002', dom);
+    await waitForIntegrityCalculation();
+    document.getElementById('integrity-copy')!.click();
+    assert.deepStrictEqual(posted.at(-1), {
+        type: 'copyText',
+        text: expected,
+        label: 'CRC32/ISO-HDLC',
+    });
+}
+
 suite('Integrity Checks sidebar', () => {
     let dom: JSDOM;
 
@@ -539,43 +608,10 @@ suite('Integrity Checks sidebar', () => {
         try {
             const view = await import('../webview/integrityView.js');
             const { calculateIntegrity } = await import('../webview/integrity.js');
-            view.renderIntegrity();
-            view.activateIntegrity();
-
-            const start = document.getElementById('integrity-start') as HTMLInputElement;
-            const end = document.getElementById('integrity-end') as HTMLInputElement;
-            assert.strictEqual(start.value, '0x00001000');
-            assert.strictEqual(end.value, '0x00001002');
-
-            await new Promise(resolve => setTimeout(resolve, 300));
-            const expectedInitial = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([1, 2, 3]));
-            assert.strictEqual(document.getElementById('integrity-value')?.textContent, expectedInitial.value);
-
-            start.value = '1001';
-            start.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-            view.activateIntegrity();
-            assert.strictEqual(start.value, '1001', 'later activation must preserve user range');
-
-            S.edits.set(0x1001, 0xFF);
-            view.notifyIntegrityBytesChanged();
-            await new Promise(resolve => setTimeout(resolve, 300));
-            const expectedEdited = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
-            assert.strictEqual(document.getElementById('integrity-value')?.textContent, expectedEdited.value);
-
-            end.value = 'not-hex';
-            end.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-            assert.strictEqual((document.getElementById('integrity-result') as HTMLElement).hidden, true);
-            assert.match(document.getElementById('integrity-error')?.textContent ?? '', /hexadecimal/);
-
-            end.value = '1002';
-            end.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-            await new Promise(resolve => setTimeout(resolve, 300));
-            document.getElementById('integrity-copy')?.click();
-            assert.deepStrictEqual(posted.at(-1), {
-                type: 'copyText',
-                text: expectedEdited.value,
-                label: 'CRC32/ISO-HDLC',
-            });
+            await verifyInitialIntegrityResult(view, calculateIntegrity);
+            const expectedEdited = await verifyEditedIntegrityResult(view, calculateIntegrity, dom);
+            verifyInvalidIntegrityRange(dom);
+            await verifyIntegrityCopy(dom, expectedEdited, posted);
         } finally {
             api.vscode.postMessage = originalPostMessage;
         }

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -10,8 +10,9 @@ import { renderInspector, renderBits, renderSegments, renderLabels, updateInspec
 import { renderStructPins, onSelectionChangeForStruct, resetStructViewState } from './struct';
 import { initSearch, runSearch, clearSearch, nextMatch, prevMatch } from './searchEngine';
 import { initFlatBytes, buildMemRows, getByte }      from './data';
-import type { SerializedRecord } from './types';
+import type { SerializedRecord, SidebarTab } from './types';
 import { MAX_VIRTUAL_SCROLL_HEIGHT }                 from './virtualScroll';
+import { activateIntegrity, notifyIntegrityBytesChanged, renderIntegrity } from './integrityView';
 
 vscode.postMessage({ type: 'ready' });
 
@@ -124,6 +125,7 @@ function handleExternalChangeErrorMessage(msg: WebviewMessage): void {
     );
     renderSegments();
     renderCurrentDataView();
+    notifyIntegrityBytesChanged();
 }
 
 function handleRepairCompleteMessage(msg: WebviewMessage): void {
@@ -151,6 +153,7 @@ function clearEditState(): void {
     S.edits.clear();
     S.undoStack.length = 0;
     S.editMode = false;
+    notifyIntegrityBytesChanged();
 }
 
 function renderCurrentDataView(): void {
@@ -199,13 +202,11 @@ function visibleClass(isVisible: boolean): string {
     return isVisible ? 'visible' : '';
 }
 
-type SidebarTabName = 'inspector' | 'struct';
-
-function tabPanelClass(tab: SidebarTabName): string {
+function tabPanelClass(tab: SidebarTab): string {
     return S.sidebarTab === tab ? 'sb-tab-panel active' : 'sb-tab-panel';
 }
 
-function sideTabClass(tab: SidebarTabName): string {
+function sideTabClass(tab: SidebarTab): string {
     return S.sidebarTab === tab ? 'stab active' : 'stab';
 }
 
@@ -277,10 +278,14 @@ function render(): void {
                 <div class="${tabPanelClass('struct')}" id="sbp-struct">
                     <div id="s-struct-pins"></div>
                 </div>
+                <div class="${tabPanelClass('integrity')}" id="sbp-integrity">
+                    <div id="s-integrity"></div>
+                </div>
             </div>
             <div id="side-tabs">
                 <button class="${sideTabClass('inspector')}" id="stab-insp">Inspector</button>
                 <button class="${sideTabClass('struct')}" id="stab-struct">Struct Overlay</button>
+                <button class="${sideTabClass('integrity')}" id="stab-integrity">Integrity Checks</button>
             </div>
         </div>
         <div id="ctx-menu" style="display:none"></div>`;
@@ -492,13 +497,20 @@ function setupSideTabs(): void {
         S.sidebarTab = 'struct';
         applySidebarState();
     });
+    document.getElementById('stab-integrity')!.addEventListener('click', () => {
+        S.sidebarTab = 'integrity';
+        applySidebarState();
+        activateIntegrity();
+    });
 }
 
 function applySidebarState(): void {
     document.getElementById('sbp-insp')!.classList.toggle('active', S.sidebarTab === 'inspector');
     document.getElementById('sbp-struct')!.classList.toggle('active', S.sidebarTab === 'struct');
+    document.getElementById('sbp-integrity')!.classList.toggle('active', S.sidebarTab === 'integrity');
     document.getElementById('stab-insp')!.classList.toggle('active', S.sidebarTab === 'inspector');
     document.getElementById('stab-struct')!.classList.toggle('active', S.sidebarTab === 'struct');
+    document.getElementById('stab-integrity')!.classList.toggle('active', S.sidebarTab === 'integrity');
 }
 
 function renderInitialViews(): void {
@@ -507,6 +519,7 @@ function renderInitialViews(): void {
     renderInspector();
     renderBits();
     renderStructPins();
+    renderIntegrity();
     renderSegments();
     renderLabels();
     setupCtxMenu();
@@ -1174,6 +1187,7 @@ function applyFill(fillVal: number): void {
     updateDirtyBar();
     if (S.currentView === 'memory') { memRerender(); }
     updateInspector();
+    notifyIntegrityBytesChanged();
 }
 
 function undoLastEdit(): void {
@@ -1190,6 +1204,7 @@ function undoLastEdit(): void {
     updateDirtyBar();
     if (S.currentView === 'memory') { memRerender(); }
     updateInspector();
+    notifyIntegrityBytesChanged();
 }
 
 function updateDirtyBar(): void {

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -1174,15 +1174,7 @@ function getOriginalByte(addr: number): number | undefined {
 // ── Edit helpers ──────────────────────────────────────────────────
 
 function applyFill(fillVal: number): void {
-    if (S.selStart === null || S.selEnd === null) { return; }
-    const prev: Array<[number, number]> = [];
-    for (let a = S.selStart; a <= S.selEnd; a++) {
-        const orig = getByte(a);
-        if (orig !== undefined) {
-            prev.push([a, orig]);
-            S.edits.set(a, fillVal);
-        }
-    }
+    const prev = buildFillTransaction(fillVal);
     if (prev.length > 0) { S.undoStack.push(prev); }
     updateDirtyBar();
     if (S.currentView === 'memory') { memRerender(); }
@@ -1190,21 +1182,50 @@ function applyFill(fillVal: number): void {
     notifyIntegrityBytesChanged();
 }
 
+function currentSelectionRange(): { start: number; end: number } | null {
+    if (S.selStart === null) { return null; }
+    if (S.selEnd === null) { return null; }
+    return { start: S.selStart, end: S.selEnd };
+}
+
+function buildFillTransaction(fillVal: number): Array<[number, number]> {
+    const range = currentSelectionRange();
+    if (!range) { return []; }
+    const prev: Array<[number, number]> = [];
+    for (let a = range.start; a <= range.end; a++) {
+        const orig = getByte(a);
+        if (orig === undefined) { continue; }
+        prev.push([a, orig]);
+        S.edits.set(a, fillVal);
+    }
+    return prev;
+}
+
 function undoLastEdit(): void {
-    if (!S.editMode || S.undoStack.length === 0) { return; }
-    const txn = S.undoStack.pop()!;
+    const txn = popUndoTransaction();
+    if (!txn) { return; }
     for (const [addr, prevVal] of txn) {
-        const orig = getOriginalByte(addr);
-        if (orig !== undefined && prevVal === orig) {
-            S.edits.delete(addr);
-        } else {
-            S.edits.set(addr, prevVal);
-        }
+        restoreEditedByte(addr, prevVal);
     }
     updateDirtyBar();
     if (S.currentView === 'memory') { memRerender(); }
     updateInspector();
     notifyIntegrityBytesChanged();
+}
+
+function popUndoTransaction(): Array<[number, number]> | null {
+    if (!S.editMode) { return null; }
+    if (S.undoStack.length === 0) { return null; }
+    return S.undoStack.pop()!;
+}
+
+function restoreEditedByte(addr: number, prevVal: number): void {
+    const orig = getOriginalByte(addr);
+    if (orig !== undefined && prevVal === orig) {
+        S.edits.delete(addr);
+        return;
+    }
+    S.edits.set(addr, prevVal);
 }
 
 function updateDirtyBar(): void {

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -92,6 +92,7 @@
     font-family: var(--vscode-editor-font-family, monospace);
     font-size: 12px;
     overflow-wrap: anywhere;
+    -webkit-user-select: text;
     user-select: text;
 }
 

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -1,0 +1,110 @@
+.integrity-shell {
+    box-sizing: border-box;
+    min-width: 0;
+    padding: 16px 14px;
+}
+
+.integrity-title {
+    color: var(--vscode-foreground);
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.integrity-help,
+.integrity-meta {
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+}
+
+.integrity-help {
+    line-height: 1.45;
+    margin-bottom: 16px;
+}
+
+.integrity-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 12px;
+    min-width: 0;
+}
+
+.integrity-field > span {
+    color: var(--vscode-foreground);
+    font-size: 11px;
+    font-weight: 500;
+}
+
+.integrity-field small {
+    color: var(--vscode-descriptionForeground);
+    font-size: inherit;
+    font-weight: 400;
+}
+
+.integrity-field input,
+.integrity-field select {
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border, transparent);
+    box-sizing: border-box;
+    color: var(--vscode-input-foreground);
+    font: inherit;
+    min-width: 0;
+    outline: none;
+    padding: 6px 7px;
+    width: 100%;
+}
+
+.integrity-field input:focus,
+.integrity-field select:focus {
+    border-color: var(--vscode-focusBorder);
+}
+
+.integrity-meta {
+    min-height: 17px;
+}
+
+.integrity-error {
+    color: var(--vscode-errorForeground);
+    font-size: 11px;
+    line-height: 1.4;
+    min-height: 17px;
+    overflow-wrap: anywhere;
+}
+
+.integrity-result {
+    background: var(--vscode-textCodeBlock-background);
+    border: 1px solid var(--vscode-widget-border, transparent);
+    margin-top: 8px;
+    padding: 10px;
+}
+
+.integrity-result-label {
+    color: var(--vscode-descriptionForeground);
+    font-size: 10px;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+}
+
+.integrity-result code {
+    color: var(--vscode-foreground);
+    display: block;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    overflow-wrap: anywhere;
+    user-select: text;
+}
+
+.integrity-result button {
+    background: var(--vscode-button-background);
+    border: 0;
+    color: var(--vscode-button-foreground);
+    cursor: pointer;
+    margin-top: 10px;
+    padding: 5px 12px;
+    width: 100%;
+}
+
+.integrity-result button:hover {
+    background: var(--vscode-button-hoverBackground);
+}

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -1,0 +1,184 @@
+export const INTEGRITY_ALGORITHMS = [
+    'crc16-ccitt-false',
+    'crc32-iso-hdlc',
+    'md5',
+    'sha-1',
+    'sha-256',
+    'sha-512',
+] as const;
+
+export type IntegrityAlgorithm = typeof INTEGRITY_ALGORITHMS[number];
+
+export interface IntegrityRequest {
+    algorithm: IntegrityAlgorithm;
+    startAddress: number;
+    endAddress: number;
+}
+
+export interface IntegrityResult {
+    algorithm: IntegrityAlgorithm;
+    value: string;
+    byteCount: number;
+}
+
+export type IntegrityValidation<T> =
+    | { ok: true; value: T }
+    | { ok: false; error: string };
+
+const MAX_ADDRESS = 0xFFFF_FFFF;
+
+export function parseIntegrityAddress(raw: string, label: string): IntegrityValidation<number> {
+    const text = raw.trim();
+    if (text === '') { return { ok: false, error: `${label} address is required.` }; }
+    const digits = text.replace(/^0x/i, '');
+    if (!/^[0-9a-f]+$/i.test(digits)) {
+        return { ok: false, error: `${label} address must be hexadecimal.` };
+    }
+    const value = Number.parseInt(digits, 16);
+    if (!Number.isSafeInteger(value) || value < 0 || value > MAX_ADDRESS) {
+        return { ok: false, error: `${label} address must be between 0x00000000 and 0xFFFFFFFF.` };
+    }
+    return { ok: true, value };
+}
+
+export function validateIntegrityRange(
+    startRaw: string,
+    endRaw: string,
+    algorithm: IntegrityAlgorithm,
+): IntegrityValidation<IntegrityRequest> {
+    const start = parseIntegrityAddress(startRaw, 'Start');
+    if (!start.ok) { return start; }
+    const end = parseIntegrityAddress(endRaw, 'End');
+    if (!end.ok) { return end; }
+    if (end.value < start.value) {
+        return { ok: false, error: 'End address must be greater than or equal to start address.' };
+    }
+    return { ok: true, value: { algorithm, startAddress: start.value, endAddress: end.value } };
+}
+
+export function collectIntegrityBytes(
+    request: IntegrityRequest,
+    readByte: (address: number) => number | undefined,
+): IntegrityValidation<Uint8Array> {
+    const length = request.endAddress - request.startAddress + 1;
+    for (let offset = 0; offset < length; offset++) {
+        const address = request.startAddress + offset;
+        if (readByte(address) === undefined) {
+            return { ok: false, error: `No mapped byte at ${formatIntegrityAddress(address)}.` };
+        }
+    }
+    const bytes = new Uint8Array(length);
+    for (let offset = 0; offset < length; offset++) {
+        bytes[offset] = readByte(request.startAddress + offset)!;
+    }
+    return { ok: true, value: bytes };
+}
+
+export async function calculateIntegrity(
+    algorithm: IntegrityAlgorithm,
+    bytes: Uint8Array,
+): Promise<IntegrityResult> {
+    let value: string;
+    switch (algorithm) {
+        case 'crc16-ccitt-false': value = crc16CcittFalse(bytes).toString(16).padStart(4, '0'); break;
+        case 'crc32-iso-hdlc': value = crc32IsoHdlc(bytes).toString(16).padStart(8, '0'); break;
+        case 'md5': value = md5(bytes); break;
+        case 'sha-1': value = await subtleDigest('SHA-1', bytes); break;
+        case 'sha-256': value = await subtleDigest('SHA-256', bytes); break;
+        case 'sha-512': value = await subtleDigest('SHA-512', bytes); break;
+    }
+    return { algorithm, value: value.toUpperCase(), byteCount: bytes.length };
+}
+
+export function formatIntegrityAddress(address: number): string {
+    return `0x${address.toString(16).toUpperCase().padStart(8, '0')}`;
+}
+
+function crc16CcittFalse(bytes: Uint8Array): number {
+    let crc = 0xFFFF;
+    for (const byte of bytes) {
+        crc ^= byte << 8;
+        for (let bit = 0; bit < 8; bit++) {
+            crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xFFFF : (crc << 1) & 0xFFFF;
+        }
+    }
+    return crc;
+}
+
+function crc32IsoHdlc(bytes: Uint8Array): number {
+    let crc = 0xFFFF_FFFF;
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++) {
+            crc = crc & 1 ? (crc >>> 1) ^ 0xEDB8_8320 : crc >>> 1;
+        }
+    }
+    return (crc ^ 0xFFFF_FFFF) >>> 0;
+}
+
+async function subtleDigest(name: AlgorithmIdentifier, bytes: Uint8Array): Promise<string> {
+    if (!globalThis.crypto?.subtle) { throw new Error('Web Crypto is unavailable.'); }
+    const digest = await globalThis.crypto.subtle.digest(name, Uint8Array.from(bytes));
+    return bytesToHex(new Uint8Array(digest));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+const MD5_SHIFTS = [
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+    5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+    4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+    6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+const MD5_CONSTANTS = Array.from({ length: 64 }, (_, i) =>
+    Math.floor(Math.abs(Math.sin(i + 1)) * 0x1_0000_0000) >>> 0);
+
+function md5(input: Uint8Array): string {
+    const bitLength = BigInt(input.length) * 8n;
+    const paddedLength = Math.ceil((input.length + 9) / 64) * 64;
+    const padded = new Uint8Array(paddedLength);
+    padded.set(input);
+    padded[input.length] = 0x80;
+    const view = new DataView(padded.buffer);
+    view.setUint32(paddedLength - 8, Number(bitLength & 0xFFFF_FFFFn), true);
+    view.setUint32(paddedLength - 4, Number(bitLength >> 32n), true);
+
+    let a0 = 0x6745_2301;
+    let b0 = 0xEFCD_AB89;
+    let c0 = 0x98BA_DCFE;
+    let d0 = 0x1032_5476;
+
+    for (let block = 0; block < paddedLength; block += 64) {
+        const words = Array.from({ length: 16 }, (_, i) => view.getUint32(block + i * 4, true));
+        let a = a0, b = b0, c = c0, d = d0;
+        for (let i = 0; i < 64; i++) {
+            let f: number;
+            let g: number;
+            if (i < 16) { f = (b & c) | (~b & d); g = i; }
+            else if (i < 32) { f = (d & b) | (~d & c); g = (5 * i + 1) % 16; }
+            else if (i < 48) { f = b ^ c ^ d; g = (3 * i + 5) % 16; }
+            else { f = c ^ (b | ~d); g = (7 * i) % 16; }
+            const nextD = c;
+            c = b;
+            const sum = (a + f + MD5_CONSTANTS[i] + words[g]) >>> 0;
+            b = (b + rotateLeft(sum, MD5_SHIFTS[i])) >>> 0;
+            a = d;
+            d = nextD;
+        }
+        a0 = (a0 + a) >>> 0;
+        b0 = (b0 + b) >>> 0;
+        c0 = (c0 + c) >>> 0;
+        d0 = (d0 + d) >>> 0;
+    }
+
+    const output = new Uint8Array(16);
+    const outputView = new DataView(output.buffer);
+    [a0, b0, c0, d0].forEach((word, i) => outputView.setUint32(i * 4, word, true));
+    return bytesToHex(output);
+}
+
+function rotateLeft(value: number, count: number): number {
+    return ((value << count) | (value >>> (32 - count))) >>> 0;
+}

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -1,4 +1,4 @@
-export const INTEGRITY_ALGORITHMS = [
+const INTEGRITY_ALGORITHMS = [
     'crc16-ccitt-false',
     'crc32-iso-hdlc',
     'md5',
@@ -35,10 +35,14 @@ export function parseIntegrityAddress(raw: string, label: string): IntegrityVali
         return { ok: false, error: `${label} address must be hexadecimal.` };
     }
     const value = Number.parseInt(digits, 16);
-    if (!Number.isSafeInteger(value) || value < 0 || value > MAX_ADDRESS) {
+    if (!isUint32(value)) {
         return { ok: false, error: `${label} address must be between 0x00000000 and 0xFFFFFFFF.` };
     }
     return { ok: true, value };
+}
+
+function isUint32(value: number): boolean {
+    return Number.isSafeInteger(value) && (value >>> 0) === value;
 }
 
 export function validateIntegrityRange(
@@ -78,17 +82,20 @@ export async function calculateIntegrity(
     algorithm: IntegrityAlgorithm,
     bytes: Uint8Array,
 ): Promise<IntegrityResult> {
-    let value: string;
-    switch (algorithm) {
-        case 'crc16-ccitt-false': value = crc16CcittFalse(bytes).toString(16).padStart(4, '0'); break;
-        case 'crc32-iso-hdlc': value = crc32IsoHdlc(bytes).toString(16).padStart(8, '0'); break;
-        case 'md5': value = md5(bytes); break;
-        case 'sha-1': value = await subtleDigest('SHA-1', bytes); break;
-        case 'sha-256': value = await subtleDigest('SHA-256', bytes); break;
-        case 'sha-512': value = await subtleDigest('SHA-512', bytes); break;
-    }
+    const value = await INTEGRITY_CALCULATORS[algorithm](bytes);
     return { algorithm, value: value.toUpperCase(), byteCount: bytes.length };
 }
+
+type IntegrityCalculator = (bytes: Uint8Array) => string | Promise<string>;
+
+const INTEGRITY_CALCULATORS: Record<IntegrityAlgorithm, IntegrityCalculator> = {
+    'crc16-ccitt-false': bytes => crc16CcittFalse(bytes).toString(16).padStart(4, '0'),
+    'crc32-iso-hdlc': bytes => crc32IsoHdlc(bytes).toString(16).padStart(8, '0'),
+    md5,
+    'sha-1': bytes => subtleDigest('SHA-1', bytes),
+    'sha-256': bytes => subtleDigest('SHA-256', bytes),
+    'sha-512': bytes => subtleDigest('SHA-512', bytes),
+};
 
 export function formatIntegrityAddress(address: number): string {
     return `0x${address.toString(16).toUpperCase().padStart(8, '0')}`;
@@ -154,15 +161,10 @@ function md5(input: Uint8Array): string {
         const words = Array.from({ length: 16 }, (_, i) => view.getUint32(block + i * 4, true));
         let a = a0, b = b0, c = c0, d = d0;
         for (let i = 0; i < 64; i++) {
-            let f: number;
-            let g: number;
-            if (i < 16) { f = (b & c) | (~b & d); g = i; }
-            else if (i < 32) { f = (d & b) | (~d & c); g = (5 * i + 1) % 16; }
-            else if (i < 48) { f = b ^ c ^ d; g = (3 * i + 5) % 16; }
-            else { f = c ^ (b | ~d); g = (7 * i) % 16; }
+            const { mix, wordIndex } = md5Round(i, b, c, d);
             const nextD = c;
             c = b;
-            const sum = (a + f + MD5_CONSTANTS[i] + words[g]) >>> 0;
+            const sum = (a + mix + MD5_CONSTANTS[i] + words[wordIndex]) >>> 0;
             b = (b + rotateLeft(sum, MD5_SHIFTS[i])) >>> 0;
             a = d;
             d = nextD;
@@ -177,6 +179,13 @@ function md5(input: Uint8Array): string {
     const outputView = new DataView(output.buffer);
     [a0, b0, c0, d0].forEach((word, i) => outputView.setUint32(i * 4, word, true));
     return bytesToHex(output);
+}
+
+function md5Round(i: number, b: number, c: number, d: number): { mix: number; wordIndex: number } {
+    if (i < 16) { return { mix: (b & c) | (~b & d), wordIndex: i }; }
+    if (i < 32) { return { mix: (d & b) | (~d & c), wordIndex: (5 * i + 1) % 16 }; }
+    if (i < 48) { return { mix: b ^ c ^ d, wordIndex: (3 * i + 5) % 16 }; }
+    return { mix: c ^ (b | ~d), wordIndex: (7 * i) % 16 };
 }
 
 function rotateLeft(value: number, count: number): number {

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -1,0 +1,198 @@
+import { vscode } from './api';
+import { getByte } from './data';
+import {
+    calculateIntegrity,
+    collectIntegrityBytes,
+    formatIntegrityAddress,
+    type IntegrityAlgorithm,
+    type IntegrityResult,
+    validateIntegrityRange,
+} from './integrity';
+import { S } from './state';
+import { esc } from './utils';
+
+const DEBOUNCE_MS = 250;
+const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
+    ['crc16-ccitt-false', 'CRC16/CCITT-FALSE'],
+    ['crc32-iso-hdlc', 'CRC32/ISO-HDLC'],
+    ['md5', 'MD5'],
+    ['sha-1', 'SHA-1'],
+    ['sha-256', 'SHA-256'],
+    ['sha-512', 'SHA-512'],
+];
+
+const integrityState = {
+    initialized: false,
+    algorithm: 'crc32-iso-hdlc' as IntegrityAlgorithm,
+    startRaw: '',
+    endRaw: '',
+    result: null as IntegrityResult | null,
+    timer: null as number | null,
+    token: 0,
+};
+
+export function renderIntegrity(): void {
+    const panel = document.getElementById('s-integrity');
+    if (!panel) { return; }
+    panel.innerHTML = `
+        <div class="integrity-shell">
+            <div class="integrity-title">Integrity Checks</div>
+            <div class="integrity-help">Calculate over an inclusive mapped memory range.</div>
+            <label class="integrity-field">
+                <span>Algorithm</span>
+                <select id="integrity-algorithm">
+                    ${ALGORITHM_LABELS.map(([value, label]) =>
+        `<option value="${value}"${value === integrityState.algorithm ? ' selected' : ''}>${label}</option>`).join('')}
+                </select>
+            </label>
+            <label class="integrity-field">
+                <span>Start address</span>
+                <input id="integrity-start" type="text" inputmode="text" spellcheck="false"
+                    placeholder="0x08000000" value="${esc(integrityState.startRaw)}">
+            </label>
+            <label class="integrity-field">
+                <span>End address <small>(inclusive)</small></span>
+                <input id="integrity-end" type="text" inputmode="text" spellcheck="false"
+                    placeholder="0x080000FF" value="${esc(integrityState.endRaw)}">
+            </label>
+            <div id="integrity-meta" class="integrity-meta"></div>
+            <div id="integrity-error" class="integrity-error" role="alert"></div>
+            <div id="integrity-result" class="integrity-result" hidden>
+                <div class="integrity-result-label">Result</div>
+                <code id="integrity-value"></code>
+                <button id="integrity-copy" type="button">Copy</button>
+            </div>
+        </div>`;
+    wireIntegrityControls();
+    if (integrityState.initialized) { scheduleIntegrityCalculation(); }
+}
+
+export function activateIntegrity(): void {
+    if (!integrityState.initialized) {
+        integrityState.initialized = true;
+        if (S.selStart !== null && S.selEnd !== null) {
+            integrityState.startRaw = formatIntegrityAddress(S.selStart);
+            integrityState.endRaw = formatIntegrityAddress(S.selEnd);
+        }
+        renderIntegrity();
+    }
+}
+
+export function notifyIntegrityBytesChanged(): void {
+    if (integrityState.initialized) { scheduleIntegrityCalculation(); }
+}
+
+function wireIntegrityControls(): void {
+    const algorithm = document.getElementById('integrity-algorithm') as HTMLSelectElement;
+    const start = document.getElementById('integrity-start') as HTMLInputElement;
+    const end = document.getElementById('integrity-end') as HTMLInputElement;
+
+    algorithm.addEventListener('change', () => {
+        integrityState.algorithm = algorithm.value as IntegrityAlgorithm;
+        scheduleIntegrityCalculation();
+    });
+    start.addEventListener('input', () => {
+        integrityState.startRaw = start.value;
+        scheduleIntegrityCalculation();
+    });
+    end.addEventListener('input', () => {
+        integrityState.endRaw = end.value;
+        scheduleIntegrityCalculation();
+    });
+    document.getElementById('integrity-copy')?.addEventListener('click', copyIntegrityResult);
+}
+
+function scheduleIntegrityCalculation(): void {
+    const token = ++integrityState.token;
+    if (integrityState.timer !== null) { window.clearTimeout(integrityState.timer); }
+    integrityState.timer = null;
+    clearResult();
+
+    if (integrityState.startRaw.trim() === '' && integrityState.endRaw.trim() === '') {
+        showMeta('Enter a start and end address.');
+        showError('');
+        return;
+    }
+
+    const validation = validateIntegrityRange(
+        integrityState.startRaw,
+        integrityState.endRaw,
+        integrityState.algorithm,
+    );
+    if (!validation.ok) {
+        showMeta('');
+        showError(validation.error);
+        return;
+    }
+
+    const byteCount = validation.value.endAddress - validation.value.startAddress + 1;
+    showMeta(`${byteCount.toLocaleString()} byte${byteCount === 1 ? '' : 's'}`);
+    showError('');
+    integrityState.timer = window.setTimeout(() => {
+        integrityState.timer = null;
+        void calculateAndRender(token);
+    }, DEBOUNCE_MS);
+}
+
+async function calculateAndRender(token: number): Promise<void> {
+    const validation = validateIntegrityRange(
+        integrityState.startRaw,
+        integrityState.endRaw,
+        integrityState.algorithm,
+    );
+    if (!validation.ok || token !== integrityState.token) { return; }
+
+    const bytes = collectIntegrityBytes(validation.value, address => S.edits.get(address) ?? getByte(address));
+    if (!bytes.ok) {
+        if (token === integrityState.token) { showError(bytes.error); }
+        return;
+    }
+
+    showMeta(`Calculating ${bytes.value.length.toLocaleString()} byte${bytes.value.length === 1 ? '' : 's'}…`);
+    try {
+        const result = await calculateIntegrity(validation.value.algorithm, bytes.value);
+        if (token !== integrityState.token) { return; }
+        integrityState.result = result;
+        showMeta(`${result.byteCount.toLocaleString()} byte${result.byteCount === 1 ? '' : 's'}`);
+        showResult(result.value);
+    } catch (error) {
+        if (token === integrityState.token) {
+            showError(error instanceof Error ? error.message : 'Integrity calculation failed.');
+        }
+    }
+}
+
+function copyIntegrityResult(): void {
+    if (!integrityState.result) { return; }
+    vscode.postMessage({
+        type: 'copyText',
+        text: integrityState.result.value,
+        label: ALGORITHM_LABELS.find(([value]) => value === integrityState.result?.algorithm)?.[1] ?? 'integrity value',
+    });
+}
+
+function clearResult(): void {
+    integrityState.result = null;
+    const result = document.getElementById('integrity-result');
+    if (result) { result.hidden = true; }
+    const value = document.getElementById('integrity-value');
+    if (value) { value.textContent = ''; }
+}
+
+function showResult(value: string): void {
+    showError('');
+    const output = document.getElementById('integrity-value');
+    const result = document.getElementById('integrity-result');
+    if (output) { output.textContent = value; }
+    if (result) { result.hidden = false; }
+}
+
+function showMeta(message: string): void {
+    const meta = document.getElementById('integrity-meta');
+    if (meta) { meta.textContent = message; }
+}
+
+function showError(message: string): void {
+    const error = document.getElementById('integrity-error');
+    if (error) { error.textContent = message; }
+}

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -5,6 +5,7 @@ import {
     collectIntegrityBytes,
     formatIntegrityAddress,
     type IntegrityAlgorithm,
+    type IntegrityRequest,
     type IntegrityResult,
     validateIntegrityRange,
 } from './integrity';
@@ -104,14 +105,27 @@ function wireIntegrityControls(): void {
 
 function scheduleIntegrityCalculation(): void {
     const token = ++integrityState.token;
-    if (integrityState.timer !== null) { window.clearTimeout(integrityState.timer); }
-    integrityState.timer = null;
+    cancelPendingCalculation();
     clearResult();
 
+    const request = prepareIntegrityRequest();
+    if (!request) { return; }
+    integrityState.timer = window.setTimeout(() => {
+        integrityState.timer = null;
+        void calculateAndRender(token, request);
+    }, DEBOUNCE_MS);
+}
+
+function cancelPendingCalculation(): void {
+    if (integrityState.timer !== null) { window.clearTimeout(integrityState.timer); }
+    integrityState.timer = null;
+}
+
+function prepareIntegrityRequest(): IntegrityRequest | null {
     if (integrityState.startRaw.trim() === '' && integrityState.endRaw.trim() === '') {
         showMeta('Enter a start and end address.');
         showError('');
-        return;
+        return null;
     }
 
     const validation = validateIntegrityRange(
@@ -122,44 +136,50 @@ function scheduleIntegrityCalculation(): void {
     if (!validation.ok) {
         showMeta('');
         showError(validation.error);
-        return;
+        return null;
     }
 
     const byteCount = validation.value.endAddress - validation.value.startAddress + 1;
-    showMeta(`${byteCount.toLocaleString()} byte${byteCount === 1 ? '' : 's'}`);
+    showMeta(formatByteCount(byteCount));
     showError('');
-    integrityState.timer = window.setTimeout(() => {
-        integrityState.timer = null;
-        void calculateAndRender(token);
-    }, DEBOUNCE_MS);
+    return validation.value;
 }
 
-async function calculateAndRender(token: number): Promise<void> {
-    const validation = validateIntegrityRange(
-        integrityState.startRaw,
-        integrityState.endRaw,
-        integrityState.algorithm,
-    );
-    if (!validation.ok || token !== integrityState.token) { return; }
+async function calculateAndRender(token: number, request: IntegrityRequest): Promise<void> {
+    const bytes = collectBytesOrShowError(token, request);
+    if (!bytes) { return; }
+    showMeta(`Calculating ${formatByteCount(bytes.length)}…`);
+    try {
+        const result = await calculateIntegrity(request.algorithm, bytes);
+        applyResultIfCurrent(token, result);
+    } catch (error) {
+        showCalculationErrorIfCurrent(token, error);
+    }
+}
 
-    const bytes = collectIntegrityBytes(validation.value, address => S.edits.get(address) ?? getByte(address));
+function collectBytesOrShowError(token: number, request: IntegrityRequest): Uint8Array | null {
+    const bytes = collectIntegrityBytes(request, address => S.edits.get(address) ?? getByte(address));
     if (!bytes.ok) {
         if (token === integrityState.token) { showError(bytes.error); }
-        return;
+        return null;
     }
+    return bytes.value;
+}
 
-    showMeta(`Calculating ${bytes.value.length.toLocaleString()} byte${bytes.value.length === 1 ? '' : 's'}…`);
-    try {
-        const result = await calculateIntegrity(validation.value.algorithm, bytes.value);
-        if (token !== integrityState.token) { return; }
-        integrityState.result = result;
-        showMeta(`${result.byteCount.toLocaleString()} byte${result.byteCount === 1 ? '' : 's'}`);
-        showResult(result.value);
-    } catch (error) {
-        if (token === integrityState.token) {
-            showError(error instanceof Error ? error.message : 'Integrity calculation failed.');
-        }
-    }
+function applyResultIfCurrent(token: number, result: IntegrityResult): void {
+    if (token !== integrityState.token) { return; }
+    integrityState.result = result;
+    showMeta(formatByteCount(result.byteCount));
+    showResult(result.value);
+}
+
+function showCalculationErrorIfCurrent(token: number, error: unknown): void {
+    if (token !== integrityState.token) { return; }
+    showError(error instanceof Error ? error.message : 'Integrity calculation failed.');
+}
+
+function formatByteCount(byteCount: number): string {
+    return `${byteCount.toLocaleString()} byte${byteCount === 1 ? '' : 's'}`;
 }
 
 function copyIntegrityResult(): void {

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -1,7 +1,7 @@
 // ── Shared mutable state ─────────────────────────────────────────
 // All modules import this object and mutate it directly.
 
-import type { SerializedParseResult, SegmentLabel, SearchMode, SearchEndianness, BitFieldAllocation, MemRow, StructDef, StructPin } from './types';
+import type { SerializedParseResult, SegmentLabel, SearchMode, SearchEndianness, BitFieldAllocation, MemRow, StructDef, StructPin, SidebarTab } from './types';
 
 export const BPR = 16; // bytes per memory row
 
@@ -26,6 +26,6 @@ export const S = {
     structs:      [] as StructDef[],           // user-defined struct definitions
     activeStructAddr: null as number | null,   // base address for struct decode
     structPins:   [] as StructPin[],           // saved (structId, addr) overlay instances
-    sidebarTab:     'inspector' as 'inspector' | 'struct',  // active sidebar tab
+    sidebarTab:     'inspector' as SidebarTab,  // active sidebar tab
     lockedDueToExternalChange: false as boolean,  // view is locked pending external change action
 };

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -41,6 +41,7 @@ export interface SegmentLabel {
 export type SearchMode = 'bytes' | 'value' | 'ascii' | 'addr';
 export type SearchEndianness = 'auto' | 'be' | 'le';
 export type BitFieldAllocation = 'lsb' | 'msb';
+export type SidebarTab = 'inspector' | 'struct' | 'integrity';
 
 export type MemRow =
     | { type: 'data'; address: number }


### PR DESCRIPTION
Add 3rd sidebar tab, “Integrity Checks,” for live integrity calculation over inclusive memory ranges
Support:
- CRC16/CCITT-FALSE
- CRC32/ISO-HDLC
- MD5
- SHA-1
- SHA-256
- SHA-512.