### PR TITLE
feat: add reusable integrity check profiles and fix edit mode staging

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           command: audit
           format: sarif
+          no-cache: true
 
       - name: Run Fallow Analysis
         if: github.event_name == 'push'

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           command: audit
           format: sarif
-          no-cache: true
+          auto-changed-since: false
+          args: --base ${{ github.event.pull_request.base.sha }}
 
       - name: Run Fallow Analysis
         if: github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Changed
 
-- Consolidated Inspector, Struct Overlay, and Integrity Checks byte order into one per-file sidebar setting; Struct field overrides and Value Search byte order remain independent
+- Consolidated Inspector, Struct Overlay, and Integrity Checks byte order into one per-file sidebar setting; all Struct fields use this setting, while Value Search byte order remains independent
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.9.0] - 2026-06-21
+
+### Added
+
+- Added an Integrity Checks sidebar for CRC16/CCITT-FALSE, CRC32/ISO-HDLC, MD5, SHA-1, SHA-256, and SHA-512 calculations
+- Added multiple independently configurable integrity checks per firmware image
+- Added comparison against values stored in firmware, with integrity-specific LE/BE byte order, overlap exclusion, match status, and highlighted calculation and stored-value ranges
+- Added Auto fix and Fix all actions that stage stored-value corrections through the normal Save and undo flow
+- Added reusable user-global integrity profiles with save, apply, update, rename, and delete controls
+- Added per-file persistence for integrity checks not saved as profiles
+- Added compact editable result cards with always-visible calculated and stored values and calculated-value copying
+
+### Fixed
+
+- Fixed Edit mode using original bytes instead of staged unsaved values when rendering memory, copying selections, applying subsequent patches, and calculating integrity results
+
 ## [2.8.0] - 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## [2.9.0] - 2026-06-21
+## [2.9.0] - 2026-06-22
 
 ### Added
 
 - Added an Integrity Checks sidebar for CRC16/CCITT-FALSE, CRC32/ISO-HDLC, MD5, SHA-1, SHA-256, and SHA-512 calculations
 - Added multiple independently configurable integrity checks per firmware image
-- Added comparison against values stored in firmware, with integrity-specific LE/BE byte order, overlap exclusion, match status, and highlighted calculation and stored-value ranges
+- Added CRC comparison against values stored in firmware, with overlap exclusion, match status, and highlighted calculation and stored-value ranges; hash checks remain calculation-only
 - Added Auto fix and Fix all actions that stage stored-value corrections through the normal Save and undo flow
 - Added reusable user-global integrity profiles with save, apply, update, rename, and delete controls
 - Added per-file persistence for integrity checks not saved as profiles
 - Added compact editable result cards with always-visible calculated and stored values and calculated-value copying
+
+### Changed
+
+- Consolidated Inspector, Struct Overlay, and Integrity Checks byte order into one per-file sidebar setting; Struct field overrides and Value Search byte order remain independent
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # HexScope
 
-VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.
+Firmware memory explorer and editor for VS Code. Open Intel HEX and Motorola SREC files as address-aware memory, inspect binary data, decode C structs, verify integrity values, and patch bytes without leaving the editor.
+
+## Core features
+
+### View and navigate
+
+- Address-aware Memory view with mapped segments and gaps
+- Record view for raw firmware records
+- Search by byte sequence, numeric value, ASCII text, or address
+
+### Inspect and decode
+
+- Inspector for selected bytes using a shared per-file LE/BE byte order
+- Struct Overlay for C-style structs, arrays, nested structs, pointers, and bit fields
+- Live decoding updates as selection, byte order, or pending edits change
+
+### Integrity and editing
+
+- Multiple CRC16, CRC32, MD5, SHA-1, SHA-256, and SHA-512 checks
+- Stored CRC comparison, range highlighting, Auto fix, Fix all, and reusable profiles
+- Undoable byte patching with explicit Save and automatic record-checksum updates
 
 ## Supported file types
 
@@ -14,14 +34,11 @@ VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex 
 | Action | How |
 |---|---|
 | Open | Right-click a supported file → **Open with HexScope Viewer** |
-| Views | Toolbar: **Memory** (edit, search, labels, structs), **Records** (read-only record table) |
+| Views | Toolbar: **Memory** or **Records** |
 | Edit | Click **Edit** to patch bytes; **Save** writes changes and recomputes checksums |
-| Repair | When errors are detected (checksum or malformed), click **Quick Repair & reload** (checksums only) or **View in text editor** (manual fix) |
-| Repair (Text Editor) | Open file in text editor, then run **HexScope: Quick Repair Checksums** from command palette |
-| External Changes | When file changes externally, a banner appears; unsaved edits are automatically discarded |
 | Search | `Ctrl+F` — search by byte sequence, numeric value (Auto/LE/BE), ASCII string, or address |
-| Labels | Add named, color-coded address-range banners; click a label to jump to it |
-| Struct Overlay | Define C structs, pin them at addresses, and decode live binary data |
+| Struct Overlay | Define C structs, pin them at addresses, and decode live memory |
+| Integrity Checks | Configure checks, compare stored CRC values, and reuse saved profiles |
 
 ## Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-hex-scope",
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
-  "description": "VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.",
+  "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
   "version": "2.9.0",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "VS Code extension for viewing and analyzing firmware files (HEX, SREC) with hex grid, search, patching.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -4,12 +4,19 @@ import { parseIntelHex } from './parser/IntelHexParser';
 import { computeSRecChecksum, parseSRec, SREC_ADDR_SIZES, srecIsData } from './parser/SRecParser';
 import type { ParseResult } from './parser/types';
 import type { StructDef } from './webview/types';
+import {
+    normalizeIntegrityProfiles,
+    type IntegrityProfile,
+} from './webview/integrity';
+
+const GLOBAL_INTEGRITY_PROFILES_KEY = 'hexScope.integrityProfiles.global.v1';
 
 export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
     public static readonly viewType = 'hexScope.hexEditor';
 
     private static _activePanel: vscode.WebviewPanel | undefined;
+    private readonly _panels = new Set<vscode.WebviewPanel>();
 
     /** Post a message to the currently active HexScope webview, if any. */
     public static postToActive(msg: unknown): void {
@@ -62,6 +69,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
 
         webviewPanel.webview.options = { enableScripts: true };
         webviewPanel.webview.html = this._getHtml(webviewPanel.webview, document.uri);
+        this._panels.add(webviewPanel);
 
         const labelKey = `hexScope.labels.${document.uri.toString()}`;
 
@@ -133,10 +141,37 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             return globalArr;
         };
 
+        const loadIntegrityProfiles = async (): Promise<IntegrityProfile[]> => {
+            const rawProfiles = this._context.globalState.get<unknown>(GLOBAL_INTEGRITY_PROFILES_KEY, []);
+            const normalized = normalizeIntegrityProfiles(rawProfiles);
+            if (JSON.stringify(rawProfiles) !== JSON.stringify(normalized)) {
+                await this._context.globalState.update(GLOBAL_INTEGRITY_PROFILES_KEY, normalized);
+            }
+            return normalized;
+        };
+
+        const broadcastIntegrityProfiles = async (error = ''): Promise<void> => {
+            const current = await loadIntegrityProfiles();
+            for (const panel of this._panels) {
+                void panel.webview.postMessage({ type: 'integrityProfiles', profiles: current, error });
+            }
+        };
+
+        const sendIntegrityProfileError = async (error: string): Promise<void> => {
+            const current = await loadIntegrityProfiles();
+            await webviewPanel.webview.postMessage({ type: 'integrityProfiles', profiles: current, error });
+        };
+
+        const saveIntegrityProfiles = async (next: IntegrityProfile[]): Promise<void> => {
+            await this._context.globalState.update(GLOBAL_INTEGRITY_PROFILES_KEY, next);
+            await broadcastIntegrityProfiles();
+        };
+
         const postInit = async () => {
             if (!webviewReady || !parseResult) { return; }
             const serialized = serializeParseResult(parseResult, format);
             const structs = await loadStructs();
+            const integrityProfiles = await loadIntegrityProfiles();
             
             const msg = {
                 type: 'init',
@@ -144,6 +179,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                 labels:      this._context.workspaceState.get(labelKey, []),
                 structs,
                 structPins:  this._context.workspaceState.get(structPinKey, []),
+                integrityProfiles,
             };
             
             webviewPanel.webview.postMessage(msg);
@@ -236,6 +272,45 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             saveStructPins: async msg => {
                 await this._context.workspaceState.update(structPinKey, msg.pins);
             },
+            createIntegrityProfile: async msg => {
+                const profile = normalizeIntegrityProfiles([msg.profile])[0];
+                if (!profile) { await sendIntegrityProfileError('Profile is invalid.'); return; }
+                const current = await loadIntegrityProfiles();
+                if (current.some(item => item.id === profile.id || sameProfileName(item.name, profile.name))) {
+                    await sendIntegrityProfileError(`A profile named “${profile.name}” already exists.`);
+                    return;
+                }
+                await saveIntegrityProfiles([...current, profile]);
+            },
+            updateIntegrityProfile: async msg => {
+                const profile = normalizeIntegrityProfiles([msg.profile])[0];
+                if (!profile) { await sendIntegrityProfileError('Profile is invalid.'); return; }
+                const current = await loadIntegrityProfiles();
+                if (!current.some(item => item.id === profile.id)) {
+                    await sendIntegrityProfileError('Profile no longer exists.');
+                    return;
+                }
+                if (current.some(item => item.id !== profile.id && sameProfileName(item.name, profile.name))) {
+                    await sendIntegrityProfileError(`A profile named “${profile.name}” already exists.`);
+                    return;
+                }
+                await saveIntegrityProfiles(current.map(item => item.id === profile.id ? profile : item));
+            },
+            renameIntegrityProfile: async msg => {
+                const current = await loadIntegrityProfiles();
+                const renamed = renameIntegrityProfiles(current, msg.id, msg.name);
+                if (!renamed.ok) { await sendIntegrityProfileError(renamed.error); return; }
+                await saveIntegrityProfiles(renamed.value);
+            },
+            deleteIntegrityProfile: async msg => {
+                const id = typeof msg.id === 'string' ? msg.id : '';
+                const current = await loadIntegrityProfiles();
+                if (!current.some(item => item.id === id)) {
+                    await sendIntegrityProfileError('Profile no longer exists.');
+                    return;
+                }
+                await saveIntegrityProfiles(current.filter(item => item.id !== id));
+            },
             updateLabelVisibility: async msg => {
                 const current: SegmentLabel[] = this._context.workspaceState.get(labelKey, []);
                 const next = current.map(l =>
@@ -302,6 +377,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         webviewPanel.onDidDispose(() => {
             watcher.dispose();
             clearTimeout(reloadTimer);
+            this._panels.delete(webviewPanel);
             if (HexEditorProvider._activePanel === webviewPanel) {
                 HexEditorProvider._activePanel = undefined;
             }
@@ -350,6 +426,33 @@ ${cssLinks}
 </body>
 </html>`;
     }
+}
+
+function sameProfileName(left: string, right: string): boolean {
+    return left.toLocaleLowerCase() === right.toLocaleLowerCase();
+}
+
+function renameIntegrityProfiles(
+    profiles: IntegrityProfile[],
+    rawId: unknown,
+    rawName: unknown,
+): { ok: true; value: IntegrityProfile[] } | { ok: false; error: string } {
+    const id = messageString(rawId);
+    const name = messageString(rawName).trim();
+    if (!validProfileRename(id, name)) { return { ok: false, error: 'Profile name is invalid.' }; }
+    if (!profiles.some(item => item.id === id)) { return { ok: false, error: 'Profile no longer exists.' }; }
+    if (profiles.some(item => item.id !== id && sameProfileName(item.name, name))) {
+        return { ok: false, error: `A profile named “${name}” already exists.` };
+    }
+    return { ok: true, value: profiles.map(item => item.id === id ? { ...item, name } : item) };
+}
+
+function validProfileRename(id: string, name: string): boolean {
+    return id.length > 0 && name.length > 0;
+}
+
+function messageString(value: unknown): string {
+    return typeof value === 'string' ? value : '';
 }
 
 interface SegmentLabel {

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -76,7 +76,8 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         const labelKey = `hexScope.labels.${document.uri.toString()}`;
 
         const structKey = `hexScope.structs.${document.uri.toString()}`;
-        const globalStructKey = 'hexScope.structs.global.v1';
+        const globalStructKey = 'hexScope.structs.global.v2';
+        const previousGlobalStructKey = 'hexScope.structs.global.v1';
         const structPinKey = `hexScope.structPins.${document.uri.toString()}`;
         const integrityChecksKey = `hexScope.integrityChecks.${document.uri.toString()}.v1`;
         const endianKey = `hexScope.endian.${document.uri.toString()}.v1`;
@@ -107,13 +108,18 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         };
 
         const loadStructs = async () => {
-            const globalStructs = this._context.globalState.get<unknown>(globalStructKey, []);
-            const legacyStructs = this._context.workspaceState.get<unknown>(structKey, []);
+            const currentGlobalStructs = this._context.globalState.get<unknown>(globalStructKey);
+            const previousGlobalStructs = this._context.globalState.get<unknown>(previousGlobalStructKey);
+            const globalStructs = currentGlobalStructs ?? migrateStructDefinitions(previousGlobalStructs ?? []);
+            const legacyStructs = migrateStructDefinitions(this._context.workspaceState.get<unknown>(structKey, []));
             let { defs: globalArr, changed: globalChanged } = normalizeStructDefs(globalStructs);
             const { defs: legacyArr } = normalizeStructDefs(legacyStructs);
 
-            if (!Array.isArray(globalStructs) || globalChanged) {
+            if (currentGlobalStructs === undefined || !Array.isArray(globalStructs) || globalChanged) {
                 await this._context.globalState.update(globalStructKey, globalArr);
+            }
+            if (previousGlobalStructs !== undefined) {
+                await this._context.globalState.update(previousGlobalStructKey, undefined);
             }
 
             if (legacyArr.length > 0) {
@@ -461,6 +467,24 @@ ${cssLinks}
 
 function sameProfileName(left: string, right: string): boolean {
     return left.toLocaleLowerCase() === right.toLocaleLowerCase();
+}
+
+export function migrateStructDefinitions(value: unknown): unknown {
+    if (!Array.isArray(value)) { return value; }
+    return value.map(item => {
+        if (item === null || typeof item !== 'object') { return item; }
+        const def = item as { fields?: unknown };
+        if (!Array.isArray(def.fields)) { return item; }
+        return {
+            ...def,
+            fields: def.fields.map(field => {
+                if (field === null || typeof field !== 'object') { return field; }
+                const clean = { ...field } as Record<string, unknown>;
+                delete clean.endian;
+                return clean;
+            }),
+        };
+    });
 }
 
 function renameIntegrityProfiles(

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -5,7 +5,9 @@ import { computeSRecChecksum, parseSRec, SREC_ADDR_SIZES, srecIsData } from './p
 import type { ParseResult } from './parser/types';
 import type { StructDef } from './webview/types';
 import {
+    normalizeIntegrityCheckSet,
     normalizeIntegrityProfiles,
+    type IntegrityCheckSet,
     type IntegrityProfile,
 } from './webview/integrity';
 
@@ -76,6 +78,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         const structKey = `hexScope.structs.${document.uri.toString()}`;
         const globalStructKey = 'hexScope.structs.global.v1';
         const structPinKey = `hexScope.structPins.${document.uri.toString()}`;
+        const integrityChecksKey = `hexScope.integrityChecks.${document.uri.toString()}.v1`;
 
         const normalizeStructDefs = (value: unknown): { defs: StructDef[]; changed: boolean } => {
             if (!Array.isArray(value)) { return { defs: [], changed: false }; }
@@ -150,6 +153,19 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             return normalized;
         };
 
+        const loadIntegrityChecks = async (): Promise<IntegrityCheckSet> => {
+            const rawChecks = this._context.workspaceState.get<unknown>(integrityChecksKey);
+            const normalized = normalizeIntegrityCheckSet(rawChecks) ?? {
+                schemaVersion: 1,
+                byteOrder: 'be',
+                checks: [],
+            };
+            if (rawChecks !== undefined && JSON.stringify(rawChecks) !== JSON.stringify(normalized)) {
+                await this._context.workspaceState.update(integrityChecksKey, normalized);
+            }
+            return normalized;
+        };
+
         const broadcastIntegrityProfiles = async (error = ''): Promise<void> => {
             const current = await loadIntegrityProfiles();
             for (const panel of this._panels) {
@@ -172,6 +188,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             const serialized = serializeParseResult(parseResult, format);
             const structs = await loadStructs();
             const integrityProfiles = await loadIntegrityProfiles();
+            const integrityChecks = await loadIntegrityChecks();
             
             const msg = {
                 type: 'init',
@@ -179,7 +196,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                 labels:      this._context.workspaceState.get(labelKey, []),
                 structs,
                 structPins:  this._context.workspaceState.get(structPinKey, []),
-                integrityProfiles,
+                integrityProfiles: { profiles: integrityProfiles, activeChecks: integrityChecks },
             };
             
             webviewPanel.webview.postMessage(msg);
@@ -271,6 +288,10 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             },
             saveStructPins: async msg => {
                 await this._context.workspaceState.update(structPinKey, msg.pins);
+            },
+            saveIntegrityChecks: async msg => {
+                const state = normalizeIntegrityCheckSet(msg.state);
+                if (state) { await this._context.workspaceState.update(integrityChecksKey, state); }
             },
             createIntegrityProfile: async msg => {
                 const profile = normalizeIntegrityProfiles([msg.profile])[0];

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -157,7 +157,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             const rawChecks = this._context.workspaceState.get<unknown>(integrityChecksKey);
             const normalized = normalizeIntegrityCheckSet(rawChecks) ?? {
                 schemaVersion: 1,
-                byteOrder: 'be',
+                byteOrder: 'le',
                 checks: [],
             };
             if (rawChecks !== undefined && JSON.stringify(rawChecks) !== JSON.stringify(normalized)) {

--- a/src/HexEditorProvider.ts
+++ b/src/HexEditorProvider.ts
@@ -79,6 +79,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
         const globalStructKey = 'hexScope.structs.global.v1';
         const structPinKey = `hexScope.structPins.${document.uri.toString()}`;
         const integrityChecksKey = `hexScope.integrityChecks.${document.uri.toString()}.v1`;
+        const endianKey = `hexScope.endian.${document.uri.toString()}.v1`;
 
         const normalizeStructDefs = (value: unknown): { defs: StructDef[]; changed: boolean } => {
             if (!Array.isArray(value)) { return { defs: [], changed: false }; }
@@ -157,13 +158,16 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             const rawChecks = this._context.workspaceState.get<unknown>(integrityChecksKey);
             const normalized = normalizeIntegrityCheckSet(rawChecks) ?? {
                 schemaVersion: 1,
-                byteOrder: 'le',
                 checks: [],
             };
             if (rawChecks !== undefined && JSON.stringify(rawChecks) !== JSON.stringify(normalized)) {
                 await this._context.workspaceState.update(integrityChecksKey, normalized);
             }
             return normalized;
+        };
+
+        const loadEndian = (): 'le' | 'be' => {
+            return this._context.workspaceState.get<unknown>(endianKey) === 'be' ? 'be' : 'le';
         };
 
         const broadcastIntegrityProfiles = async (error = ''): Promise<void> => {
@@ -196,6 +200,7 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
                 labels:      this._context.workspaceState.get(labelKey, []),
                 structs,
                 structPins:  this._context.workspaceState.get(structPinKey, []),
+                endian: loadEndian(),
                 integrityProfiles: { profiles: integrityProfiles, activeChecks: integrityChecks },
             };
             
@@ -292,6 +297,11 @@ export class HexEditorProvider implements vscode.CustomReadonlyEditorProvider {
             saveIntegrityChecks: async msg => {
                 const state = normalizeIntegrityCheckSet(msg.state);
                 if (state) { await this._context.workspaceState.update(integrityChecksKey, state); }
+            },
+            saveEndian: async msg => {
+                if (msg.endian === 'le' || msg.endian === 'be') {
+                    await this._context.workspaceState.update(endianKey, msg.endian);
+                }
             },
             createIntegrityProfile: async msg => {
                 const profile = normalizeIntegrityProfiles([msg.profile])[0];

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -134,7 +134,7 @@ suite('integrity profile normalization', () => {
         const profiles = normalizeIntegrityProfiles([validProfile]);
         assert.strictEqual(profiles.length, 1);
         assert.strictEqual(profiles[0].name, 'STM32 App');
-        assert.strictEqual(profiles[0].byteOrder, 'le');
+        assert.strictEqual('byteOrder' in profiles[0], false);
         assert.strictEqual(profiles[0].checks[0].storedAddress, 0x08000100);
         assert.strictEqual(profiles[0].checks[0].autoFixStoredValue, false);
     });
@@ -174,7 +174,7 @@ suite('integrity check-set normalization', () => {
     });
     test('accepts empty and configured per-file check sets', () => {
         assert.deepStrictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [] }), {
-            schemaVersion: 1, byteOrder: 'be', checks: [],
+            schemaVersion: 1, checks: [],
         });
         const normalized = normalizeIntegrityCheckSet({
             schemaVersion: 1,
@@ -187,7 +187,6 @@ suite('integrity check-set normalization', () => {
 
     test('rejects malformed per-file check sets', () => {
         assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 2, byteOrder: 'be', checks: [] }), null);
-        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'mixed', checks: [] }), null);
         assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [{}] }), null);
         assert.strictEqual(normalizeIntegrityCheckSet({
             schemaVersion: 1,

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -3,7 +3,11 @@ import * as assert from 'assert';
 import {
     calculateIntegrity,
     collectIntegrityBytes,
+    integrityBytesEqual,
+    integrityValueToBytes,
+    normalizeIntegrityProfiles,
     parseIntegrityAddress,
+    readStoredIntegrityBytes,
     type IntegrityAlgorithm,
     validateIntegrityRange,
 } from '../webview/integrity';
@@ -75,5 +79,67 @@ suite('integrity range parsing', () => {
         const edits = new Map([[0x2001, 0xFF]]);
         const bytes = collectIntegrityBytes(request.value, address => edits.get(address) ?? source.get(address));
         assert.deepStrictEqual(bytes, { ok: true, value: new Uint8Array([1, 0xFF, 3]) });
+    });
+
+    test('excludes an overlapping stored field from calculation bytes', () => {
+        const request = validateIntegrityRange('1000', '1005', 'crc32-iso-hdlc');
+        assert.strictEqual(request.ok, true);
+        if (!request.ok) { return; }
+        const bytes = collectIntegrityBytes(
+            request.value,
+            address => address - 0x1000,
+            { startAddress: 0x1002, byteLength: 2 },
+        );
+        assert.deepStrictEqual(bytes, { ok: true, value: new Uint8Array([0, 1, 4, 5]) });
+    });
+
+    test('encodes calculated values in selectable stored byte order', () => {
+        assert.deepStrictEqual(integrityValueToBytes('1234ABCD', 'be'), new Uint8Array([0x12, 0x34, 0xAB, 0xCD]));
+        assert.deepStrictEqual(integrityValueToBytes('1234ABCD', 'le'), new Uint8Array([0xCD, 0xAB, 0x34, 0x12]));
+        assert.strictEqual(integrityBytesEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2])), true);
+        assert.strictEqual(integrityBytesEqual(new Uint8Array([1, 2]), new Uint8Array([2, 1])), false);
+    });
+
+    test('reads stored bytes and reports an unmapped stored address', () => {
+        assert.deepStrictEqual(readStoredIntegrityBytes(
+            { startAddress: 0x2000, byteLength: 2 },
+            address => address === 0x2000 ? 0xAA : 0xBB,
+        ), { ok: true, value: new Uint8Array([0xAA, 0xBB]) });
+        assert.deepStrictEqual(readStoredIntegrityBytes(
+            { startAddress: 0x2000, byteLength: 2 },
+            address => address === 0x2000 ? 0xAA : undefined,
+        ), { ok: false, error: 'No mapped stored byte at 0x00002001.' });
+    });
+});
+
+suite('integrity profile normalization', () => {
+    const validProfile = {
+        schemaVersion: 1,
+        id: 'profile-1',
+        name: ' STM32 App ',
+        checks: [{
+            algorithm: 'crc32-iso-hdlc',
+            startAddress: 0x08000000,
+            endAddress: 0x080000FF,
+            storedAddress: 0x08000100,
+            byteOrder: 'le',
+        }],
+    };
+
+    test('normalizes valid versioned profiles', () => {
+        const profiles = normalizeIntegrityProfiles([validProfile]);
+        assert.strictEqual(profiles.length, 1);
+        assert.strictEqual(profiles[0].name, 'STM32 App');
+        assert.strictEqual(profiles[0].checks[0].storedAddress, 0x08000100);
+    });
+
+    test('drops malformed profiles and case-insensitive duplicate names', () => {
+        const profiles = normalizeIntegrityProfiles([
+            validProfile,
+            { ...validProfile, id: 'profile-2', name: 'stm32 app' },
+            { ...validProfile, id: 'bad-version', schemaVersion: 2 },
+            { ...validProfile, id: 'bad-range', name: 'Bad', checks: [{ ...validProfile.checks[0], endAddress: 1 }] },
+        ]);
+        assert.deepStrictEqual(profiles.map(profile => profile.id), ['profile-1']);
     });
 });

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -123,7 +123,6 @@ suite('integrity profile normalization', () => {
         schemaVersion: 1,
         id: 'profile-1',
         name: ' STM32 App ',
-        byteOrder: 'le',
         checks: [{
             algorithm: 'crc32-iso-hdlc',
             startAddress: 0x08000000,
@@ -137,7 +136,6 @@ suite('integrity profile normalization', () => {
         const profiles = normalizeIntegrityProfiles([validProfile]);
         assert.strictEqual(profiles.length, 1);
         assert.strictEqual(profiles[0].name, 'STM32 App');
-        assert.strictEqual('byteOrder' in profiles[0], false);
         assert.strictEqual(profiles[0].checks[0].storedAddress, 0x08000100);
         assert.strictEqual(profiles[0].checks[0].autoFixStoredValue, false);
     });
@@ -176,12 +174,11 @@ suite('integrity check-set normalization', () => {
         assert.strictEqual(isChecksumAlgorithm('sha-512'), false);
     });
     test('accepts empty and configured per-file check sets', () => {
-        assert.deepStrictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [] }), {
+        assert.deepStrictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, checks: [] }), {
             schemaVersion: 1, checks: [],
         });
         const normalized = normalizeIntegrityCheckSet({
             schemaVersion: 1,
-            byteOrder: 'le',
             checks: [{ algorithm: 'crc16-ccitt-false', startAddress: 0x1000, endAddress: 0x10FF, autoFixStoredValue: true }],
         });
         assert.strictEqual(normalized?.checks.length, 1);
@@ -189,11 +186,10 @@ suite('integrity check-set normalization', () => {
     });
 
     test('rejects malformed per-file check sets', () => {
-        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 2, byteOrder: 'be', checks: [] }), null);
-        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [{}] }), null);
+        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 2, checks: [] }), null);
+        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, checks: [{}] }), null);
         assert.strictEqual(normalizeIntegrityCheckSet({
             schemaVersion: 1,
-            byteOrder: 'be',
             checks: [{ algorithm: 'crc32-iso-hdlc', startAddress: 0, endAddress: 1 }],
         }), null);
     });

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -4,6 +4,7 @@ import {
     calculateIntegrity,
     collectIntegrityBytes,
     integrityBytesEqual,
+    integrityBytesToValueHex,
     integrityValueToBytes,
     isChecksumAlgorithm,
     mergeIntegrityEdits,
@@ -99,6 +100,8 @@ suite('integrity range parsing', () => {
     test('encodes calculated values in selectable stored byte order', () => {
         assert.deepStrictEqual(integrityValueToBytes('1234ABCD', 'be'), new Uint8Array([0x12, 0x34, 0xAB, 0xCD]));
         assert.deepStrictEqual(integrityValueToBytes('1234ABCD', 'le'), new Uint8Array([0xCD, 0xAB, 0x34, 0x12]));
+        assert.strictEqual(integrityBytesToValueHex(new Uint8Array([0x12, 0x34, 0xAB, 0xCD]), 'be'), '1234ABCD');
+        assert.strictEqual(integrityBytesToValueHex(new Uint8Array([0xCD, 0xAB, 0x34, 0x12]), 'le'), '1234ABCD');
         assert.strictEqual(integrityBytesEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2])), true);
         assert.strictEqual(integrityBytesEqual(new Uint8Array([1, 2]), new Uint8Array([2, 1])), false);
     });

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -5,6 +5,8 @@ import {
     collectIntegrityBytes,
     integrityBytesEqual,
     integrityValueToBytes,
+    mergeIntegrityEdits,
+    normalizeIntegrityCheckSet,
     normalizeIntegrityProfiles,
     parseIntegrityAddress,
     readStoredIntegrityBytes,
@@ -117,12 +119,13 @@ suite('integrity profile normalization', () => {
         schemaVersion: 1,
         id: 'profile-1',
         name: ' STM32 App ',
+        byteOrder: 'le',
         checks: [{
             algorithm: 'crc32-iso-hdlc',
             startAddress: 0x08000000,
             endAddress: 0x080000FF,
             storedAddress: 0x08000100,
-            byteOrder: 'le',
+            autoFixStoredValue: false,
         }],
     };
 
@@ -130,7 +133,9 @@ suite('integrity profile normalization', () => {
         const profiles = normalizeIntegrityProfiles([validProfile]);
         assert.strictEqual(profiles.length, 1);
         assert.strictEqual(profiles[0].name, 'STM32 App');
+        assert.strictEqual(profiles[0].byteOrder, 'le');
         assert.strictEqual(profiles[0].checks[0].storedAddress, 0x08000100);
+        assert.strictEqual(profiles[0].checks[0].autoFixStoredValue, false);
     });
 
     test('drops malformed profiles and case-insensitive duplicate names', () => {
@@ -141,5 +146,48 @@ suite('integrity profile normalization', () => {
             { ...validProfile, id: 'bad-range', name: 'Bad', checks: [{ ...validProfile.checks[0], endAddress: 1 }] },
         ]);
         assert.deepStrictEqual(profiles.map(profile => profile.id), ['profile-1']);
+    });
+
+});
+
+suite('integrity check-set normalization', () => {
+    test('accepts empty and configured per-file check sets', () => {
+        assert.deepStrictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [] }), {
+            schemaVersion: 1, byteOrder: 'be', checks: [],
+        });
+        const normalized = normalizeIntegrityCheckSet({
+            schemaVersion: 1,
+            byteOrder: 'le',
+            checks: [{ algorithm: 'crc16-ccitt-false', startAddress: 0x1000, endAddress: 0x10FF, autoFixStoredValue: true }],
+        });
+        assert.strictEqual(normalized?.checks.length, 1);
+        assert.strictEqual(normalized?.checks[0].autoFixStoredValue, true);
+    });
+
+    test('rejects malformed per-file check sets', () => {
+        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 2, byteOrder: 'be', checks: [] }), null);
+        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'mixed', checks: [] }), null);
+        assert.strictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [{}] }), null);
+        assert.strictEqual(normalizeIntegrityCheckSet({
+            schemaVersion: 1,
+            byteOrder: 'be',
+            checks: [{ algorithm: 'crc32-iso-hdlc', startAddress: 0, endAddress: 1 }],
+        }), null);
+    });
+});
+
+suite('integrity edit merging', () => {
+    test('deduplicates compatible overlapping fixes', () => {
+        assert.deepStrictEqual(mergeIntegrityEdits([
+            [[0x1000, 0xAA], [0x1001, 0xBB]],
+            [[0x1001, 0xBB], [0x1002, 0xCC]],
+        ]), { ok: true, value: [[0x1000, 0xAA], [0x1001, 0xBB], [0x1002, 0xCC]] });
+    });
+
+    test('rejects conflicting overlaps atomically', () => {
+        assert.deepStrictEqual(mergeIntegrityEdits([
+            [[0x1000, 0xAA]],
+            [[0x1000, 0xBB]],
+        ]), { ok: false, error: 'Fix all conflict at 0x00001000.' });
     });
 });

--- a/src/test/integrity.test.ts
+++ b/src/test/integrity.test.ts
@@ -5,6 +5,7 @@ import {
     collectIntegrityBytes,
     integrityBytesEqual,
     integrityValueToBytes,
+    isChecksumAlgorithm,
     mergeIntegrityEdits,
     normalizeIntegrityCheckSet,
     normalizeIntegrityProfiles,
@@ -148,9 +149,29 @@ suite('integrity profile normalization', () => {
         assert.deepStrictEqual(profiles.map(profile => profile.id), ['profile-1']);
     });
 
+    test('strips stored verification settings from hash profiles', () => {
+        const profiles = normalizeIntegrityProfiles([{
+            ...validProfile,
+            checks: [{
+                algorithm: 'sha-256', startAddress: 0x1000, endAddress: 0x10FF,
+                storedAddress: 0x1100, autoFixStoredValue: true,
+            }],
+        }]);
+        assert.deepStrictEqual(profiles[0].checks[0], {
+            algorithm: 'sha-256', startAddress: 0x1000, endAddress: 0x10FF,
+            autoFixStoredValue: false,
+        });
+    });
+
 });
 
 suite('integrity check-set normalization', () => {
+    test('recognizes only CRC algorithms as stored checksums', () => {
+        assert.strictEqual(isChecksumAlgorithm('crc16-ccitt-false'), true);
+        assert.strictEqual(isChecksumAlgorithm('crc32-iso-hdlc'), true);
+        assert.strictEqual(isChecksumAlgorithm('md5'), false);
+        assert.strictEqual(isChecksumAlgorithm('sha-512'), false);
+    });
     test('accepts empty and configured per-file check sets', () => {
         assert.deepStrictEqual(normalizeIntegrityCheckSet({ schemaVersion: 1, byteOrder: 'be', checks: [] }), {
             schemaVersion: 1, byteOrder: 'be', checks: [],

--- a/src/test/provider-utils.test.ts
+++ b/src/test/provider-utils.test.ts
@@ -1,7 +1,14 @@
 import * as assert from 'assert';
-import { detectFormatFromParts, buildSRecDataRecord, serializeSRec, repairChecksums } from '../HexEditorProvider';
+import {
+    buildSRecDataRecord,
+    detectFormatFromParts,
+    migrateStructDefinitions,
+    repairChecksums,
+    serializeSRec,
+} from '../HexEditorProvider';
 import { parseSRec } from '../parser/SRecParser';
 import { parseIntelHex } from '../parser/IntelHexParser';
+import type { StructDef } from '../webview/types';
 
 // ── detectFormatFromParts ─────────────────────────────────────────────────────
 
@@ -76,6 +83,33 @@ suite('detectFormatFromParts()', () => {
     // Extension takes priority over content
     test('SREC extension overrides IHEX content', () => {
         assert.strictEqual(detectFormatFromParts('srec', ':020000040800F2\n'), 'srec');
+    });
+});
+
+suite('migrateStructDefinitions()', () => {
+    test('writes old definitions in the shared-byte-order shape', () => {
+        const stored = [{
+            id: 'saved',
+            name: 'Saved',
+            fields: [
+                { name: 'word', type: 'uint16', count: 1, endian: 'be' },
+                { name: 'data', type: 'uint8', count: 4 },
+            ],
+        }];
+
+        const migrated = migrateStructDefinitions(stored) as StructDef[];
+
+        assert.deepStrictEqual(migrated[0].fields, [
+            { name: 'word', type: 'uint16', count: 1 },
+            { name: 'data', type: 'uint8', count: 4 },
+        ]);
+    });
+
+    test('copies clean definitions into the new storage shape', () => {
+        const clean: StructDef = {
+            id: 'clean', name: 'Clean', fields: [{ name: 'word', type: 'uint16', count: 1 }],
+        };
+        assert.deepStrictEqual(migrateStructDefinitions([clean]), [clean]);
     });
 });
 

--- a/src/test/struct-test-helpers.ts
+++ b/src/test/struct-test-helpers.ts
@@ -1,0 +1,14 @@
+import { initFlatBytes } from '../webview/data';
+import { S } from '../webview/state';
+
+export function setBytesInSegment(baseAddr: number, bytes: number[]): void {
+    S.parseResult = {
+        records: [],
+        segments: [{ startAddress: baseAddr, data: bytes }],
+        totalDataBytes: bytes.length,
+        checksumErrors: 0,
+        malformedLines: 0,
+        format: 'ihex',
+    };
+    initFlatBytes();
+}

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -644,14 +644,12 @@ suite('struct UI array header summary', () => {
 
         const toggleGroups = Array.from(document.querySelectorAll<HTMLElement>('.si-toggle-group'))
             .map(el => el.getAttribute('title') ?? '');
-        assert.ok(toggleGroups.some(title => title.includes('Byte endianness')), 'byte endianness detail should be available on hover');
+        assert.ok(!toggleGroups.some(title => title.includes('Byte endianness')), 'Struct must use shared sidebar byte order');
         assert.ok(toggleGroups.some(title => title.includes('Bit-field allocation')), 'bit-field allocation detail should be available on hover');
         const toggleLabels = Array.from(document.querySelectorAll<HTMLElement>('.si-toggle-label'))
             .map(el => el.textContent ?? '');
-        assert.ok(toggleLabels.includes('Endian'), 'compact endian label should render above the byte endianness toggle');
+        assert.ok(!toggleLabels.includes('Endian'), 'Struct must not render a local endian toggle');
         assert.ok(toggleLabels.includes('Bit Layout'), 'compact bit layout label should render above the bit-field allocation toggle');
-        assert.strictEqual(document.getElementById('sa-btn-le')?.textContent, 'LE');
-        assert.strictEqual(document.getElementById('sa-btn-be')?.textContent, 'BE');
         assert.strictEqual(document.getElementById('sa-btn-bit-lsb')?.textContent, 'LSB');
         assert.strictEqual(document.getElementById('sa-btn-bit-msb')?.textContent, 'MSB');
         assert.ok(document.getElementById('sa-btn-bit-lsb')?.getAttribute('title')?.includes('least significant bit'), 'LSB button should explain allocation on hover');

--- a/src/test/struct-ui.test.ts
+++ b/src/test/struct-ui.test.ts
@@ -2,8 +2,8 @@ import * as assert from 'assert';
 import { JSDOM } from 'jsdom';
 
 import { S } from '../webview/state';
-import { initFlatBytes } from '../webview/data';
 import type { StructDef, StructPin } from '../webview/types';
+import { setBytesInSegment } from './struct-test-helpers';
 
 function resetStructState(): void {
     S.structs = [];
@@ -14,18 +14,6 @@ function resetStructState(): void {
     S.endian = 'le';
     S.bitFieldAllocation = 'msb';
     S.sidebarTab = 'struct';
-}
-
-function setBytesInSegment(baseAddr: number, bytes: number[]): void {
-    S.parseResult = {
-        records: [],
-        segments: [{ startAddress: baseAddr, data: bytes }],
-        totalDataBytes: bytes.length,
-        checksumErrors: 0,
-        malformedLines: 0,
-        format: 'ihex',
-    };
-    initFlatBytes();
 }
 
 suite('struct UI array header summary', () => {
@@ -101,15 +89,15 @@ suite('struct UI array header summary', () => {
             id: 'child',
             name: 'ChildNode',
             fields: [
-                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+                { name: 'a', type: 'uint8', count: 1 },
+                { name: 'b', type: 'uint16', count: 1 },
             ],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
             fields: [
-                { name: 'nodes', type: 'struct', refStructId: 'child', count: 3, endian: 'inherit' },
+                { name: 'nodes', type: 'struct', refStructId: 'child', count: 3 },
             ],
         };
         const pin: StructPin = {
@@ -142,16 +130,16 @@ suite('struct UI array header summary', () => {
             id: 'child',
             name: 'ChildNode',
             fields: [
-                { name: 'field0', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'field1', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'field2', type: 'uint8', count: 2, endian: 'inherit' },
+                { name: 'field0', type: 'uint8', count: 1 },
+                { name: 'field1', type: 'uint8', count: 1 },
+                { name: 'field2', type: 'uint8', count: 2 },
             ],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
             fields: [
-                { name: 'nodes', type: 'struct', refStructId: 'child', count: 2, endian: 'inherit' },
+                { name: 'nodes', type: 'struct', refStructId: 'child', count: 2 },
             ],
         };
         const pin: StructPin = {
@@ -222,16 +210,16 @@ suite('struct UI array header summary', () => {
             id: 'child',
             name: 'MyStruct',
             fields: [
-                { name: 'field0', type: 'uint32', count: 1, endian: 'inherit' },
-                { name: 'field1', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'field2', type: 'uint8', count: 2, endian: 'inherit' },
+                { name: 'field0', type: 'uint32', count: 1 },
+                { name: 'field1', type: 'uint8', count: 1 },
+                { name: 'field2', type: 'uint8', count: 2 },
             ],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
             fields: [
-                { name: 'field3', type: 'struct', refStructId: 'child', count: 1, endian: 'inherit' },
+                { name: 'field3', type: 'struct', refStructId: 'child', count: 1 },
             ],
         };
         const pin: StructPin = {
@@ -272,15 +260,15 @@ suite('struct UI array header summary', () => {
             id: 'child_collapse',
             name: 'ChildCollapse',
             fields: [
-                { name: 'field0', type: 'uint32', count: 1, endian: 'inherit' },
-                { name: 'field1', type: 'uint8', count: 2, endian: 'inherit' },
+                { name: 'field0', type: 'uint32', count: 1 },
+                { name: 'field1', type: 'uint8', count: 2 },
             ],
         };
         const parent: StructDef = {
             id: 'parent_collapse',
             name: 'ParentCollapse',
             fields: [
-                { name: 'field3', type: 'struct', refStructId: 'child_collapse', count: 1, endian: 'inherit' },
+                { name: 'field3', type: 'struct', refStructId: 'child_collapse', count: 1 },
             ],
         };
 
@@ -311,14 +299,14 @@ suite('struct UI array header summary', () => {
             id: 'single_leaf_child',
             name: 'SingleLeafChild',
             fields: [
-                { name: 'only', type: 'uint16', count: 1, endian: 'inherit' },
+                { name: 'only', type: 'uint16', count: 1 },
             ],
         };
         const parent: StructDef = {
             id: 'single_leaf_parent',
             name: 'SingleLeafParent',
             fields: [
-                { name: 'wrap', type: 'struct', refStructId: 'single_leaf_child', count: 1, endian: 'inherit' },
+                { name: 'wrap', type: 'struct', refStructId: 'single_leaf_child', count: 1 },
             ],
         };
 
@@ -341,21 +329,21 @@ suite('struct UI array header summary', () => {
             id: 'depth_l3',
             name: 'DepthL3',
             fields: [
-                { name: 'bytes', type: 'uint8', count: 2, endian: 'inherit' },
+                { name: 'bytes', type: 'uint8', count: 2 },
             ],
         };
         const level2: StructDef = {
             id: 'depth_l2',
             name: 'DepthL2',
             fields: [
-                { name: 'inner', type: 'struct', refStructId: 'depth_l3', count: 1, endian: 'inherit' },
+                { name: 'inner', type: 'struct', refStructId: 'depth_l3', count: 1 },
             ],
         };
         const level1: StructDef = {
             id: 'depth_l1',
             name: 'DepthL1',
             fields: [
-                { name: 'outer', type: 'struct', refStructId: 'depth_l2', count: 1, endian: 'inherit' },
+                { name: 'outer', type: 'struct', refStructId: 'depth_l2', count: 1 },
             ],
         };
 
@@ -390,8 +378,8 @@ suite('struct UI array header summary', () => {
             id: 'array_offset',
             name: 'ArrayOffset',
             fields: [
-                { name: 'prefix', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'values', type: 'uint16', count: 2, endian: 'inherit' },
+                { name: 'prefix', type: 'uint8', count: 1 },
+                { name: 'values', type: 'uint16', count: 2 },
             ],
         };
 
@@ -423,16 +411,16 @@ suite('struct UI array header summary', () => {
             id: 'nested_offset_child',
             name: 'NestedOffsetChild',
             fields: [
-                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+                { name: 'a', type: 'uint8', count: 1 },
+                { name: 'b', type: 'uint16', count: 1 },
             ],
         };
         const parent: StructDef = {
             id: 'nested_offset_parent',
             name: 'NestedOffsetParent',
             fields: [
-                { name: 'prefix', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'node', type: 'struct', refStructId: 'nested_offset_child', count: 1, endian: 'inherit' },
+                { name: 'prefix', type: 'uint8', count: 1 },
+                { name: 'node', type: 'struct', refStructId: 'nested_offset_child', count: 1 },
             ],
         };
 
@@ -464,7 +452,7 @@ suite('struct UI array header summary', () => {
             id: 'str_leaf',
             name: 'StrLeaf',
             fields: [
-                { name: 'name', type: 'ascii', count: 8, endian: 'inherit' },
+                { name: 'name', type: 'ascii', count: 8 },
             ],
         };
         const pin: StructPin = {
@@ -493,21 +481,21 @@ suite('struct UI array header summary', () => {
             id: 'leaf_suffix',
             name: 'LeafSuffix',
             fields: [
-                { name: 'field0', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'field0', type: 'uint8', count: 1 },
             ],
         };
         const mid: StructDef = {
             id: 'mid_suffix',
             name: 'MidSuffix',
             fields: [
-                { name: 'children', type: 'struct', refStructId: 'leaf_suffix', count: 2, endian: 'inherit' },
+                { name: 'children', type: 'struct', refStructId: 'leaf_suffix', count: 2 },
             ],
         };
         const top: StructDef = {
             id: 'top_suffix',
             name: 'TopSuffix',
             fields: [
-                { name: 'nodes', type: 'struct', refStructId: 'mid_suffix', count: 2, endian: 'inherit' },
+                { name: 'nodes', type: 'struct', refStructId: 'mid_suffix', count: 2 },
             ],
         };
         const pin: StructPin = {
@@ -547,7 +535,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 2,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
@@ -557,7 +544,6 @@ suite('struct UI array header summary', () => {
                     name: 'field1',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'bit0', bitWidth: 1 },
                         { name: 'bit1', bitWidth: 1 },
@@ -618,7 +604,7 @@ suite('struct UI array header summary', () => {
         assert.ok(childRows.length > 0, 'bit-field array element should expose child bit rows');
     });
 
-    test('shows independent byte endianness and bit-field allocation toggles', async () => {
+    test('uses shared byte order with a local bit-layout toggle', async () => {
         const def: StructDef = {
             id: 'bit_alloc_toggle',
             name: 'BitAllocToggle',
@@ -627,7 +613,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'a', bitWidth: 3 },
                         { name: 'b', bitWidth: 5 },
@@ -670,18 +655,18 @@ suite('struct UI array header summary', () => {
         assert.deepStrictEqual(childValuesLsb, ['001', '1 0110'], 'LSB-first should allocate from low bits independently of byte endianness');
     });
 
-    test('renders scalar values with each field effective endian instead of the global toggle', async () => {
+    test('renders scalar values using shared byte order', async () => {
         const fields: StructDef['fields'] = [
-            { name: 'u16', type: 'uint16', count: 1, endian: 'inherit' },
-            { name: 'i16', type: 'int16', count: 1, endian: 'inherit' },
-            { name: 'u32', type: 'uint32', count: 1, endian: 'inherit' },
-            { name: 'i32', type: 'int32', count: 1, endian: 'inherit' },
-            { name: 'u64', type: 'uint64', count: 1, endian: 'inherit' },
-            { name: 'i64', type: 'int64', count: 1, endian: 'inherit' },
-            { name: 'f32', type: 'float32', count: 1, endian: 'inherit' },
-            { name: 'f64', type: 'float64', count: 1, endian: 'inherit' },
-            { name: 'ptr', type: 'pointer', count: 1, endian: 'inherit' },
-            { name: 'arr', type: 'uint16', count: 2, endian: 'inherit' },
+            { name: 'u16', type: 'uint16', count: 1 },
+            { name: 'i16', type: 'int16', count: 1 },
+            { name: 'u32', type: 'uint32', count: 1 },
+            { name: 'i32', type: 'int32', count: 1 },
+            { name: 'u64', type: 'uint64', count: 1 },
+            { name: 'i64', type: 'int64', count: 1 },
+            { name: 'f32', type: 'float32', count: 1 },
+            { name: 'f64', type: 'float64', count: 1 },
+            { name: 'ptr', type: 'pointer', count: 1 },
+            { name: 'arr', type: 'uint16', count: 2 },
         ];
         const leBytes = [
             0x34, 0x12, 0xFE, 0xFF, 0x78, 0x56, 0x34, 0x12,
@@ -698,24 +683,24 @@ suite('struct UI array header summary', () => {
             0x12, 0x34, 0x56, 0x78,
         ];
 
-        const renderValues = async (fieldEndian: 'le' | 'be', globalEndian: 'le' | 'be', bytes: number[]) => {
+        const renderValues = async (endian: 'le' | 'be', bytes: number[]) => {
             resetStructState();
-            S.endian = globalEndian;
+            S.endian = endian;
             const def: StructDef = {
-                id: `scalar_${fieldEndian}`,
-                name: `Scalar${fieldEndian.toUpperCase()}`,
+                id: `scalar_${endian}`,
+                name: `Scalar${endian.toUpperCase()}`,
                 packed: true,
-                fields: fields.map(f => ({ ...f, endian: fieldEndian })),
+                fields,
             };
             S.structs = [def];
-            S.structPins = [{ id: `pin_${fieldEndian}`, structId: def.id, addr: 0, name: 'inst' }];
+            S.structPins = [{ id: `pin_${endian}`, structId: def.id, addr: 0, name: 'inst' }];
             setBytesInSegment(0, bytes);
             await renderPinsAndExpandCard();
             return Array.from(document.querySelectorAll<HTMLElement>('.si-field > .si-f-body > .si-f-val'))
                 .map(el => el.textContent?.replace(/\s+/g, ' ').trim() ?? '');
         };
 
-        const leValues = await renderValues('le', 'be', leBytes);
+        const leValues = await renderValues('le', leBytes);
         assert.ok(leValues[0].includes('0x1234'), `u16 LE display: ${leValues[0]}`);
         assert.ok(leValues[1].includes('0xFFFE'), `i16 LE display: ${leValues[1]}`);
         assert.ok(leValues[2].includes('0x12345678'), `u32 LE display: ${leValues[2]}`);
@@ -739,7 +724,7 @@ suite('struct UI array header summary', () => {
         assert.ok(hexItem, 'hex view menu item should render');
         hexItem!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 
-        const beValues = await renderValues('be', 'le', beBytes);
+        const beValues = await renderValues('be', beBytes);
         assert.ok(beValues[0].includes('0x1234'), `u16 BE display: ${beValues[0]}`);
         assert.ok(beValues[1].includes('0xFFFE'), `i16 BE display: ${beValues[1]}`);
         assert.ok(beValues[2].includes('0x12345678'), `u32 BE display: ${beValues[2]}`);
@@ -768,7 +753,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'bit0', bitWidth: 1 },
                         { name: 'bit1', bitWidth: 1 },
@@ -842,7 +826,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'lo', bitWidth: 4 },
                         { name: 'hi', bitWidth: 4 },
@@ -878,7 +861,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'a', bitWidth: 2 },
                         { name: 'b', bitWidth: 3 },
@@ -921,14 +903,13 @@ suite('struct UI array header summary', () => {
             id: 'single_line_copy',
             name: 'SingleLineCopy',
             fields: [
-                { name: 'wide', type: 'uint64', count: 1, endian: 'inherit' },
-                { name: 'flt', type: 'float32', count: 1, endian: 'inherit' },
-                { name: 'text', type: 'ascii', count: 4, endian: 'inherit' },
+                { name: 'wide', type: 'uint64', count: 1 },
+                { name: 'flt', type: 'float32', count: 1 },
+                { name: 'text', type: 'ascii', count: 4 },
                 {
                     name: 'flags',
                     type: 'uint32',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'top', bitWidth: 5 },
                         { name: 'mid', bitWidth: 7 },
@@ -1000,7 +981,6 @@ suite('struct UI array header summary', () => {
                     name: 'flags',
                     type: 'uint32',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'lo', bitWidth: 4 },
                         { name: 'hi', bitWidth: 4 },
@@ -1018,7 +998,7 @@ suite('struct UI array header summary', () => {
         const parentValue = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-f-val[data-val-type="bin"]');
         assert.ok(parentValue, 'wide bit-field parent should render full binary by default');
         assert.strictEqual(parentValue!.querySelectorAll('br').length, 1, 'uint32 bit-field parent binary should wrap after 16 bits');
-        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '01111000010101100011010000010010', 'wide bit-field parent binary should show full storage bits in effective endian order');
+        assert.strictEqual(parentValue!.textContent?.replace(/\s+/g, ''), '01111000010101100011010000010010', 'wide bit-field parent binary should follow shared byte order');
 
         const expandBits = document.querySelector<HTMLElement>('.si-bitunit-hdr .si-arr-exp-btn');
         assert.ok(expandBits, 'wide bit-field parent should be expandable');
@@ -1046,7 +1026,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'wide', bitWidth: 5 },
                     ],
@@ -1078,7 +1057,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 2,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
@@ -1127,7 +1105,6 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 2,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
@@ -1173,20 +1150,19 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 2,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
                     ],
                 },
-                { name: 'payload', type: 'uint8', count: 2, endian: 'inherit' },
+                { name: 'payload', type: 'uint8', count: 2 },
             ],
         };
         const parent: StructDef = {
             id: 'parent_bits',
             name: 'ParentBits',
             fields: [
-                { name: 'nodes', type: 'struct', refStructId: 'child_bits', count: 2, endian: 'inherit' },
+                { name: 'nodes', type: 'struct', refStructId: 'child_bits', count: 2 },
             ],
         };
 
@@ -1232,7 +1208,6 @@ suite('struct UI array header summary', () => {
                     name: 'control',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'enabled', bitWidth: 1 },
@@ -1244,7 +1219,7 @@ suite('struct UI array header summary', () => {
             id: 'parent_single_bits',
             name: 'ParentSingleBits',
             fields: [
-                { name: 'node', type: 'struct', refStructId: 'child_single_bits', count: 1, endian: 'inherit' },
+                { name: 'node', type: 'struct', refStructId: 'child_single_bits', count: 1 },
             ],
         };
 
@@ -1288,18 +1263,16 @@ suite('struct UI array header summary', () => {
                     name: 'field0',
                     type: 'uint8',
                     count: 2,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
                     ],
                 },
-                { name: 'data', type: 'uint8', count: 3, endian: 'inherit' },
+                { name: 'data', type: 'uint8', count: 3 },
                 {
                     name: 'field1',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'bit0', bitWidth: 1 },
                         { name: 'bit1', bitWidth: 1 },

--- a/src/test/struct.test.ts
+++ b/src/test/struct.test.ts
@@ -5,8 +5,9 @@ import {
     allStructs, parseStructText, fieldsToText, validateStructs, structToC, resolveStructFieldByPath,
 } from '../webview/struct-codec';
 import { S } from '../webview/state';
-import { initFlatBytes, getByte } from '../webview/data';
+import { getByte } from '../webview/data';
 import type { StructDef, StructField } from '../webview/types';
+import { setBytesInSegment } from './struct-test-helpers';
 
 function resetStructState(): void {
     S.structs           = [];
@@ -15,17 +16,21 @@ function resetStructState(): void {
     S.segmentIndex      = [];
 }
 
-/** Helper: set up parseResult with bytes at the given addresses. */
-function setBytesInSegment(baseAddr: number, bytes: number[]): void {
-    S.parseResult = {
-        records: [],
-        segments: [{ startAddress: baseAddr, data: bytes }],
-        totalDataBytes: bytes.length,
-        checksumErrors: 0,
-        malformedLines: 0,
-        format: 'ihex',
+function layoutFields(): StructField[] {
+    return [
+        { name: 'a', type: 'uint8', count: 1 },
+        { name: 'b', type: 'uint32', count: 1 },
+        { name: 'c', type: 'uint16', count: 1 },
+    ];
+}
+
+function bitFieldStruct(): StructDef {
+    return {
+        id: 'x', name: 'Bits', packed: true, fields: [{
+            name: 'bits', type: 'uint8', count: 1,
+            bitFields: [{ name: 'a', bitWidth: 3 }, { name: 'b', bitWidth: 5 }],
+        }],
     };
-    initFlatBytes();
 }
 
 // ── fieldByteSize ─────────────────────────────────────────────────
@@ -54,25 +59,25 @@ suite('structByteSize()', () => {
 
     test('single uint32 field is 4 bytes', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint32', count: 1 },
         ]};
         assert.strictEqual(structByteSize(def), 4);
     });
 
     test('mixed field types packed: no padding (7 bytes)', () => {
         const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // 1
-            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },  // 2
-            { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },  // 4
+            { name: 'a', type: 'uint8',  count: 1 },  // 1
+            { name: 'b', type: 'uint16', count: 1 },  // 2
+            { name: 'c', type: 'uint32', count: 1 },  // 4
         ]};
         assert.strictEqual(structByteSize(def), 7);
     });
 
     test('mixed field types aligned: uint8+uint16+uint32 = 8 bytes', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0
-            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },  // +2 (1B pad)
-            { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },  // +4
+            { name: 'a', type: 'uint8',  count: 1 },  // +0
+            { name: 'b', type: 'uint16', count: 1 },  // +2 (1B pad)
+            { name: 'c', type: 'uint32', count: 1 },  // +4
         ]};
         assert.strictEqual(structByteSize(def), 8);
     });
@@ -80,31 +85,31 @@ suite('structByteSize()', () => {
     test('aligned struct has trailing padding to max alignment', () => {
         // uint32 then uint8: size = 4+1 padded to 8 (align=4)
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },  // +0
-            { name: 'b', type: 'uint8',  count: 1, endian: 'inherit' },  // +4
+            { name: 'a', type: 'uint32', count: 1 },  // +0
+            { name: 'b', type: 'uint8',  count: 1 },  // +4
         ]};
         assert.strictEqual(structByteSize(def), 8);
     });
 
     test('array field multiplies by count', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'v', type: 'uint32', count: 4, endian: 'inherit' },  // 4 × 4 = 16
+            { name: 'v', type: 'uint32', count: 4 },  // 4 × 4 = 16
         ]};
         assert.strictEqual(structByteSize(def), 16);
     });
 
     test('uint64 alignment (not packed): uint32 then uint64 → 16', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },
-            { name: 'b', type: 'uint64', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint32', count: 1 },
+            { name: 'b', type: 'uint64', count: 1 },
         ]};
         assert.strictEqual(structByteSize(def), 16);
     });
 
     test('uint64 alignment (packed): uint32 then uint64 → 12', () => {
         const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
-            { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },
-            { name: 'b', type: 'uint64', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint32', count: 1 },
+            { name: 'b', type: 'uint64', count: 1 },
         ]};
         assert.strictEqual(structByteSize(def), 12);
     });
@@ -115,7 +120,6 @@ suite('structByteSize()', () => {
                 name: 'bits',
                 type: 'uint16',
                 count: 1,
-                endian: 'inherit',
                 bitFields: [
                     { name: 'a', bitWidth: 3 },
                     { name: 'b', bitWidth: 5 },
@@ -132,13 +136,12 @@ suite('structByteSize()', () => {
                 name: 'bits',
                 type: 'uint16',
                 count: 1,
-                endian: 'inherit',
                 bitFields: [
                     { name: 'a', bitWidth: 3 },
                     { name: 'b', bitWidth: 5 },
                 ],
             },
-            { name: 'c', type: 'uint32', count: 1, endian: 'inherit' },
+            { name: 'c', type: 'uint32', count: 1 },
         ]};
         assert.strictEqual(structByteSize(def), 8);
     });
@@ -149,7 +152,6 @@ suite('structByteSize()', () => {
                 name: 'flags',
                 type: 'uint8',
                 count: 2,
-                endian: 'inherit',
                 bitFields: [
                     { name: 'enabled', bitWidth: 1 },
                     { name: 'mode', bitWidth: 7 },
@@ -174,16 +176,16 @@ suite('structByteSize()', () => {
             id: 'child',
             name: 'Child',
             fields: [
-                { name: 'x', type: 'uint16', count: 1, endian: 'inherit' },
-                { name: 'y', type: 'uint16', count: 1, endian: 'inherit' },
+                { name: 'x', type: 'uint16', count: 1 },
+                { name: 'y', type: 'uint16', count: 1 },
             ],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
             fields: [
-                { name: 'head', type: 'uint32', count: 1, endian: 'inherit' },
-                { name: 'c', type: 'struct', refStructId: 'child', count: 1, endian: 'inherit' },
+                { name: 'head', type: 'uint32', count: 1 },
+                { name: 'c', type: 'struct', refStructId: 'child', count: 1 },
             ],
         };
         S.structs = [child, parent];
@@ -303,8 +305,8 @@ suite('decodeStruct()', () => {
 
     test('produces one row per scalar field', () => {
         const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },
-            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint8',  count: 1 },
+            { name: 'b', type: 'uint16', count: 1 },
         ]};
         // populate parseResult at base 0x100
         setBytesInSegment(0x100, [0x01, 0x02, 0x03]);
@@ -319,8 +321,8 @@ suite('decodeStruct()', () => {
 
     test('aligned struct: uint8 then uint16 at offset 2', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },
-            { name: 'b', type: 'uint16', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint8',  count: 1 },
+            { name: 'b', type: 'uint16', count: 1 },
         ]};
         const rows = decodeStruct(def, 0, getByte, 'le');
         assert.strictEqual(rows[0].byteOffset, 0);
@@ -329,7 +331,7 @@ suite('decodeStruct()', () => {
 
     test('array field expands to count rows named field[0], field[1]...', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'v', type: 'uint8', count: 3, endian: 'inherit' },
+            { name: 'v', type: 'uint8', count: 3 },
         ]};
         setBytesInSegment(0, [0x0A, 0x0B, 0x0C]);
 
@@ -342,7 +344,7 @@ suite('decodeStruct()', () => {
 
     test('hasData is false when byte is absent from segments', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint8', count: 1 },
         ]};
         // Do NOT populate parseResult; getBy te will return undefined
         S.parseResult = null;
@@ -352,34 +354,32 @@ suite('decodeStruct()', () => {
         assert.strictEqual(rows[0].decoded, '??');
     });
 
-    test('field-level endian "le" overrides global "be"', () => {
+    test('shared big-endian setting applies to scalar fields', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint16', count: 1, endian: 'le' },
+            { name: 'a', type: 'uint16', count: 1 },
         ]};
         setBytesInSegment(0, [0x01, 0x00]);
-        // LE: 0x0001 = 1, even though global endian is BE
         const rows = decodeStruct(def, 0, getByte, 'be');
-        assert.ok(rows[0].decoded.startsWith('1'), rows[0].decoded);
+        assert.ok(rows[0].decoded.startsWith('256'), rows[0].decoded);
     });
 
-    test('field-level endian "be" overrides global "le"', () => {
+    test('shared little-endian setting applies to scalar fields', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint16', count: 1, endian: 'be' },
+            { name: 'a', type: 'uint16', count: 1 },
         ]};
         setBytesInSegment(0, [0x00, 0x01]);
-        // BE read of 00 01 = 1
         const rows = decodeStruct(def, 0, getByte, 'le');
-        assert.ok(rows[0].decoded.startsWith('1'), rows[0].decoded);
+        assert.ok(rows[0].decoded.startsWith('256'), rows[0].decoded);
     });
 
-    test('decoded rows keep effective endian for arrays and nested structs', () => {
+    test('shared byte order applies to arrays and nested structs', () => {
         const child: StructDef = {
             id: 'endian_child',
             name: 'EndianChild',
             fields: [
-                { name: 'word', type: 'uint16', count: 2, endian: 'inherit' },
-                { name: 'flt', type: 'float32', count: 1, endian: 'inherit' },
-                { name: 'ptr', type: 'pointer', count: 1, endian: 'inherit' },
+                { name: 'word', type: 'uint16', count: 2 },
+                { name: 'flt', type: 'float32', count: 1 },
+                { name: 'ptr', type: 'pointer', count: 1 },
             ],
         };
         const parent: StructDef = {
@@ -387,8 +387,8 @@ suite('decodeStruct()', () => {
             name: 'EndianParent',
             packed: true,
             fields: [
-                { name: 'leWord', type: 'uint16', count: 1, endian: 'le' },
-                { name: 'beNode', type: 'struct', refStructId: 'endian_child', count: 1, endian: 'be' },
+                { name: 'word', type: 'uint16', count: 1 },
+                { name: 'node', type: 'struct', refStructId: 'endian_child', count: 1 },
             ],
         };
         S.structs = [child, parent];
@@ -400,11 +400,9 @@ suite('decodeStruct()', () => {
             0x12, 0x34, 0x56, 0x78,
         ]);
 
-        const rows = decodeStruct(parent, 0, getByte, 'le');
-        assert.strictEqual(rows[0].fieldName, 'leWord');
-        assert.strictEqual(rows[0].endian, 'le');
-        assert.ok(rows[0].decoded.startsWith('4660'), rows[0].decoded);
-        assert.deepStrictEqual(rows.slice(1).map(r => r.endian), ['be', 'be', 'be', 'be']);
+        const rows = decodeStruct(parent, 0, getByte, 'be');
+        assert.strictEqual(rows[0].fieldName, 'word');
+        assert.ok(rows[0].decoded.startsWith('13330'), rows[0].decoded);
         assert.ok(rows[1].decoded.startsWith('4660'), rows[1].decoded);
         assert.ok(rows[2].decoded.startsWith('22136'), rows[2].decoded);
         assert.strictEqual(parseFloat(rows[3].decoded), 1);
@@ -412,11 +410,7 @@ suite('decodeStruct()', () => {
     });
 
     test('byte offsets accumulate correctly (packed)', () => {
-        const def: StructDef = { id: 'x', name: 'S', packed: true, fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0, 1 B
-            { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },  // +1, 4 B
-            { name: 'c', type: 'uint16', count: 1, endian: 'inherit' },  // +5, 2 B
-        ]};
+        const def: StructDef = { id: 'x', name: 'S', packed: true, fields: layoutFields() };
         const rows = decodeStruct(def, 0, getByte, 'le');
         assert.strictEqual(rows[0].byteOffset, 0);
         assert.strictEqual(rows[1].byteOffset, 1);
@@ -424,11 +418,7 @@ suite('decodeStruct()', () => {
     });
 
     test('byte offsets with alignment (not packed)', () => {
-        const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint8',  count: 1, endian: 'inherit' },  // +0
-            { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },  // +4 (3B pad)
-            { name: 'c', type: 'uint16', count: 1, endian: 'inherit' },  // +8
-        ]};
+        const def: StructDef = { id: 'x', name: 'S', fields: layoutFields() };
         const rows = decodeStruct(def, 0, getByte, 'le');
         assert.strictEqual(rows[0].byteOffset, 0);
         assert.strictEqual(rows[1].byteOffset, 4);
@@ -436,18 +426,7 @@ suite('decodeStruct()', () => {
     });
 
     test('decodes bit fields MSB-first by default as unsigned values', () => {
-        const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
-            {
-                name: 'bits',
-                type: 'uint8',
-                count: 1,
-                endian: 'inherit',
-                bitFields: [
-                    { name: 'a', bitWidth: 3 },
-                    { name: 'b', bitWidth: 5 },
-                ],
-            },
-        ]};
+        const def = bitFieldStruct();
         // 0xB1 => a=0b101=5, b=0b10001=17 in MSB-first allocation.
         setBytesInSegment(0, [0xB1]);
         const rows = decodeStruct(def, 0, getByte, 'le');
@@ -460,18 +439,7 @@ suite('decodeStruct()', () => {
     });
 
     test('decodes bit fields LSB-first when allocation is LSB', () => {
-        const def: StructDef = { id: 'x', name: 'Bits', packed: true, fields: [
-            {
-                name: 'bits',
-                type: 'uint8',
-                count: 1,
-                endian: 'inherit',
-                bitFields: [
-                    { name: 'a', bitWidth: 3 },
-                    { name: 'b', bitWidth: 5 },
-                ],
-            },
-        ]};
+        const def = bitFieldStruct();
         // 0b10110001 => a=0b001=1, b=0b10110=22 in LSB-first allocation.
         setBytesInSegment(0, [0xB1]);
         const rows = decodeStruct(def, 0, getByte, 'le', 'lsb');
@@ -485,7 +453,6 @@ suite('decodeStruct()', () => {
                 name: 'word',
                 type: 'uint16',
                 count: 1,
-                endian: 'inherit',
                 bitFields: [
                     { name: 'a', bitWidth: 4 },
                     { name: 'b', bitWidth: 4 },
@@ -513,7 +480,7 @@ suite('decodeStruct()', () => {
 
     test('bytesHex shows ?? for missing bytes', () => {
         const def: StructDef = { id: 'x', name: 'S', fields: [
-            { name: 'a', type: 'uint16', count: 1, endian: 'inherit' },
+            { name: 'a', type: 'uint16', count: 1 },
         ]};
         setBytesInSegment(0, [0xAB]); // only first byte present
         const rows = decodeStruct(def, 0, getByte, 'le');
@@ -524,12 +491,12 @@ suite('decodeStruct()', () => {
         const child: StructDef = {
             id: 'child',
             name: 'Child',
-            fields: [{ name: 'v', type: 'uint8', count: 1, endian: 'inherit' }],
+            fields: [{ name: 'v', type: 'uint8', count: 1 }],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
-            fields: [{ name: 'nodes', type: 'struct', refStructId: 'child', count: 3, endian: 'inherit' }],
+            fields: [{ name: 'nodes', type: 'struct', refStructId: 'child', count: 3 }],
         };
         S.structs = [child, parent];
         setBytesInSegment(0, [0x11, 0x22, 0x33]);
@@ -549,12 +516,12 @@ suite('resolveStructFieldByPath()', () => {
         const child: StructDef = {
             id: 'child',
             name: 'ChildNode',
-            fields: [{ name: 'v', type: 'uint8', count: 1, endian: 'inherit' }],
+            fields: [{ name: 'v', type: 'uint8', count: 1 }],
         };
         const parent: StructDef = {
             id: 'parent',
             name: 'Parent',
-            fields: [{ name: 'nodes', type: 'struct', refStructId: 'child', count: 3, endian: 'inherit' }],
+            fields: [{ name: 'nodes', type: 'struct', refStructId: 'child', count: 3 }],
         };
 
         S.structs = [child, parent];
@@ -570,17 +537,17 @@ suite('resolveStructFieldByPath()', () => {
         const leaf: StructDef = {
             id: 'leaf',
             name: 'Leaf',
-            fields: [{ name: 'x', type: 'uint8', count: 1, endian: 'inherit' }],
+            fields: [{ name: 'x', type: 'uint8', count: 1 }],
         };
         const mid: StructDef = {
             id: 'mid',
             name: 'Mid',
-            fields: [{ name: 'nodes', type: 'struct', refStructId: 'leaf', count: 4, endian: 'inherit' }],
+            fields: [{ name: 'nodes', type: 'struct', refStructId: 'leaf', count: 4 }],
         };
         const top: StructDef = {
             id: 'top',
             name: 'Top',
-            fields: [{ name: 'wrappers', type: 'struct', refStructId: 'mid', count: 2, endian: 'inherit' }],
+            fields: [{ name: 'wrappers', type: 'struct', refStructId: 'mid', count: 2 }],
         };
 
         S.structs = [leaf, mid, top];
@@ -600,12 +567,12 @@ suite('validateStructs()', () => {
         const a: StructDef = {
             id: 'a',
             name: 'A',
-            fields: [{ name: 'b', type: 'struct', refStructId: 'b', count: 1, endian: 'inherit' }],
+            fields: [{ name: 'b', type: 'struct', refStructId: 'b', count: 1 }],
         };
         const b: StructDef = {
             id: 'b',
             name: 'B',
-            fields: [{ name: 'a', type: 'struct', refStructId: 'a', count: 1, endian: 'inherit' }],
+            fields: [{ name: 'a', type: 'struct', refStructId: 'a', count: 1 }],
         };
         const errs = validateStructs([a, b], 3);
         assert.ok(errs.some(e => e.includes('cycle')), `errors: ${errs.join(' | ')}`);
@@ -619,8 +586,8 @@ suite('validateStructs()', () => {
                 id: `s${i}`,
                 name: `S${i}`,
                 fields: i === depth
-                    ? [{ name: 'x', type: 'uint8', count: 1, endian: 'inherit' }]
-                    : [{ name: `s${i + 1}`, type: 'struct', refStructId: `s${i + 1}`, count: 1, endian: 'inherit' }],
+                    ? [{ name: 'x', type: 'uint8', count: 1 }]
+                    : [{ name: `s${i + 1}`, type: 'struct', refStructId: `s${i + 1}`, count: 1 }],
             });
         }
         const errs = validateStructs(defs, 32);
@@ -636,7 +603,6 @@ suite('validateStructs()', () => {
                     name: 'flags',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'a', bitWidth: 9 },
                         { name: 'b', bitWidth: 1 },
@@ -682,13 +648,13 @@ suite('allStructs()', () => {
 suite('parseStructText()', () => {
     test('parses uint32_t scalar field', () => {
         const { fields, errors } = parseStructText('uint32_t handler;');
-        assert.deepStrictEqual(fields, [{ name: 'handler', type: 'uint32', count: 1, endian: 'inherit' }]);
+        assert.deepStrictEqual(fields, [{ name: 'handler', type: 'uint32', count: 1 }]);
         assert.strictEqual(errors.length, 0);
     });
 
     test('parses uint8_t array field', () => {
         const { fields, errors } = parseStructText('uint8_t data[16];');
-        assert.deepStrictEqual(fields, [{ name: 'data', type: 'uint8', count: 16, endian: 'inherit' }]);
+        assert.deepStrictEqual(fields, [{ name: 'data', type: 'uint8', count: 16 }]);
         assert.strictEqual(errors.length, 0);
     });
 
@@ -739,24 +705,12 @@ suite('parseStructText()', () => {
         assert.strictEqual(fields[0].type, 'uint32');
     });
 
-    test('endian hint /* be */ sets endian to be', () => {
-        const { fields } = parseStructText('uint32_t reg; /* be */');
-        assert.strictEqual(fields[0].endian, 'be');
-    });
-
-    test('endian hint // le sets endian to le', () => {
-        const { fields } = parseStructText('uint32_t reg; // le');
-        assert.strictEqual(fields[0].endian, 'le');
-    });
-
-    test('endian hint // be sets endian to be', () => {
-        const { fields } = parseStructText('uint32_t reg; // be');
-        assert.strictEqual(fields[0].endian, 'be');
-    });
-
-    test('inherit endian when no hint present', () => {
-        const { fields } = parseStructText('uint32_t reg;');
-        assert.strictEqual(fields[0].endian, 'inherit');
+    test('treats old endian annotations as ordinary comments', () => {
+        for (const text of ['uint32_t reg; /* be */', 'uint32_t reg; // le', 'uint32_t reg; // be']) {
+            const { fields, errors } = parseStructText(text);
+            assert.deepStrictEqual(errors, []);
+            assert.deepStrictEqual(fields, [{ name: 'reg', type: 'uint32', count: 1 }]);
+        }
     });
 
     test('extracts structName from struct wrapper', () => {
@@ -824,38 +778,28 @@ suite('fieldsToText()', () => {
     });
 
     test('uint32_t field emits uint32_t keyword', () => {
-        const f: StructField[] = [{ name: 'handler', type: 'uint32', count: 1, endian: 'inherit' }];
+        const f: StructField[] = [{ name: 'handler', type: 'uint32', count: 1 }];
         assert.ok(fieldsToText(f).includes('uint32_t'));
         assert.ok(fieldsToText(f).includes('handler;'));
     });
 
     test('array field has [N] suffix', () => {
-        const f: StructField[] = [{ name: 'data', type: 'uint8', count: 8, endian: 'inherit' }];
+        const f: StructField[] = [{ name: 'data', type: 'uint8', count: 8 }];
         assert.ok(fieldsToText(f).includes('[8]'));
     });
 
-    test('be endian adds // be comment', () => {
-        const f: StructField[] = [{ name: 'reg', type: 'uint32', count: 1, endian: 'be' }];
-        assert.ok(fieldsToText(f).includes('// be'));
-    });
-
-    test('le endian adds // le comment', () => {
-        const f: StructField[] = [{ name: 'reg', type: 'uint16', count: 1, endian: 'le' }];
-        assert.ok(fieldsToText(f).includes('// le'));
-    });
-
-    test('inherit endian emits no comment', () => {
-        const f: StructField[] = [{ name: 'reg', type: 'uint32', count: 1, endian: 'inherit' }];
-        assert.ok(!fieldsToText(f).includes('/*'));
+    test('emits no field byte-order annotation', () => {
+        const f: StructField[] = [{ name: 'reg', type: 'uint32', count: 1 }];
+        assert.strictEqual(fieldsToText(f), 'uint32_t reg;');
     });
 
     test('float32 maps to float keyword', () => {
-        const f: StructField[] = [{ name: 'temp', type: 'float32', count: 1, endian: 'inherit' }];
+        const f: StructField[] = [{ name: 'temp', type: 'float32', count: 1 }];
         assert.ok(fieldsToText(f).startsWith('float '));
     });
 
     test('float64 maps to double keyword', () => {
-        const f: StructField[] = [{ name: 'val', type: 'float64', count: 1, endian: 'inherit' }];
+        const f: StructField[] = [{ name: 'val', type: 'float64', count: 1 }];
         assert.ok(fieldsToText(f).startsWith('double '));
     });
 
@@ -864,7 +808,6 @@ suite('fieldsToText()', () => {
             name: 'mode',
             type: 'uint16',
             count: 1,
-            endian: 'inherit',
             bitFields: [{ name: 'mode', bitWidth: 3 }],
         }];
         assert.ok(fieldsToText(f).includes('mode:3;'));
@@ -876,17 +819,16 @@ suite('fieldsToText()', () => {
 suite('parseStructText() round-trip', () => {
     test('fields → text → parse produces identical fields', () => {
         const original: StructField[] = [
-            { name: 'sp',   type: 'uint32',  count: 1,  endian: 'inherit' },
+            { name: 'sp',   type: 'uint32',  count: 1 },
             {
                 name: 'mode',
                 type: 'uint16',
                 count: 1,
-                endian: 'inherit',
                 bitFields: [{ name: 'mode', bitWidth: 3 }],
             },
-            { name: 'data', type: 'uint8',   count: 16, endian: 'inherit' },
-            { name: 'temp', type: 'float32', count: 1,  endian: 'be' },
-            { name: 'val',  type: 'int16',   count: 2,  endian: 'le' },
+            { name: 'data', type: 'uint8',   count: 16 },
+            { name: 'temp', type: 'float32', count: 1 },
+            { name: 'val',  type: 'int16',   count: 2 },
         ];
         const text = fieldsToText(original);
         const { fields, errors } = parseStructText(text);
@@ -903,8 +845,8 @@ suite('structToC()', () => {
             id: 'x',
             name: 'S',
             fields: [
-                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },
+                { name: 'a', type: 'uint8', count: 1 },
+                { name: 'b', type: 'uint32', count: 1 },
             ],
         };
         const text = structToC(def, [def]);
@@ -918,8 +860,8 @@ suite('structToC()', () => {
             name: 'S',
             packed: true,
             fields: [
-                { name: 'a', type: 'uint8', count: 1, endian: 'inherit' },
-                { name: 'b', type: 'uint32', count: 1, endian: 'inherit' },
+                { name: 'a', type: 'uint8', count: 1 },
+                { name: 'b', type: 'uint32', count: 1 },
             ],
         };
         const text = structToC(def, [def]);
@@ -933,8 +875,8 @@ suite('structToC()', () => {
             id: 'x',
             name: 'S',
             fields: [
-                { name: 'a', type: 'uint32', count: 1, endian: 'inherit' },
-                { name: 'b', type: 'uint8', count: 1, endian: 'inherit' },
+                { name: 'a', type: 'uint32', count: 1 },
+                { name: 'b', type: 'uint8', count: 1 },
             ],
         };
         const text = structToC(def, [def]);
@@ -951,7 +893,6 @@ suite('structToC()', () => {
                     name: 'flags',
                     type: 'uint16',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'mode', bitWidth: 3 },
                         { name: 'flags', bitWidth: 5 },
@@ -973,7 +914,6 @@ suite('structToC()', () => {
                     name: 'flags',
                     type: 'uint8',
                     count: 1,
-                    endian: 'inherit',
                     bitFields: [
                         { name: 'enabled', bitWidth: 1 },
                         { name: 'error', bitWidth: 1 },

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -739,7 +739,6 @@ suite('Integrity Checks sidebar', () => {
                 schemaVersion: 1,
                 id: 'stm32-profile',
                 name: 'STM32 Layout',
-                byteOrder: 'be',
                 checks: [
                     { algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1001, autoFixStoredValue: false },
                     { algorithm: 'crc16-ccitt-false', startAddress: 0x1002, endAddress: 0x1003, storedAddress: 0x1000, autoFixStoredValue: false },
@@ -836,7 +835,6 @@ suite('Integrity Checks sidebar', () => {
 
             document.getElementById('integrity-profile-update')!.click();
             const updatedProfile = (posted.at(-1) as { type: string; profile: { checks: Array<{ autoFixStoredValue: boolean }> } }).profile;
-            assert.strictEqual('byteOrder' in updatedProfile, false);
             assert.strictEqual(updatedProfile.checks[1].autoFixStoredValue, true);
             dom.window.prompt = () => 'Renamed Layout';
             document.getElementById('integrity-profile-rename')!.click();

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -612,6 +612,45 @@ suite('Integrity Checks sidebar', () => {
             const expectedEdited = await verifyEditedIntegrityResult(view, calculateIntegrity, dom);
             verifyInvalidIntegrityRange(dom);
             await verifyIntegrityCopy(dom, expectedEdited, posted);
+
+            document.getElementById('integrity-add-check')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
+            document.querySelectorAll<HTMLElement>('[data-check-action="up"]')[1].click();
+            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
+            document.querySelectorAll<HTMLElement>('[data-check-action="remove"]')[1].click();
+            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 1);
+
+            view.setIntegrityProfiles([{
+                schemaVersion: 1,
+                id: 'stm32-profile',
+                name: 'STM32 Layout',
+                checks: [
+                    { algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1001, byteOrder: 'be' },
+                    { algorithm: 'crc16-ccitt-false', startAddress: 0x1002, endAddress: 0x1003, storedAddress: 0x1000, byteOrder: 'le' },
+                ],
+            }]);
+            const profileSelect = document.getElementById('integrity-profile-select') as HTMLSelectElement;
+            profileSelect.value = 'stm32-profile';
+            profileSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            document.getElementById('integrity-profile-apply')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
+            assert.strictEqual((document.getElementById('integrity-start') as HTMLInputElement).value, '0x00001000');
+            assert.strictEqual((document.querySelector('[data-control="stored"]') as HTMLInputElement).value, '');
+            assert.strictEqual((document.querySelectorAll('[data-control="stored"]')[1] as HTMLInputElement).value, '0x00001000');
+
+            document.getElementById('integrity-profile-update')!.click();
+            assert.strictEqual((posted.at(-1) as { type: string }).type, 'updateIntegrityProfile');
+            dom.window.prompt = () => 'Renamed Layout';
+            document.getElementById('integrity-profile-rename')!.click();
+            assert.deepStrictEqual(posted.at(-1), {
+                type: 'renameIntegrityProfile', id: 'stm32-profile', name: 'Renamed Layout',
+            });
+            dom.window.confirm = () => true;
+            document.getElementById('integrity-profile-delete')!.click();
+            assert.deepStrictEqual(posted.at(-1), { type: 'deleteIntegrityProfile', id: 'stm32-profile' });
+            dom.window.prompt = () => 'New Layout';
+            document.getElementById('integrity-profile-save')!.click();
+            assert.strictEqual((posted.at(-1) as { type: string }).type, 'createIntegrityProfile');
         } finally {
             api.vscode.postMessage = originalPostMessage;
         }

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -836,16 +836,24 @@ suite('Integrity Checks sidebar', () => {
             document.getElementById('integrity-profile-update')!.click();
             const updatedProfile = (posted.at(-1) as { type: string; profile: { checks: Array<{ autoFixStoredValue: boolean }> } }).profile;
             assert.strictEqual(updatedProfile.checks[1].autoFixStoredValue, true);
-            dom.window.prompt = () => 'Renamed Layout';
             document.getElementById('integrity-profile-rename')!.click();
+            const renameInput = document.getElementById('integrity-profile-name') as HTMLInputElement;
+            assert.strictEqual(renameInput.value, 'STM32 Layout');
+            renameInput.value = 'Renamed Layout';
+            document.getElementById('integrity-profile-name-save')!.click();
             assert.deepStrictEqual(posted.at(-1), {
                 type: 'renameIntegrityProfile', id: 'stm32-profile', name: 'Renamed Layout',
             });
             document.getElementById('integrity-profile-delete')!.click();
             assert.deepStrictEqual(posted.at(-1), { type: 'deleteIntegrityProfile', id: 'stm32-profile' });
-            dom.window.prompt = () => 'New Layout';
             document.getElementById('integrity-profile-save')!.click();
-            assert.strictEqual((posted.at(-1) as { type: string }).type, 'createIntegrityProfile');
+            const saveInput = document.getElementById('integrity-profile-name') as HTMLInputElement;
+            saveInput.value = 'New Layout';
+            saveInput.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            const created = posted.at(-1) as { type: string; profile: { name: string; checks: unknown[] } };
+            assert.strictEqual(created.type, 'createIntegrityProfile');
+            assert.strictEqual(created.profile.name, 'New Layout');
+            assert.strictEqual(created.profile.checks.length, 2);
 
             integrityCard().querySelector<HTMLElement>('.act-btn-del')!.click();
             integrityCard().querySelector<HTMLElement>('.act-btn-del')!.click();

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -620,7 +620,7 @@ suite('Integrity Checks sidebar', () => {
             });
             assert.ok(!integrityCard().querySelector<HTMLElement>('[data-check-body]')!.hidden, 'comparison is always visible');
             assert.strictEqual(integrityCard().querySelector('.si-expand-btn'), null);
-            assert.ok(integrityCard().querySelector<HTMLInputElement>('[data-auto-fix]')!.disabled);
+            assert.strictEqual(integrityCard().querySelector('[data-auto-fix]'), null);
             assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             await waitForIntegrityCalculation();
             assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.textContent, '∑');
@@ -655,6 +655,12 @@ suite('Integrity Checks sidebar', () => {
             const expectedEdited = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
             assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${expectedEdited.value}`);
             assert.strictEqual(integrityCard().querySelector('[data-result-action="copy"]'), null);
+            integrityCard().querySelector<HTMLElement>('[data-copy-calculated]')!.click();
+            assert.deepStrictEqual(posted.at(-1), {
+                type: 'copyText',
+                text: `0x${expectedEdited.value}`,
+                label: 'CRC32/ISO-HDLC calculated value',
+            });
 
             document.getElementById('integrity-add-btn')!.click();
             const addForm = integrityForm('add');
@@ -691,6 +697,7 @@ suite('Integrity Checks sidebar', () => {
             assert.ok(integrityCard(1).querySelector('[data-check-toggle]')!.firstElementChild!.matches('[data-check-status]'));
             assert.match(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent!, /^0x/);
             assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored')!.classList.contains('mismatch'));
+            assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored [data-auto-fix]'));
             assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
 
             const stagedTransactions: Array<Array<[number, number]>> = [];

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -4,6 +4,7 @@ import { JSDOM } from 'jsdom';
 import { esc, fmtB, byteClass } from '../webview/utils';
 import { S, BPR } from '../webview/state';
 import { initFlatBytes, buildMemRows, getByte } from '../webview/data';
+import { integrityHighlightClass } from '../webview/memoryView';
 import { rerender } from '../webview/render';
 import {
     calcRowOffset,
@@ -31,6 +32,7 @@ function resetState(): void {
 
     S.activeStructAddr = null;
     S.structPins       = [];
+    S.integrityHighlight = null;
     S.sidebarTab       = 'inspector';
 }
 
@@ -184,6 +186,19 @@ suite('initFlatBytes() - segment index', () => {
         assert.strictEqual(getByte(0x1002), 0xBE);
         assert.strictEqual(getByte(0x1003), 0xEF);
         assert.strictEqual(getByte(0x1004), undefined);
+    });
+
+    test('getByte returns unsaved edits without changing original data', () => {
+        S.parseResult = {
+            records: [],
+            segments: [{ startAddress: 0x1000, data: [0xDE, 0xAD] }],
+            totalDataBytes: 2, checksumErrors: 0, malformedLines: 0, format: 'ihex',
+        };
+        initFlatBytes();
+        S.edits.set(0x1001, 0x42);
+
+        assert.strictEqual(getByte(0x1001), 0x42);
+        assert.strictEqual(S.parseResult.segments[0].data[1], 0xAD);
     });
 
     test('getByte works with two non-contiguous segments', () => {
@@ -509,73 +524,26 @@ suite('Record View rendering', () => {
     });
 });
 
-type IntegrityViewModule = typeof import('../webview/integrityView.js');
-type IntegrityCalculator = typeof import('../webview/integrity.js').calculateIntegrity;
-
-function integrityInputs(): { start: HTMLInputElement; end: HTMLInputElement } {
-    return {
-        start: document.getElementById('integrity-start') as HTMLInputElement,
-        end: document.getElementById('integrity-end') as HTMLInputElement,
-    };
-}
-
-function setIntegrityInput(input: HTMLInputElement, value: string, dom: JSDOM): void {
-    input.value = value;
-    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-}
-
 async function waitForIntegrityCalculation(): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 300));
 }
 
-async function verifyInitialIntegrityResult(
-    view: IntegrityViewModule,
-    calculateIntegrity: IntegrityCalculator,
-): Promise<void> {
-    view.renderIntegrity();
-    view.activateIntegrity();
-    const { start, end } = integrityInputs();
-    assert.strictEqual(start.value, '0x00001000');
-    assert.strictEqual(end.value, '0x00001002');
-    await waitForIntegrityCalculation();
-    const expected = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([1, 2, 3]));
-    assert.strictEqual(document.getElementById('integrity-value')!.textContent, expected.value);
+function integrityCard(index = 0): HTMLElement {
+    return document.querySelectorAll<HTMLElement>('.integrity-card')[index];
 }
 
-async function verifyEditedIntegrityResult(
-    view: IntegrityViewModule,
-    calculateIntegrity: IntegrityCalculator,
-    dom: JSDOM,
-): Promise<string> {
-    const { start } = integrityInputs();
-    setIntegrityInput(start, '1001', dom);
-    view.activateIntegrity();
-    assert.strictEqual(start.value, '1001', 'later activation must preserve user range');
-    S.edits.set(0x1001, 0xFF);
-    view.notifyIntegrityBytesChanged();
-    await waitForIntegrityCalculation();
-    const expected = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
-    assert.strictEqual(document.getElementById('integrity-value')!.textContent, expected.value);
-    return expected.value;
+function integrityForm(id: string): HTMLElement {
+    return document.querySelector<HTMLElement>(`[data-integrity-form="${id}"]`)!;
 }
 
-function verifyInvalidIntegrityRange(dom: JSDOM): void {
-    const { end } = integrityInputs();
-    setIntegrityInput(end, 'not-hex', dom);
-    assert.strictEqual((document.getElementById('integrity-result') as HTMLElement).hidden, true);
-    assert.match(document.getElementById('integrity-error')!.textContent!, /hexadecimal/);
+function setDraftValue(form: HTMLElement, control: string, value: string): void {
+    (form.querySelector(`[data-draft-control="${control}"]`) as HTMLInputElement).value = value;
 }
 
-async function verifyIntegrityCopy(dom: JSDOM, expected: string, posted: unknown[]): Promise<void> {
-    const { end } = integrityInputs();
-    setIntegrityInput(end, '1002', dom);
-    await waitForIntegrityCalculation();
-    document.getElementById('integrity-copy')!.click();
-    assert.deepStrictEqual(posted.at(-1), {
-        type: 'copyText',
-        text: expected,
-        label: 'CRC32/ISO-HDLC',
-    });
+function assertEmptyIntegrityChecks(): void {
+    assert.strictEqual(document.querySelectorAll('.integrity-card').length, 0);
+    assert.strictEqual(document.querySelector('.integrity-empty')!.textContent, 'No integrity checks configured.');
+    assert.ok((document.getElementById('integrity-profile-save') as HTMLButtonElement).disabled);
 }
 
 suite('Integrity Checks sidebar', () => {
@@ -599,7 +567,7 @@ suite('Integrity Checks sidebar', () => {
 
     teardown(() => cleanupWebviewDom(dom));
 
-    test('prefills once, recalculates visible bytes, clears invalid results, and copies', async () => {
+    test('uses struct-style cards, global endian, edit forms, and profiles', async () => {
         const api = await import('../webview/api.js');
         const originalPostMessage = api.vscode.postMessage;
         const posted: unknown[] = [];
@@ -608,49 +576,193 @@ suite('Integrity Checks sidebar', () => {
         try {
             const view = await import('../webview/integrityView.js');
             const { calculateIntegrity } = await import('../webview/integrity.js');
-            await verifyInitialIntegrityResult(view, calculateIntegrity);
-            const expectedEdited = await verifyEditedIntegrityResult(view, calculateIntegrity, dom);
-            verifyInvalidIntegrityRange(dom);
-            await verifyIntegrityCopy(dom, expectedEdited, posted);
+            S.endian = 'le';
+            view.renderIntegrity();
+            view.activateIntegrity();
+            assertEmptyIntegrityChecks();
+            assert.ok(document.getElementById('integrity-btn-be')!.classList.contains('active'), 'integrity has independent BE default');
 
-            document.getElementById('integrity-add-check')!.click();
-            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
-            document.querySelectorAll<HTMLElement>('[data-check-action="up"]')[1].click();
-            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
-            document.querySelectorAll<HTMLElement>('[data-check-action="remove"]')[1].click();
-            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 1);
+            document.getElementById('integrity-add-btn')!.click();
+            let selectedAddForm = integrityForm('add');
+            assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="algorithm"]') as HTMLSelectElement).value, 'crc32-iso-hdlc');
+            assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="start"]') as HTMLInputElement).value, '00001000');
+            assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
+            S.selStart = 0x1001;
+            S.selEnd = 0x1001;
+            document.getElementById('integrity-btn-le')!.click();
+            selectedAddForm = integrityForm('add');
+            assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="start"]') as HTMLInputElement).value, '00001000');
+            assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
+            document.getElementById('integrity-btn-be')!.click();
+            integrityForm('add').querySelector<HTMLElement>('[data-form-action="cancel"]')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 0);
+
+            S.selStart = null;
+            S.selEnd = null;
+            document.getElementById('integrity-add-btn')!.click();
+            const blankAddForm = integrityForm('add');
+            assert.strictEqual((blankAddForm.querySelector('[data-draft-control="start"]') as HTMLInputElement).value, '');
+            assert.strictEqual((blankAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '');
+            blankAddForm.querySelector<HTMLElement>('[data-form-action="cancel"]')!.click();
+
+            S.selStart = 0x1000;
+            S.selEnd = 0x1002;
+            document.getElementById('integrity-add-btn')!.click();
+            integrityForm('add').querySelector<HTMLElement>('[data-form-action="save"]')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
+            assert.deepStrictEqual(posted.at(-1), {
+                type: 'saveIntegrityChecks',
+                state: {
+                    schemaVersion: 1,
+                    byteOrder: 'be',
+                    checks: [{ algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1002, autoFixStoredValue: false }],
+                },
+            });
+            assert.ok(!integrityCard().querySelector<HTMLElement>('[data-check-body]')!.hidden, 'comparison is always visible');
+            assert.strictEqual(integrityCard().querySelector('.si-expand-btn'), null);
+            assert.ok(integrityCard().querySelector<HTMLInputElement>('[data-auto-fix]')!.disabled);
+            assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+            await waitForIntegrityCalculation();
+            assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.textContent, '∑');
+            assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Calculated');
+
+            integrityCard().querySelector<HTMLElement>('[data-check-toggle]')!.click();
+            assert.deepStrictEqual(S.integrityHighlight, {
+                rangeStart: 0x1000,
+                rangeEnd: 0x1002,
+                status: 'unverified',
+            });
+            assert.strictEqual(integrityHighlightClass(0x1001), ' integrity-range');
+            const expectedInitial = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([1, 2, 3]));
+            assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${expectedInitial.value}`);
+
+            integrityCard().querySelector<HTMLElement>('.act-btn-edit')!.click();
+            const editForm = integrityForm('edit-1');
+            setDraftValue(editForm, 'start', 'ABCD');
+            view.setIntegrityProfiles([]);
+            assert.strictEqual((integrityForm('edit-1').querySelector('[data-draft-control="start"]') as HTMLInputElement).value, 'ABCD');
+            setDraftValue(editForm, 'start', '1001');
+            setDraftValue(editForm, 'end', 'not-hex');
+            editForm.querySelector<HTMLElement>('[data-form-action="save"]')!.click();
+            assert.match(editForm.querySelector('[data-form-error]')!.textContent!, /hexadecimal/);
+            setDraftValue(editForm, 'end', '1002');
+            editForm.querySelector<HTMLElement>('[data-form-action="save"]')!.click();
+            assert.ok(!integrityCard().querySelector<HTMLElement>('[data-check-body]')!.hidden, 'save restores visible comparison');
+
+            S.edits.set(0x1001, 0xFF);
+            view.notifyIntegrityBytesChanged();
+            await waitForIntegrityCalculation();
+            const expectedEdited = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
+            assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${expectedEdited.value}`);
+            assert.strictEqual(integrityCard().querySelector('[data-result-action="copy"]'), null);
+
+            document.getElementById('integrity-add-btn')!.click();
+            const addForm = integrityForm('add');
+            setDraftValue(addForm, 'start', '1000');
+            setDraftValue(addForm, 'end', '1003');
+            addForm.querySelector<HTMLElement>('[data-form-action="save"]')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 2);
+            assert.ok(!integrityCard(1).querySelector<HTMLElement>('[data-check-body]')!.hidden);
+            integrityCard(1).querySelector<HTMLElement>('.act-btn-edit')!.click();
+            integrityForm('edit-2').querySelector<HTMLElement>('[data-form-action="cancel"]')!.click();
+            integrityCard(1).querySelector<HTMLElement>('.act-btn-del')!.click();
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
 
             view.setIntegrityProfiles([{
                 schemaVersion: 1,
                 id: 'stm32-profile',
                 name: 'STM32 Layout',
+                byteOrder: 'le',
                 checks: [
-                    { algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1001, byteOrder: 'be' },
-                    { algorithm: 'crc16-ccitt-false', startAddress: 0x1002, endAddress: 0x1003, storedAddress: 0x1000, byteOrder: 'le' },
+                    { algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1001, autoFixStoredValue: false },
+                    { algorithm: 'crc16-ccitt-false', startAddress: 0x1002, endAddress: 0x1003, storedAddress: 0x1000, autoFixStoredValue: false },
                 ],
             }]);
             const profileSelect = document.getElementById('integrity-profile-select') as HTMLSelectElement;
             profileSelect.value = 'stm32-profile';
             profileSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
             document.getElementById('integrity-profile-apply')!.click();
-            assert.strictEqual(document.querySelectorAll('.integrity-check').length, 2);
-            assert.strictEqual((document.getElementById('integrity-start') as HTMLInputElement).value, '0x00001000');
-            assert.strictEqual((document.querySelector('[data-control="stored"]') as HTMLInputElement).value, '');
-            assert.strictEqual((document.querySelectorAll('[data-control="stored"]')[1] as HTMLInputElement).value, '0x00001000');
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 2);
+            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'));
+            assert.strictEqual(S.endian, 'le', 'integrity endian does not change Struct Overlay endian');
+            await waitForIntegrityCalculation();
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✕');
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Mismatch');
+            assert.ok(integrityCard(1).querySelector('[data-check-toggle]')!.firstElementChild!.matches('[data-check-status]'));
+            assert.match(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent!, /^0x/);
+            assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored')!.classList.contains('mismatch'));
+            assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+
+            const stagedTransactions: Array<Array<[number, number]>> = [];
+            view.setIntegrityEditHandler(edits => {
+                stagedTransactions.push(edits);
+                edits.forEach(([address, value]) => S.edits.set(address, value));
+                view.notifyIntegrityBytesChanged();
+            });
+            integrityCard(1).querySelector<HTMLElement>('[data-check-toggle]')!.click();
+            assert.strictEqual(S.integrityHighlight?.status, 'mismatch');
+            assert.strictEqual(integrityHighlightClass(0x1000), ' integrity-stored-mismatch');
+            assert.strictEqual(integrityHighlightClass(0x1002), ' integrity-range');
+            integrityCard(1).querySelector<HTMLElement>('[data-check-toggle]')!.click();
+            assert.strictEqual(S.integrityHighlight, null);
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-fix]'), null);
+            const autoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
+            autoFix.checked = true;
+            autoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✓');
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Match');
+            assert.strictEqual(stagedTransactions.length, 1);
+            assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+            assert.ok((posted.at(-1) as { state: { checks: Array<{ autoFixStoredValue: boolean }> } }).state.checks[1].autoFixStoredValue);
+
+            const disableAutoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
+            disableAutoFix.checked = false;
+            disableAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            S.edits.clear();
+            view.notifyIntegrityBytesChanged();
+            await waitForIntegrityCalculation();
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✕');
+            assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+            document.getElementById('integrity-fix-all')!.click();
+            assert.strictEqual(stagedTransactions.length, 2);
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✓');
+            assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+            const persistedAutoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
+            persistedAutoFix.checked = true;
+            persistedAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+            document.getElementById('integrity-btn-be')!.click();
+            assert.ok(document.getElementById('integrity-btn-be')!.classList.contains('active'));
+            assert.strictEqual(S.endian, 'le', 'integrity toggle remains independent');
 
             document.getElementById('integrity-profile-update')!.click();
-            assert.strictEqual((posted.at(-1) as { type: string }).type, 'updateIntegrityProfile');
+            const updatedProfile = (posted.at(-1) as { type: string; profile: { byteOrder: string; checks: Array<{ autoFixStoredValue: boolean }> } }).profile;
+            assert.strictEqual(updatedProfile.byteOrder, 'be');
+            assert.strictEqual(updatedProfile.checks[1].autoFixStoredValue, true);
             dom.window.prompt = () => 'Renamed Layout';
             document.getElementById('integrity-profile-rename')!.click();
             assert.deepStrictEqual(posted.at(-1), {
                 type: 'renameIntegrityProfile', id: 'stm32-profile', name: 'Renamed Layout',
             });
-            dom.window.confirm = () => true;
             document.getElementById('integrity-profile-delete')!.click();
             assert.deepStrictEqual(posted.at(-1), { type: 'deleteIntegrityProfile', id: 'stm32-profile' });
             dom.window.prompt = () => 'New Layout';
             document.getElementById('integrity-profile-save')!.click();
             assert.strictEqual((posted.at(-1) as { type: string }).type, 'createIntegrityProfile');
+
+            integrityCard().querySelector<HTMLElement>('.act-btn-del')!.click();
+            integrityCard().querySelector<HTMLElement>('.act-btn-del')!.click();
+            assertEmptyIntegrityChecks();
+            assert.ok((document.getElementById('integrity-profile-update') as HTMLButtonElement).disabled);
+
+            view.setIntegrityChecks({
+                schemaVersion: 1,
+                byteOrder: 'le',
+                checks: [{ algorithm: 'crc16-ccitt-false', startAddress: 0x1000, endAddress: 0x1002, autoFixStoredValue: false }],
+            });
+            view.renderIntegrity();
+            assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
+            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'));
         } finally {
             api.vscode.postMessage = originalPostMessage;
         }

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -37,16 +37,18 @@ function resetState(): void {
 }
 
 function installWebviewDom(markup: string): JSDOM {
-    const dom = new JSDOM(markup);
+    const dom = new JSDOM(markup, { url: 'https://hexscope.test/' });
     const globals = globalThis as unknown as {
         window: Window;
         document: Document;
         getComputedStyle: typeof getComputedStyle;
+        localStorage: Storage;
         acquireVsCodeApi: () => unknown;
     };
     globals.window = dom.window as unknown as Window;
     globals.document = dom.window.document as unknown as Document;
     globals.getComputedStyle = dom.window.getComputedStyle.bind(dom.window) as typeof getComputedStyle;
+    globals.localStorage = dom.window.localStorage;
     globals.acquireVsCodeApi = () => ({
         postMessage: (_msg: unknown) => {},
         getState: () => ({}),
@@ -61,10 +63,15 @@ function installWebviewDom(markup: string): JSDOM {
 
 function cleanupWebviewDom(dom: JSDOM): void {
     resetState();
+    rerender.memory = () => {};
+    rerender.labels = () => {};
+    rerender.toMemory = () => {};
+    rerender.jumpTo = () => {};
     dom.window.close();
     delete (globalThis as unknown as { window?: Window }).window;
     delete (globalThis as unknown as { document?: Document }).document;
     delete (globalThis as unknown as { getComputedStyle?: typeof getComputedStyle }).getComputedStyle;
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
     delete (globalThis as unknown as { acquireVsCodeApi?: () => unknown }).acquireVsCodeApi;
 }
 
@@ -521,6 +528,29 @@ suite('Record View rendering', () => {
         assert.strictEqual(rows.length, 1, 'record view should render a real table row');
         assert.strictEqual(document.querySelector('#record-view .raddr')?.textContent, '08000000');
         assert.ok(!(document.getElementById('record-view')?.textContent ?? '').includes('<tr'), 'record markup should not be escaped as text');
+
+        const api = await import('../webview/api.js');
+        const originalPostMessage = api.vscode.postMessage;
+        const posted: unknown[] = [];
+        api.vscode.postMessage = msg => { posted.push(msg); };
+        try {
+            document.body.innerHTML = '<div id="app"></div>';
+            window.dispatchEvent(new dom.window.MessageEvent('message', { data: {
+                type: 'init', parseResult: S.parseResult, labels: [], structs: [], structPins: [], endian: 'le',
+                integrityProfiles: { profiles: [], activeChecks: { schemaVersion: 1, checks: [] } },
+            } }));
+            assert.strictEqual(document.querySelectorAll('#sidebar-common-settings').length, 1);
+            assert.ok(document.getElementById('sidebar-btn-le')!.classList.contains('active'));
+            assert.strictEqual(document.getElementById('btn-le'), null);
+            assert.strictEqual(document.getElementById('sa-btn-le'), null);
+            assert.strictEqual(document.getElementById('integrity-btn-le'), null);
+            assert.ok(document.getElementById('search-btn-auto'), 'Value Search keeps its own endian control');
+            document.getElementById('sidebar-btn-be')!.click();
+            assert.strictEqual(S.endian, 'be');
+            assert.deepStrictEqual(posted.at(-1), { type: 'saveEndian', endian: 'be' });
+        } finally {
+            api.vscode.postMessage = originalPostMessage;
+        }
     });
 });
 
@@ -583,11 +613,13 @@ suite('Integrity Checks sidebar', () => {
         try {
             const view = await import('../webview/integrityView.js');
             const { calculateIntegrity } = await import('../webview/integrity.js');
-            S.endian = 'be';
+            S.edits.clear();
+            S.endian = 'le';
             view.renderIntegrity();
             view.activateIntegrity();
             assertEmptyIntegrityChecks();
-            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'), 'integrity has independent LE default');
+            assert.strictEqual(document.getElementById('integrity-btn-le'), null);
+            assert.strictEqual(document.getElementById('integrity-btn-be'), null);
 
             document.getElementById('integrity-add-btn')!.click();
             let selectedAddForm = integrityForm('add');
@@ -596,11 +628,11 @@ suite('Integrity Checks sidebar', () => {
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
             S.selStart = 0x1001;
             S.selEnd = 0x1001;
-            document.getElementById('integrity-btn-be')!.click();
+            S.endian = 'be';
+            view.notifyIntegrityEndianChanged();
             selectedAddForm = integrityForm('add');
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="start"]') as HTMLInputElement).value, '00001000');
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
-            document.getElementById('integrity-btn-be')!.click();
             integrityForm('add').querySelector<HTMLElement>('[data-form-action="cancel"]')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 0);
 
@@ -623,7 +655,6 @@ suite('Integrity Checks sidebar', () => {
                 type: 'saveIntegrityChecks',
                 state: {
                     schemaVersion: 1,
-                    byteOrder: 'be',
                     checks: [{ algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1002, autoFixStoredValue: false }],
                 },
             });
@@ -632,7 +663,11 @@ suite('Integrity Checks sidebar', () => {
             assert.strictEqual(integrityCard().querySelector('[data-auto-fix]'), null);
             assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             await waitForIntegrityCalculation();
-            assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.textContent, '∑');
+            assert.strictEqual(
+                integrityCard().querySelector('[data-check-status]')!.textContent,
+                '∑',
+                integrityCard().textContent ?? '',
+            );
             assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Calculated');
 
             integrityCard().querySelector<HTMLElement>('[data-check-toggle]')!.click();
@@ -697,11 +732,14 @@ suite('Integrity Checks sidebar', () => {
             integrityCard(1).querySelector<HTMLElement>('.act-btn-del')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
 
+            S.edits.clear();
+            S.endian = 'le';
+            view.notifyIntegrityEndianChanged();
             view.setIntegrityProfiles([{
                 schemaVersion: 1,
                 id: 'stm32-profile',
                 name: 'STM32 Layout',
-                byteOrder: 'le',
+                byteOrder: 'be',
                 checks: [
                     { algorithm: 'crc32-iso-hdlc', startAddress: 0x1000, endAddress: 0x1001, autoFixStoredValue: false },
                     { algorithm: 'crc16-ccitt-false', startAddress: 0x1002, endAddress: 0x1003, storedAddress: 0x1000, autoFixStoredValue: false },
@@ -712,8 +750,7 @@ suite('Integrity Checks sidebar', () => {
             profileSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
             document.getElementById('integrity-profile-apply')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 2);
-            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'));
-            assert.strictEqual(S.endian, 'be', 'integrity endian does not change Struct Overlay endian');
+            assert.strictEqual(S.endian, 'le', 'applying a profile does not change shared endian');
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '…');
             assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent, '0x—');
             assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent, '0x—');
@@ -726,12 +763,13 @@ suite('Integrity Checks sidebar', () => {
             assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored [data-auto-fix]'));
             assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             const canonicalStoredChecksum = await calculateIntegrity('crc16-ccitt-false', new Uint8Array([3, 4]));
-            const littleEndianChecksum = canonicalStoredChecksum.value.match(/../g)!.reverse().join('');
-            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${littleEndianChecksum}`);
-            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.getAttribute('title'), `Canonical checksum: 0x${canonicalStoredChecksum.value}`);
-            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated (LE)');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${canonicalStoredChecksum.value}`);
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent, '0x0201');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.getAttribute('title'), 'Raw bytes: 0x0102');
+            assert.strictEqual(integrityCard(1).querySelectorAll('.integrity-value-hdr span')[1].textContent, 'Stored (LE)');
             integrityCard(1).querySelector<HTMLElement>('[data-copy-calculated]')!.click();
-            assert.strictEqual((posted.at(-1) as { text: string }).text, `0x${littleEndianChecksum}`);
+            assert.strictEqual((posted.at(-1) as { text: string }).text, `0x${canonicalStoredChecksum.value}`);
 
             const stagedTransactions: Array<Array<[number, number]>> = [];
             view.setIntegrityEditHandler(edits => {
@@ -751,6 +789,10 @@ suite('Integrity Checks sidebar', () => {
             autoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
             await assertIntegrityRecalculationCompletes(1);
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Match');
+            assert.strictEqual(
+                integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent,
+                integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent,
+            );
             assert.strictEqual(stagedTransactions.length, 1);
             assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             assert.ok((posted.at(-1) as { state: { checks: Array<{ autoFixStoredValue: boolean }> } }).state.checks[1].autoFixStoredValue);
@@ -782,19 +824,19 @@ suite('Integrity Checks sidebar', () => {
             assert.strictEqual(stagedTransactions.length, 3, 'toggle off/on overrides suppression');
             await assertIntegrityRecalculationCompletes(1);
 
-            document.getElementById('integrity-btn-be')!.click();
-            assert.ok(document.getElementById('integrity-btn-be')!.classList.contains('active'));
-            assert.strictEqual(S.endian, 'be', 'integrity toggle remains independent');
+            S.endian = 'be';
+            view.notifyIntegrityEndianChanged();
             await waitForIntegrityCalculation();
             await waitForIntegrityCalculation();
             assert.strictEqual(stagedTransactions.length, 4, 'endian change re-arms Auto fix');
             const beCalculated = integrityCard(1).querySelector('.integrity-value-pane.calculated code')!;
             assert.strictEqual(beCalculated.textContent, integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent);
-            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated (BE)');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated');
+            assert.strictEqual(integrityCard(1).querySelectorAll('.integrity-value-hdr span')[1].textContent, 'Stored (BE)');
 
             document.getElementById('integrity-profile-update')!.click();
-            const updatedProfile = (posted.at(-1) as { type: string; profile: { byteOrder: string; checks: Array<{ autoFixStoredValue: boolean }> } }).profile;
-            assert.strictEqual(updatedProfile.byteOrder, 'be');
+            const updatedProfile = (posted.at(-1) as { type: string; profile: { checks: Array<{ autoFixStoredValue: boolean }> } }).profile;
+            assert.strictEqual('byteOrder' in updatedProfile, false);
             assert.strictEqual(updatedProfile.checks[1].autoFixStoredValue, true);
             dom.window.prompt = () => 'Renamed Layout';
             document.getElementById('integrity-profile-rename')!.click();
@@ -814,12 +856,11 @@ suite('Integrity Checks sidebar', () => {
 
             view.setIntegrityChecks({
                 schemaVersion: 1,
-                byteOrder: 'le',
                 checks: [{ algorithm: 'crc16-ccitt-false', startAddress: 0x1000, endAddress: 0x1002, autoFixStoredValue: false }],
             });
             view.renderIntegrity();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
-            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'));
+            assert.strictEqual(document.getElementById('integrity-btn-le'), null);
         } finally {
             api.vscode.postMessage = originalPostMessage;
         }

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -603,7 +603,7 @@ suite('Integrity Checks sidebar', () => {
 
     teardown(() => cleanupWebviewDom(dom));
 
-    test('uses struct-style cards, global endian, edit forms, and profiles', async function () {
+    test('uses struct-style cards, shared byte order, edit forms, and profiles', async function () {
         this.timeout(5_000);
         const api = await import('../webview/api.js');
         const originalPostMessage = api.vscode.postMessage;

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -528,6 +528,12 @@ async function waitForIntegrityCalculation(): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 300));
 }
 
+async function assertIntegrityRecalculationCompletes(index: number): Promise<void> {
+    assert.strictEqual(integrityCard(index).querySelector('[data-check-status]')!.textContent, '…');
+    await waitForIntegrityCalculation();
+    assert.strictEqual(integrityCard(index).querySelector('[data-check-status]')!.textContent, '✓');
+}
+
 function integrityCard(index = 0): HTMLElement {
     return document.querySelectorAll<HTMLElement>('.integrity-card')[index];
 }
@@ -567,7 +573,8 @@ suite('Integrity Checks sidebar', () => {
 
     teardown(() => cleanupWebviewDom(dom));
 
-    test('uses struct-style cards, global endian, edit forms, and profiles', async () => {
+    test('uses struct-style cards, global endian, edit forms, and profiles', async function () {
+        this.timeout(5_000);
         const api = await import('../webview/api.js');
         const originalPostMessage = api.vscode.postMessage;
         const posted: unknown[] = [];
@@ -576,11 +583,11 @@ suite('Integrity Checks sidebar', () => {
         try {
             const view = await import('../webview/integrityView.js');
             const { calculateIntegrity } = await import('../webview/integrity.js');
-            S.endian = 'le';
+            S.endian = 'be';
             view.renderIntegrity();
             view.activateIntegrity();
             assertEmptyIntegrityChecks();
-            assert.ok(document.getElementById('integrity-btn-be')!.classList.contains('active'), 'integrity has independent BE default');
+            assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'), 'integrity has independent LE default');
 
             document.getElementById('integrity-add-btn')!.click();
             let selectedAddForm = integrityForm('add');
@@ -589,7 +596,7 @@ suite('Integrity Checks sidebar', () => {
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
             S.selStart = 0x1001;
             S.selEnd = 0x1001;
-            document.getElementById('integrity-btn-le')!.click();
+            document.getElementById('integrity-btn-be')!.click();
             selectedAddForm = integrityForm('add');
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="start"]') as HTMLInputElement).value, '00001000');
             assert.strictEqual((selectedAddForm.querySelector('[data-draft-control="end"]') as HTMLInputElement).value, '00001002');
@@ -610,6 +617,8 @@ suite('Integrity Checks sidebar', () => {
             document.getElementById('integrity-add-btn')!.click();
             integrityForm('add').querySelector<HTMLElement>('[data-form-action="save"]')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 1);
+            assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.textContent, '…');
+            assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, '0x—');
             assert.deepStrictEqual(posted.at(-1), {
                 type: 'saveIntegrityChecks',
                 state: {
@@ -648,9 +657,13 @@ suite('Integrity Checks sidebar', () => {
             setDraftValue(editForm, 'end', '1002');
             editForm.querySelector<HTMLElement>('[data-form-action="save"]')!.click();
             assert.ok(!integrityCard().querySelector<HTMLElement>('[data-check-body]')!.hidden, 'save restores visible comparison');
+            await waitForIntegrityCalculation();
+            const expectedBeforeEdit = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([2, 3]));
 
             S.edits.set(0x1001, 0xFF);
             view.notifyIntegrityBytesChanged();
+            assert.strictEqual(integrityCard().querySelector('[data-check-status]')!.textContent, '…');
+            assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${expectedBeforeEdit.value}`);
             await waitForIntegrityCalculation();
             const expectedEdited = await calculateIntegrity('crc32-iso-hdlc', new Uint8Array([0xFF, 3]));
             assert.strictEqual(integrityCard().querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${expectedEdited.value}`);
@@ -666,9 +679,19 @@ suite('Integrity Checks sidebar', () => {
             const addForm = integrityForm('add');
             setDraftValue(addForm, 'start', '1000');
             setDraftValue(addForm, 'end', '1003');
+            setDraftValue(addForm, 'stored', '1000');
+            const hashAlgorithm = addForm.querySelector<HTMLSelectElement>('[data-draft-control="algorithm"]')!;
+            hashAlgorithm.value = 'sha-256';
+            hashAlgorithm.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            assert.ok(addForm.querySelector<HTMLElement>('[data-stored-field]')!.hidden);
             addForm.querySelector<HTMLElement>('[data-form-action="save"]')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 2);
             assert.ok(!integrityCard(1).querySelector<HTMLElement>('[data-check-body]')!.hidden);
+            assert.strictEqual(integrityCard(1).querySelector('[data-auto-fix]'), null);
+            const hashConfig = (posted.at(-1) as { state: { checks: Array<{ storedAddress?: number; autoFixStoredValue: boolean }> } }).state.checks[1];
+            assert.deepStrictEqual(hashConfig, {
+                algorithm: 'sha-256', startAddress: 0x1000, endAddress: 0x1003, autoFixStoredValue: false,
+            });
             integrityCard(1).querySelector<HTMLElement>('.act-btn-edit')!.click();
             integrityForm('edit-2').querySelector<HTMLElement>('[data-form-action="cancel"]')!.click();
             integrityCard(1).querySelector<HTMLElement>('.act-btn-del')!.click();
@@ -690,7 +713,10 @@ suite('Integrity Checks sidebar', () => {
             document.getElementById('integrity-profile-apply')!.click();
             assert.strictEqual(document.querySelectorAll('.integrity-card').length, 2);
             assert.ok(document.getElementById('integrity-btn-le')!.classList.contains('active'));
-            assert.strictEqual(S.endian, 'le', 'integrity endian does not change Struct Overlay endian');
+            assert.strictEqual(S.endian, 'be', 'integrity endian does not change Struct Overlay endian');
+            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '…');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent, '0x—');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent, '0x—');
             await waitForIntegrityCalculation();
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✕');
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Mismatch');
@@ -699,6 +725,13 @@ suite('Integrity Checks sidebar', () => {
             assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored')!.classList.contains('mismatch'));
             assert.ok(integrityCard(1).querySelector('.integrity-value-pane.stored [data-auto-fix]'));
             assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
+            const canonicalStoredChecksum = await calculateIntegrity('crc16-ccitt-false', new Uint8Array([3, 4]));
+            const littleEndianChecksum = canonicalStoredChecksum.value.match(/../g)!.reverse().join('');
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.textContent, `0x${littleEndianChecksum}`);
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-pane.calculated code')!.getAttribute('title'), `Canonical checksum: 0x${canonicalStoredChecksum.value}`);
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated (LE)');
+            integrityCard(1).querySelector<HTMLElement>('[data-copy-calculated]')!.click();
+            assert.strictEqual((posted.at(-1) as { text: string }).text, `0x${littleEndianChecksum}`);
 
             const stagedTransactions: Array<Array<[number, number]>> = [];
             view.setIntegrityEditHandler(edits => {
@@ -716,31 +749,48 @@ suite('Integrity Checks sidebar', () => {
             const autoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
             autoFix.checked = true;
             autoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
-            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✓');
+            await assertIntegrityRecalculationCompletes(1);
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.getAttribute('aria-label'), 'Match');
             assert.strictEqual(stagedTransactions.length, 1);
             assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             assert.ok((posted.at(-1) as { state: { checks: Array<{ autoFixStoredValue: boolean }> } }).state.checks[1].autoFixStoredValue);
 
-            const disableAutoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
-            disableAutoFix.checked = false;
-            disableAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
             S.edits.clear();
-            view.notifyIntegrityBytesChanged();
+            view.notifyIntegrityEditsDiscarded();
             await waitForIntegrityCalculation();
             assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✕');
+            assert.strictEqual(stagedTransactions.length, 1, 'Discard must not immediately re-stage Auto fix');
+            assert.ok(integrityCard(1).querySelector('.integrity-auto-fix')!.classList.contains('paused'));
+            assert.ok(integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!.checked);
+            view.notifyIntegrityBytesChanged();
+            await waitForIntegrityCalculation();
+            assert.strictEqual(stagedTransactions.length, 1, 'identical mismatch remains suppressed');
             assert.ok(!(document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
             document.getElementById('integrity-fix-all')!.click();
             assert.strictEqual(stagedTransactions.length, 2);
-            assert.strictEqual(integrityCard(1).querySelector('[data-check-status]')!.textContent, '✓');
+            await assertIntegrityRecalculationCompletes(1);
             assert.ok((document.getElementById('integrity-fix-all') as HTMLButtonElement).disabled);
-            const persistedAutoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
-            persistedAutoFix.checked = true;
-            persistedAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+            S.edits.clear();
+            view.notifyIntegrityEditsDiscarded();
+            await waitForIntegrityCalculation();
+            const rearmAutoFix = integrityCard(1).querySelector<HTMLInputElement>('[data-auto-fix]')!;
+            rearmAutoFix.checked = false;
+            rearmAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            rearmAutoFix.checked = true;
+            rearmAutoFix.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+            assert.strictEqual(stagedTransactions.length, 3, 'toggle off/on overrides suppression');
+            await assertIntegrityRecalculationCompletes(1);
 
             document.getElementById('integrity-btn-be')!.click();
             assert.ok(document.getElementById('integrity-btn-be')!.classList.contains('active'));
-            assert.strictEqual(S.endian, 'le', 'integrity toggle remains independent');
+            assert.strictEqual(S.endian, 'be', 'integrity toggle remains independent');
+            await waitForIntegrityCalculation();
+            await waitForIntegrityCalculation();
+            assert.strictEqual(stagedTransactions.length, 4, 'endian change re-arms Auto fix');
+            const beCalculated = integrityCard(1).querySelector('.integrity-value-pane.calculated code')!;
+            assert.strictEqual(beCalculated.textContent, integrityCard(1).querySelector('.integrity-value-pane.stored code')!.textContent);
+            assert.strictEqual(integrityCard(1).querySelector('.integrity-value-hdr span')!.textContent, 'Calculated (BE)');
 
             document.getElementById('integrity-profile-update')!.click();
             const updatedProfile = (posted.at(-1) as { type: string; profile: { byteOrder: string; checks: Array<{ autoFixStoredValue: boolean }> } }).profile;

--- a/src/webview/data.ts
+++ b/src/webview/data.ts
@@ -25,7 +25,7 @@ function initSegmentIndex(): void {
 }
 
 /**
- * Get byte at address by binary-searching segment index and indexing into segment data.
+ * Get effective byte at address, including any unsaved edit staged over segment data.
  * Returns undefined if address is not in any segment.
  */
 export function getByte(addr: number): number | undefined {
@@ -37,7 +37,7 @@ export function getByte(addr: number): number | undefined {
         const seg = S.segmentIndex[mid];
         if (addr >= seg.startAddr && addr <= seg.endAddr) {
             const offset = addr - seg.startAddr;
-            return S.parseResult.segments[seg.offset].data[offset];
+            return S.edits.get(addr) ?? S.parseResult.segments[seg.offset].data[offset];
         } else if (addr < seg.startAddr) {
             hi = mid - 1;
         } else {

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -16,6 +16,7 @@ import {
     activateIntegrity,
     notifyIntegrityBytesChanged,
     notifyIntegrityEditsDiscarded,
+    notifyIntegrityEndianChanged,
     renderIntegrity,
     setIntegrityEditHandler,
     setIntegrityProfiles,
@@ -63,6 +64,7 @@ function handleInitMessage(msg: WebviewMessage): void {
     S.labels      = (msg.labels as typeof S.labels) ?? [];
     S.structs     = (msg.structs as typeof S.structs) ?? [];
     S.structPins  = (msg.structPins as typeof S.structPins) ?? [];
+    S.endian      = msg.endian === 'be' ? 'be' : 'le';
     setIntegrityProfiles(msg.integrityProfiles);
     initFlatBytes();
     buildMemRows();
@@ -283,6 +285,13 @@ function render(): void {
             </div>
             <div id="sidebar-resizer" aria-label="Resize sidebar" title="Drag to resize sidebar"></div>
             <div id="sidebar">
+                <div id="sidebar-common-settings">
+                    <span>Byte order</span>
+                    <div class="endian-tabs sidebar-endian-tabs">
+                        <button id="sidebar-btn-le" class="${activeClass(S.endian === 'le')}" type="button">LE</button>
+                        <button id="sidebar-btn-be" class="${activeClass(S.endian === 'be')}" type="button">BE</button>
+                    </div>
+                </div>
                 <div class="${tabPanelClass('inspector')}" id="sbp-insp">
                     <div class="sb-section" id="s-insp"></div>
                     <div class="sb-section" id="s-bits"></div>
@@ -311,6 +320,7 @@ function setupRenderedUi(): void {
     setupToolbarButtons();
     setupLockInterception();
     setupSidebarResize();
+    setupEndianControl();
     setupEditButtons();
     setupSearchControls();
     setupRerenderCallbacks();
@@ -319,6 +329,22 @@ function setupRenderedUi(): void {
     setupMemoryDragSelection();
     setupSideTabs();
     renderInitialViews();
+}
+
+function setupEndianControl(): void {
+    document.getElementById('sidebar-btn-le')?.addEventListener('click', () => setFileEndian('le'));
+    document.getElementById('sidebar-btn-be')?.addEventListener('click', () => setFileEndian('be'));
+}
+
+function setFileEndian(endian: 'le' | 'be'): void {
+    if (S.endian === endian) { return; }
+    S.endian = endian;
+    document.getElementById('sidebar-btn-le')?.classList.toggle('active', endian === 'le');
+    document.getElementById('sidebar-btn-be')?.classList.toggle('active', endian === 'be');
+    vscode.postMessage({ type: 'saveEndian', endian });
+    renderInspector();
+    renderStructPins();
+    notifyIntegrityEndianChanged();
 }
 
 function setupToolbarButtons(): void {

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -12,7 +12,13 @@ import { initSearch, runSearch, clearSearch, nextMatch, prevMatch } from './sear
 import { initFlatBytes, buildMemRows, getByte }      from './data';
 import type { SerializedRecord, SidebarTab } from './types';
 import { MAX_VIRTUAL_SCROLL_HEIGHT }                 from './virtualScroll';
-import { activateIntegrity, notifyIntegrityBytesChanged, renderIntegrity } from './integrityView';
+import {
+    activateIntegrity,
+    notifyIntegrityBytesChanged,
+    renderIntegrity,
+    setIntegrityEditHandler,
+    setIntegrityProfiles,
+} from './integrityView';
 
 vscode.postMessage({ type: 'ready' });
 
@@ -42,6 +48,7 @@ const MESSAGE_HANDLERS: ReadonlyArray<readonly [string, WebviewMessageHandler]> 
     ['externalChange', handleExternalChangeMessage],
     ['externalChangeError', handleExternalChangeErrorMessage],
     ['repairComplete', handleRepairCompleteMessage],
+    ['integrityProfiles', handleIntegrityProfilesMessage],
 ];
 
 window.addEventListener('message', (e: MessageEvent) => {
@@ -55,11 +62,16 @@ function handleInitMessage(msg: WebviewMessage): void {
     S.labels      = (msg.labels as typeof S.labels) ?? [];
     S.structs     = (msg.structs as typeof S.structs) ?? [];
     S.structPins  = (msg.structPins as typeof S.structPins) ?? [];
+    setIntegrityProfiles(msg.integrityProfiles);
     initFlatBytes();
     buildMemRows();
 
     S.currentView = 'memory';
     render();
+}
+
+function handleIntegrityProfilesMessage(msg: WebviewMessage): void {
+    setIntegrityProfiles(msg.profiles, typeof msg.error === 'string' ? msg.error : '');
 }
 
 function handleLoadErrorMessage(msg: WebviewMessage): void {
@@ -300,6 +312,7 @@ function setupRenderedUi(): void {
     setupEditButtons();
     setupSearchControls();
     setupRerenderCallbacks();
+    setIntegrityEditHandler(stageIntegrityEdits);
     initSearch(() => switchView('memory'));
     setupMemoryDragSelection();
     setupSideTabs();
@@ -1169,6 +1182,40 @@ function getOriginalByte(addr: number): number | undefined {
         if (off >= 0 && off < seg.data.length) { return seg.data[off]; }
     }
     return undefined;
+}
+
+function stageIntegrityEdits(edits: Array<[number, number]>): void {
+    const previous: Array<[number, number]> = [];
+    for (const [address, value] of edits) {
+        const prior = stageIntegrityEdit(address, value);
+        if (prior) { previous.push(prior); }
+    }
+    if (previous.length === 0) { return; }
+    S.undoStack.push(previous);
+    S.editMode = true;
+    refreshAfterIntegrityEdits();
+}
+
+function refreshAfterIntegrityEdits(): void {
+    updateEditControls();
+    updateDirtyBar();
+    if (S.currentView === 'memory') { memRerender(); }
+    updateInspector();
+    notifyIntegrityBytesChanged();
+}
+
+function stageIntegrityEdit(address: number, value: number): [number, number] | null {
+    const original = getOriginalByte(address);
+    if (original === undefined) { return null; }
+    const current = currentIntegrityByte(address, original);
+    if (current === value) { return null; }
+    if (value === original) { S.edits.delete(address); }
+    else { S.edits.set(address, value); }
+    return [address, current];
+}
+
+function currentIntegrityByte(address: number, original: number): number {
+    return S.edits.has(address) ? S.edits.get(address)! : original;
 }
 
 // ── Edit helpers ──────────────────────────────────────────────────

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -15,6 +15,7 @@ import { MAX_VIRTUAL_SCROLL_HEIGHT }                 from './virtualScroll';
 import {
     activateIntegrity,
     notifyIntegrityBytesChanged,
+    notifyIntegrityEditsDiscarded,
     renderIntegrity,
     setIntegrityEditHandler,
     setIntegrityProfiles,
@@ -161,11 +162,12 @@ function rebuildLabelsAndMemory(): void {
     if (S.currentView === 'memory') { rerender.memory(); }
 }
 
-function clearEditState(): void {
+function clearEditState(reason: 'refresh' | 'discard' = 'refresh'): void {
     S.edits.clear();
     S.undoStack.length = 0;
     S.editMode = false;
-    notifyIntegrityBytesChanged();
+    if (reason === 'discard') { notifyIntegrityEditsDiscarded(); }
+    else { notifyIntegrityBytesChanged(); }
 }
 
 function renderCurrentDataView(): void {
@@ -380,7 +382,7 @@ function setupEditButtons(): void {
         if (S.currentView === 'memory') { memRerender(); }
     });
     document.getElementById('btn-cancel')!.addEventListener('click', () => {
-        clearEditState();
+        clearEditState('discard');
         updateEditControls();
         updateDirtyBar();
         if (S.currentView === 'memory') { memRerender(); }

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -262,7 +262,7 @@ function render(): void {
                 <button id="btn-cancel" class="tb-cancel-btn" title="Discard all edits">&#10005; Cancel</button>
             </div>
             <div id="search-box">
-                <div id="search-endian-toggle" class="endian-tabs search-endian-toggle" style="display:none">
+                <div id="search-endian-toggle" class="compact-tabs search-endian-toggle" style="display:none">
                     <button id="search-btn-auto" class="${activeClass(S.searchEndianness === 'auto')}" type="button">Auto</button>
                     <button id="search-btn-le" class="${activeClass(S.searchEndianness === 'le')}" type="button">LE</button>
                     <button id="search-btn-be" class="${activeClass(S.searchEndianness === 'be')}" type="button">BE</button>
@@ -295,7 +295,7 @@ function render(): void {
             <div id="sidebar">
                 <div id="sidebar-common-settings">
                     <span>Byte order</span>
-                    <div class="endian-tabs sidebar-endian-tabs">
+                    <div class="compact-tabs sidebar-endian-tabs">
                         <button id="sidebar-btn-le" class="${activeClass(S.endian === 'le')}" type="button">LE</button>
                         <button id="sidebar-btn-be" class="${activeClass(S.endian === 'be')}" type="button">BE</button>
                     </div>

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -61,16 +61,24 @@ window.addEventListener('message', (e: MessageEvent) => {
 
 function handleInitMessage(msg: WebviewMessage): void {
     S.parseResult = msg.parseResult as typeof S.parseResult;
-    S.labels      = (msg.labels as typeof S.labels) ?? [];
-    S.structs     = (msg.structs as typeof S.structs) ?? [];
-    S.structPins  = (msg.structPins as typeof S.structPins) ?? [];
-    S.endian      = msg.endian === 'be' ? 'be' : 'le';
+    S.labels      = messageArray<typeof S.labels[number]>(msg.labels);
+    S.structs     = messageArray<typeof S.structs[number]>(msg.structs);
+    S.structPins  = messageArray<typeof S.structPins[number]>(msg.structPins);
+    S.endian      = messageEndian(msg.endian);
     setIntegrityProfiles(msg.integrityProfiles);
     initFlatBytes();
     buildMemRows();
 
     S.currentView = 'memory';
     render();
+}
+
+function messageArray<T>(value: unknown): T[] {
+    return Array.isArray(value) ? value as T[] : [];
+}
+
+function messageEndian(value: unknown): 'le' | 'be' {
+    return value === 'be' ? 'be' : 'le';
 }
 
 function handleIntegrityProfilesMessage(msg: WebviewMessage): void {

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -101,15 +101,21 @@
 }
 
 .integrity-card-status {
+    align-items: center;
     border: 1px solid var(--border);
     border-radius: 8px;
+    box-sizing: border-box;
     color: var(--addr-fg);
-    flex-shrink: 0;
+    display: inline-flex;
+    flex: 0 0 16px;
     font-family: var(--font-ui);
-    font-size: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    height: 16px;
+    justify-content: center;
     line-height: 1;
-    padding: 2px 5px;
-    text-transform: uppercase;
+    padding: 0;
+    width: 16px;
 }
 
 .integrity-card-status.match {
@@ -189,6 +195,17 @@
     background: var(--high-color);
     transform: translateX(10px);
 }
+.integrity-auto-fix.paused { border-color: var(--vscode-editorWarning-foreground, #cca700); }
+.integrity-auto-fix.paused input:checked + .integrity-auto-fix-label {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+.integrity-auto-fix.paused input:checked ~ .integrity-auto-fix-track {
+    background: rgba(204,167,0,.18);
+    border-color: var(--vscode-editorWarning-foreground, #cca700);
+}
+.integrity-auto-fix.paused input:checked ~ .integrity-auto-fix-track .integrity-auto-fix-knob {
+    background: var(--vscode-editorWarning-foreground, #cca700);
+}
 .integrity-auto-fix:focus-within {
     border-color: var(--vscode-focusBorder, #4f9de8);
     outline: 1px solid var(--vscode-focusBorder, #4f9de8);
@@ -256,6 +273,11 @@
 .integrity-copy-btn:hover,
 .integrity-copy-btn:focus-visible { color: var(--high-color); }
 
+.integrity-copy-btn:disabled {
+    cursor: default;
+    opacity: .35;
+}
+
 .integrity-value-pane code {
     color: var(--high-color);
     display: grid;
@@ -273,6 +295,8 @@
     overflow-wrap: anywhere;
     word-break: break-all;
 }
+
+.integrity-value-pane.pending code { color: var(--addr-fg); }
 
 .integrity-value-pane.stored.match { background: rgba(55,190,105,.12); border-color: rgba(55,190,105,.48); }
 .integrity-value-pane.stored.match code { color: var(--vscode-testing-iconPassed, #73c991); }

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -19,7 +19,76 @@
 
 .integrity-help {
     line-height: 1.45;
-    margin-bottom: 16px;
+    margin-bottom: 12px;
+}
+
+.integrity-profiles {
+    border-bottom: 1px solid var(--vscode-widget-border, transparent);
+    margin-bottom: 14px;
+    padding-bottom: 12px;
+}
+
+.integrity-profile-actions,
+.integrity-check-actions,
+.integrity-result-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.integrity-profile-actions button,
+.integrity-check-actions button,
+.integrity-add {
+    background: var(--vscode-button-secondaryBackground);
+    border: 0;
+    color: var(--vscode-button-secondaryForeground);
+    cursor: pointer;
+    font: inherit;
+    padding: 5px 8px;
+}
+
+.integrity-profile-actions button:hover,
+.integrity-check-actions button:hover,
+.integrity-add:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.integrity-profile-actions button:disabled,
+.integrity-check-actions button:disabled {
+    cursor: default;
+    opacity: .45;
+}
+
+.integrity-check {
+    border: 1px solid var(--vscode-widget-border, transparent);
+    margin-bottom: 12px;
+    padding: 10px;
+}
+
+.integrity-check-header {
+    align-items: center;
+    display: flex;
+    font-size: 11px;
+    font-weight: 600;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.integrity-check-actions button {
+    min-width: 24px;
+    padding: 3px 6px;
+}
+
+.integrity-address-grid {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.integrity-address-grid.stored {
+    border-top: 1px solid var(--vscode-widget-border, transparent);
+    margin-top: 2px;
+    padding-top: 10px;
 }
 
 .integrity-field {
@@ -86,6 +155,24 @@
     text-transform: uppercase;
 }
 
+.integrity-result-label.stored-label {
+    margin-top: 9px;
+}
+
+.integrity-status {
+    font-size: 11px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.integrity-status.match {
+    color: var(--vscode-testing-iconPassed, #73c991);
+}
+
+.integrity-status.mismatch {
+    color: var(--vscode-testing-iconFailed, #f14c4c);
+}
+
 .integrity-result code {
     color: var(--vscode-foreground);
     display: block;
@@ -103,9 +190,17 @@
     cursor: pointer;
     margin-top: 10px;
     padding: 5px 12px;
-    width: 100%;
+    flex: 1 1 auto;
 }
 
 .integrity-result button:hover {
     background: var(--vscode-button-hoverBackground);
+}
+
+.integrity-result-actions {
+    margin-top: 10px;
+}
+
+.integrity-add {
+    width: 100%;
 }

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -1,206 +1,315 @@
+#s-integrity { padding: 10px 12px; }
+
 .integrity-shell {
     box-sizing: border-box;
+    color: var(--fg);
+    font-family: var(--font-ui);
     min-width: 0;
-    padding: 16px 14px;
 }
 
-.integrity-title {
-    color: var(--vscode-foreground);
-    font-size: 13px;
-    font-weight: 600;
-    margin-bottom: 4px;
-}
-
-.integrity-help,
-.integrity-meta {
-    color: var(--vscode-descriptionForeground);
-    font-size: 11px;
-}
-
-.integrity-help {
-    line-height: 1.45;
-    margin-bottom: 12px;
-}
+.integrity-hdr-row { margin-bottom: 7px; }
+.integrity-endian-tabs button { font-size: 9px; padding: 1px 5px; }
 
 .integrity-profiles {
-    border-bottom: 1px solid var(--vscode-widget-border, transparent);
-    margin-bottom: 14px;
-    padding-bottom: 12px;
-}
-
-.integrity-profile-actions,
-.integrity-check-actions,
-.integrity-result-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-}
-
-.integrity-profile-actions button,
-.integrity-check-actions button,
-.integrity-add {
-    background: var(--vscode-button-secondaryBackground);
-    border: 0;
-    color: var(--vscode-button-secondaryForeground);
-    cursor: pointer;
-    font: inherit;
-    padding: 5px 8px;
-}
-
-.integrity-profile-actions button:hover,
-.integrity-check-actions button:hover,
-.integrity-add:hover {
-    background: var(--vscode-button-secondaryHoverBackground);
-}
-
-.integrity-profile-actions button:disabled,
-.integrity-check-actions button:disabled {
-    cursor: default;
-    opacity: .45;
-}
-
-.integrity-check {
-    border: 1px solid var(--vscode-widget-border, transparent);
-    margin-bottom: 12px;
-    padding: 10px;
-}
-
-.integrity-check-header {
-    align-items: center;
-    display: flex;
-    font-size: 11px;
-    font-weight: 600;
-    justify-content: space-between;
-    margin-bottom: 10px;
-}
-
-.integrity-check-actions button {
-    min-width: 24px;
-    padding: 3px 6px;
-}
-
-.integrity-address-grid {
     display: grid;
-    gap: 8px;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-}
-
-.integrity-address-grid.stored {
-    border-top: 1px solid var(--vscode-widget-border, transparent);
-    margin-top: 2px;
-    padding-top: 10px;
-}
-
-.integrity-field {
-    display: flex;
-    flex-direction: column;
     gap: 5px;
-    margin-bottom: 12px;
-    min-width: 0;
-}
-
-.integrity-field > span {
-    color: var(--vscode-foreground);
-    font-size: 11px;
-    font-weight: 500;
-}
-
-.integrity-field small {
-    color: var(--vscode-descriptionForeground);
-    font-size: inherit;
-    font-weight: 400;
-}
-
-.integrity-field input,
-.integrity-field select {
-    background: var(--vscode-input-background);
-    border: 1px solid var(--vscode-input-border, transparent);
-    box-sizing: border-box;
-    color: var(--vscode-input-foreground);
-    font: inherit;
-    min-width: 0;
-    outline: none;
-    padding: 6px 7px;
-    width: 100%;
-}
-
-.integrity-field input:focus,
-.integrity-field select:focus {
-    border-color: var(--vscode-focusBorder);
-}
-
-.integrity-meta {
-    min-height: 17px;
-}
-
-.integrity-error {
-    color: var(--vscode-errorForeground);
-    font-size: 11px;
-    line-height: 1.4;
-    min-height: 17px;
-    overflow-wrap: anywhere;
-}
-
-.integrity-result {
-    background: var(--vscode-textCodeBlock-background);
-    border: 1px solid var(--vscode-widget-border, transparent);
-    margin-top: 8px;
-    padding: 10px;
-}
-
-.integrity-result-label {
-    color: var(--vscode-descriptionForeground);
-    font-size: 10px;
-    margin-bottom: 6px;
-    text-transform: uppercase;
-}
-
-.integrity-result-label.stored-label {
-    margin-top: 9px;
-}
-
-.integrity-status {
-    font-size: 11px;
-    font-weight: 600;
+    grid-template-columns: minmax(0, 1fr) auto;
     margin-bottom: 8px;
 }
 
-.integrity-status.match {
+.integrity-profiles > .struct-sel { min-width: 0; }
+
+.integrity-profile-actions {
+    align-items: center;
+    display: flex;
+    gap: 3px;
+}
+
+.integrity-profile-actions .struct-btn {
+    font-size: 9px;
+    padding: 2px 6px;
+}
+
+.integrity-profile-actions .si-icon-btn {
+    font-size: 10px;
+    padding: 2px 4px;
+}
+
+.integrity-profile-actions button:disabled {
+    cursor: not-allowed;
+    opacity: .35;
+}
+
+#integrity-fix-all:disabled {
+    cursor: not-allowed;
+    opacity: .35;
+}
+
+.integrity-error,
+.integrity-form-error {
+    color: var(--err);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+
+#integrity-profile-error {
+    grid-column: 1 / -1;
+    min-height: 0;
+}
+
+#integrity-profile-error:empty { display: none; }
+
+.integrity-empty { padding: 10px 4px; }
+
+.integrity-card {
+    margin-bottom: 4px;
+}
+
+.integrity-card-selected {
+    border-color: var(--vscode-focusBorder, #4f9de8);
+    box-shadow: 0 0 0 1px var(--vscode-focusBorder, #4f9de8);
+}
+
+.integrity-card-info {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.integrity-card-title {
+    color: var(--fg);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.integrity-card-meta {
+    color: var(--addr-fg);
+    font-family: var(--font-editor);
+    font-size: 9px;
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.integrity-card-status {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--addr-fg);
+    flex-shrink: 0;
+    font-family: var(--font-ui);
+    font-size: 8px;
+    line-height: 1;
+    padding: 2px 5px;
+    text-transform: uppercase;
+}
+
+.integrity-card-status.match {
+    border-color: rgba(115,201,145,.45);
     color: var(--vscode-testing-iconPassed, #73c991);
 }
 
-.integrity-status.mismatch {
-    color: var(--vscode-testing-iconFailed, #f14c4c);
+.integrity-card-status.mismatch,
+.integrity-card-status.error {
+    border-color: rgba(241,76,76,.45);
+    color: var(--err);
 }
 
-.integrity-result code {
-    color: var(--vscode-foreground);
+.integrity-card-status.calculating { color: var(--high-color); }
+
+.integrity-card-status.calculated {
+    border-color: rgba(79,195,247,.35);
+    color: var(--high-color);
+}
+
+.integrity-auto-fix {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: var(--addr-fg);
+    cursor: pointer;
+    display: inline-flex;
+    flex-shrink: 0;
+    font-family: var(--font-ui);
+    font-size: 8px;
+    gap: 4px;
+    padding: 2px 4px;
+    transition: background .1s, border-color .1s, color .1s;
+    white-space: nowrap;
+}
+
+.integrity-auto-fix:hover:not(.disabled) {
+    background: rgba(255,255,255,.06);
+    border-color: var(--border);
+    color: var(--fg);
+}
+
+.integrity-auto-fix input {
+    height: 1px;
+    opacity: 0;
+    position: absolute;
+    width: 1px;
+}
+
+.integrity-auto-fix-track {
+    background: rgba(255,255,255,.12);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-sizing: border-box;
+    display: inline-flex;
+    height: 12px;
+    padding: 1px;
+    transition: background .1s, border-color .1s;
+    width: 22px;
+}
+
+.integrity-auto-fix-knob {
+    background: var(--addr-fg);
+    border-radius: 50%;
+    height: 8px;
+    transition: background .1s, transform .1s;
+    width: 8px;
+}
+
+.integrity-auto-fix input:checked + .integrity-auto-fix-label { color: var(--high-color); }
+.integrity-auto-fix input:checked ~ .integrity-auto-fix-track {
+    background: rgba(79,195,247,.24);
+    border-color: rgba(79,195,247,.65);
+}
+.integrity-auto-fix input:checked ~ .integrity-auto-fix-track .integrity-auto-fix-knob {
+    background: var(--high-color);
+    transform: translateX(10px);
+}
+.integrity-auto-fix:focus-within {
+    border-color: var(--vscode-focusBorder, #4f9de8);
+    outline: 1px solid var(--vscode-focusBorder, #4f9de8);
+    outline-offset: -1px;
+}
+.integrity-auto-fix.disabled { cursor: default; opacity: .45; }
+#integrity-action-error:empty { display: none; }
+
+.integrity-card-body {
+    background: rgba(0,0,0,.12);
+    border-top: 1px solid var(--border);
+    padding: 7px 8px;
+}
+
+.integrity-card-empty,
+.integrity-result-meta {
+    color: var(--addr-fg);
+    font-size: 9px;
+}
+
+.integrity-comparison {
+    display: grid;
+    gap: 6px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-bottom: 5px;
+}
+
+.integrity-comparison-single { grid-template-columns: minmax(0, 1fr); }
+
+.integrity-value-pane {
+    background: rgba(255,255,255,.025);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    min-width: 0;
+    padding: 5px;
+}
+
+.integrity-value-pane > span {
     display: block;
-    font-family: var(--vscode-editor-font-family, monospace);
-    font-size: 12px;
+    color: var(--addr-fg);
+    font-family: var(--font-ui);
+    font-size: 9px;
+    margin-bottom: 3px;
+    text-transform: uppercase;
+}
+
+.integrity-value-pane code {
+    color: var(--high-color);
+    display: grid;
+    font-family: var(--font-editor);
+    font-size: 10px;
+    grid-template-columns: auto minmax(0, 1fr);
+    line-height: 1.35;
     overflow-wrap: anywhere;
     -webkit-user-select: text;
     user-select: text;
 }
 
-.integrity-result button {
-    background: var(--vscode-button-background);
-    border: 0;
-    color: var(--vscode-button-foreground);
-    cursor: pointer;
-    margin-top: 10px;
-    padding: 5px 12px;
-    flex: 1 1 auto;
+.integrity-value-pane code .si-hex-body {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-all;
 }
 
-.integrity-result button:hover {
-    background: var(--vscode-button-hoverBackground);
+.integrity-value-pane.stored.match { background: rgba(55,190,105,.12); border-color: rgba(55,190,105,.48); }
+.integrity-value-pane.stored.match code { color: var(--vscode-testing-iconPassed, #73c991); }
+.integrity-value-pane.stored.mismatch { background: rgba(241,76,76,.14); border-color: rgba(241,76,76,.52); }
+.integrity-value-pane.stored.mismatch code { color: var(--err); }
+.integrity-value-pane.stored.unverified { background: rgba(225,165,45,.1); border-color: rgba(225,165,45,.4); }
+
+.integrity-check-form {
+    background: rgba(0,0,0,.18);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
 }
 
-.integrity-result-actions {
-    margin-top: 10px;
+.integrity-add-form {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    margin-bottom: 8px;
 }
 
-.integrity-add {
+.integrity-edit-form { border-top: 1px solid var(--border); }
+
+.integrity-form-grid {
+    display: grid;
+    gap: 6px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.integrity-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
+.integrity-form-field > span {
+    color: var(--addr-fg);
+    font-family: var(--font-ui);
+    font-size: 9px;
+}
+
+.integrity-form-field .struct-sel {
+    box-sizing: border-box;
     width: 100%;
 }
+
+.integrity-address-input {
+    align-items: center;
+    display: flex;
+    min-width: 0;
+}
+
+.integrity-address-input .struct-addr-inp {
+    box-sizing: border-box;
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+}
+
+.integrity-form-error:empty { display: none; }

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -59,6 +59,20 @@
 
 #integrity-profile-error:empty { display: none; }
 
+.integrity-profile-name-form {
+    display: grid;
+    gap: 4px;
+    grid-column: 1 / -1;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.integrity-profile-name-form .struct-addr-inp { min-width: 0; }
+
+.integrity-profile-name-form .struct-btn {
+    font-size: 9px;
+    padding: 2px 7px;
+}
+
 .integrity-empty { padding: 10px 4px; }
 
 .integrity-card {

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -147,7 +147,7 @@
     white-space: nowrap;
 }
 
-.integrity-auto-fix:hover:not(.disabled) {
+.integrity-auto-fix:hover {
     background: rgba(255,255,255,.06);
     border-color: var(--border);
     color: var(--fg);
@@ -194,7 +194,6 @@
     outline: 1px solid var(--vscode-focusBorder, #4f9de8);
     outline-offset: -1px;
 }
-.integrity-auto-fix.disabled { cursor: default; opacity: .45; }
 #integrity-action-error:empty { display: none; }
 
 .integrity-card-body {
@@ -226,14 +225,36 @@
     padding: 5px;
 }
 
-.integrity-value-pane > span {
+.integrity-value-pane > span,
+.integrity-value-hdr > span {
     display: block;
     color: var(--addr-fg);
     font-family: var(--font-ui);
     font-size: 9px;
-    margin-bottom: 3px;
     text-transform: uppercase;
 }
+
+.integrity-value-pane > span { margin-bottom: 3px; }
+
+.integrity-value-hdr {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 3px;
+}
+
+.integrity-copy-btn {
+    background: transparent;
+    border: 0;
+    color: var(--addr-fg);
+    cursor: pointer;
+    font: inherit;
+    line-height: 1;
+    padding: 0 1px;
+}
+
+.integrity-copy-btn:hover,
+.integrity-copy-btn:focus-visible { color: var(--high-color); }
 
 .integrity-value-pane code {
     color: var(--high-color);

--- a/src/webview/integrity.css
+++ b/src/webview/integrity.css
@@ -8,8 +8,6 @@
 }
 
 .integrity-hdr-row { margin-bottom: 7px; }
-.integrity-endian-tabs button { font-size: 9px; padding: 1px 5px; }
-
 .integrity-profiles {
     display: grid;
     gap: 5px;

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -17,14 +17,29 @@ export interface IntegrityCheckConfig {
     startAddress: number;
     endAddress: number;
     storedAddress?: number;
-    byteOrder: IntegrityByteOrder;
+    autoFixStoredValue: boolean;
 }
 
 export interface IntegrityProfile {
     schemaVersion: typeof INTEGRITY_PROFILE_SCHEMA_VERSION;
     id: string;
     name: string;
+    byteOrder: IntegrityByteOrder;
     checks: IntegrityCheckConfig[];
+}
+
+export interface IntegrityCheckSet {
+    schemaVersion: typeof INTEGRITY_PROFILE_SCHEMA_VERSION;
+    byteOrder: IntegrityByteOrder;
+    checks: IntegrityCheckConfig[];
+}
+
+interface IntegrityProfileCandidate {
+    schemaVersion?: unknown;
+    id?: unknown;
+    name?: unknown;
+    byteOrder?: unknown;
+    checks?: unknown;
 }
 
 export interface IntegrityRequest {
@@ -48,6 +63,8 @@ export type IntegrityValidation<T> =
     | { ok: true; value: T }
     | { ok: false; error: string };
 
+export type IntegrityEdit = [number, number];
+
 const MAX_ADDRESS = 0xFFFF_FFFF;
 
 function isIntegrityAlgorithm(value: unknown): value is IntegrityAlgorithm {
@@ -67,6 +84,23 @@ export function normalizeIntegrityProfiles(value: unknown): IntegrityProfile[] {
     return profiles;
 }
 
+export function normalizeIntegrityCheckSet(value: unknown): IntegrityCheckSet | null {
+    const raw = integrityCheckSetCandidate(value);
+    return raw ? normalizeIntegrityCheckSetCandidate(raw) : null;
+}
+
+function normalizeIntegrityCheckSetCandidate(raw: Partial<IntegrityCheckSet>): IntegrityCheckSet | null {
+    if (raw.schemaVersion !== INTEGRITY_PROFILE_SCHEMA_VERSION) { return null; }
+    if (!isIntegrityByteOrder(raw.byteOrder)) { return null; }
+    const checks = normalizeIntegrityChecks(raw.checks);
+    if (!checks) { return null; }
+    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, byteOrder: raw.byteOrder, checks };
+}
+
+function integrityCheckSetCandidate(value: unknown): Partial<IntegrityCheckSet> | null {
+    return value !== null && typeof value === 'object' ? value as Partial<IntegrityCheckSet> : null;
+}
+
 function appendNormalizedProfile(profiles: IntegrityProfile[], candidate: unknown): void {
     const profile = normalizeIntegrityProfile(candidate);
     if (!profile) { return; }
@@ -80,23 +114,35 @@ function normalizeIntegrityProfile(value: unknown): IntegrityProfile | null {
     if (!raw) { return null; }
     const identity = integrityProfileIdentity(raw);
     if (!identity) { return null; }
-    const checks = normalizeIntegrityChecks(raw.checks);
-    if (!checks) { return null; }
-    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, ...identity, checks };
+    if (raw.schemaVersion !== INTEGRITY_PROFILE_SCHEMA_VERSION) { return null; }
+    return normalizeCurrentIntegrityProfile(raw, identity);
 }
 
-function integrityProfileCandidate(value: unknown): Partial<IntegrityProfile> | null {
+function integrityProfileCandidate(value: unknown): IntegrityProfileCandidate | null {
     if (value === null) { return null; }
     if (typeof value !== 'object') { return null; }
-    return value as Partial<IntegrityProfile>;
+    return value as IntegrityProfileCandidate;
 }
 
-function integrityProfileIdentity(raw: Partial<IntegrityProfile>): Pick<IntegrityProfile, 'id' | 'name'> | null {
-    if (raw.schemaVersion !== INTEGRITY_PROFILE_SCHEMA_VERSION) { return null; }
+function integrityProfileIdentity(raw: IntegrityProfileCandidate): Pick<IntegrityProfile, 'id' | 'name'> | null {
     const id = trimmedString(raw.id);
     if (!id) { return null; }
     const name = trimmedString(raw.name);
     return name ? { id, name } : null;
+}
+
+function normalizeCurrentIntegrityProfile(
+    raw: IntegrityProfileCandidate,
+    identity: Pick<IntegrityProfile, 'id' | 'name'>,
+): IntegrityProfile | null {
+    if (!isIntegrityByteOrder(raw.byteOrder)) { return null; }
+    const checks = normalizeIntegrityChecks(raw.checks);
+    if (!checks || checks.length === 0) { return null; }
+    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, ...identity, byteOrder: raw.byteOrder, checks };
+}
+
+function isIntegrityByteOrder(value: unknown): value is IntegrityByteOrder {
+    return value === 'le' || value === 'be';
 }
 
 function trimmedString(value: unknown): string {
@@ -105,9 +151,13 @@ function trimmedString(value: unknown): string {
 
 function normalizeIntegrityChecks(value: unknown): IntegrityCheckConfig[] | null {
     if (!Array.isArray(value)) { return null; }
-    const checks = value.map(normalizeIntegrityCheck).filter((check): check is IntegrityCheckConfig => !!check);
-    if (checks.length === 0) { return null; }
-    return checks.length === value.length ? checks : null;
+    const checks: IntegrityCheckConfig[] = [];
+    for (const item of value) {
+        const check = normalizeIntegrityCheck(item);
+        if (!check) { return null; }
+        checks.push(check);
+    }
+    return checks;
 }
 
 function normalizeIntegrityCheck(value: unknown): IntegrityCheckConfig | null {
@@ -119,8 +169,8 @@ function normalizeIntegrityCheck(value: unknown): IntegrityCheckConfig | null {
         algorithm: raw.algorithm,
         startAddress: raw.startAddress as number,
         endAddress: raw.endAddress as number,
+        autoFixStoredValue: raw.autoFixStoredValue,
         ...normalizedStoredAddress(raw.storedAddress),
-        byteOrder: raw.byteOrder,
     };
 }
 
@@ -135,8 +185,8 @@ function integrityCheckCandidate(value: unknown): Partial<IntegrityCheckConfig> 
 
 function isIntegrityCheckCore(raw: Partial<IntegrityCheckConfig>): raw is IntegrityCheckConfig {
     if (!isIntegrityAlgorithm(raw.algorithm)) { return false; }
-    if (!isIntegrityRange(raw.startAddress, raw.endAddress)) { return false; }
-    return raw.byteOrder === 'be' || raw.byteOrder === 'le';
+    if (typeof raw.autoFixStoredValue !== 'boolean') { return false; }
+    return isIntegrityRange(raw.startAddress, raw.endAddress);
 }
 
 function isIntegrityRange(start: unknown, end: unknown): start is number {
@@ -240,6 +290,22 @@ export function integrityBytesEqual(left: Uint8Array, right: Uint8Array): boolea
 
 export function integrityBytesToHex(bytes: Uint8Array): string {
     return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+export function mergeIntegrityEdits(groups: IntegrityEdit[][]): IntegrityValidation<IntegrityEdit[]> {
+    const merged = new Map<number, number>();
+    for (const [address, value] of groups.flat()) {
+        if (isConflictingIntegrityEdit(merged, address, value)) {
+            return { ok: false, error: `Fix all conflict at ${formatIntegrityAddress(address)}.` };
+        }
+        merged.set(address, value);
+    }
+    return { ok: true, value: Array.from(merged.entries()) };
+}
+
+function isConflictingIntegrityEdit(merged: Map<number, number>, address: number, value: number): boolean {
+    if (!merged.has(address)) { return false; }
+    return merged.get(address) !== value;
 }
 
 export async function calculateIntegrity(

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -28,13 +28,11 @@ export interface IntegrityProfile {
     schemaVersion: typeof INTEGRITY_PROFILE_SCHEMA_VERSION;
     id: string;
     name: string;
-    byteOrder: IntegrityByteOrder;
     checks: IntegrityCheckConfig[];
 }
 
 export interface IntegrityCheckSet {
     schemaVersion: typeof INTEGRITY_PROFILE_SCHEMA_VERSION;
-    byteOrder: IntegrityByteOrder;
     checks: IntegrityCheckConfig[];
 }
 
@@ -42,7 +40,6 @@ interface IntegrityProfileCandidate {
     schemaVersion?: unknown;
     id?: unknown;
     name?: unknown;
-    byteOrder?: unknown;
     checks?: unknown;
 }
 
@@ -95,10 +92,9 @@ export function normalizeIntegrityCheckSet(value: unknown): IntegrityCheckSet | 
 
 function normalizeIntegrityCheckSetCandidate(raw: Partial<IntegrityCheckSet>): IntegrityCheckSet | null {
     if (raw.schemaVersion !== INTEGRITY_PROFILE_SCHEMA_VERSION) { return null; }
-    if (!isIntegrityByteOrder(raw.byteOrder)) { return null; }
     const checks = normalizeIntegrityChecks(raw.checks);
     if (!checks) { return null; }
-    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, byteOrder: raw.byteOrder, checks };
+    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, checks };
 }
 
 function integrityCheckSetCandidate(value: unknown): Partial<IntegrityCheckSet> | null {
@@ -139,14 +135,9 @@ function normalizeCurrentIntegrityProfile(
     raw: IntegrityProfileCandidate,
     identity: Pick<IntegrityProfile, 'id' | 'name'>,
 ): IntegrityProfile | null {
-    if (!isIntegrityByteOrder(raw.byteOrder)) { return null; }
     const checks = normalizeIntegrityChecks(raw.checks);
     if (!checks || checks.length === 0) { return null; }
-    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, ...identity, byteOrder: raw.byteOrder, checks };
-}
-
-function isIntegrityByteOrder(value: unknown): value is IntegrityByteOrder {
-    return value === 'le' || value === 'be';
+    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, ...identity, checks };
 }
 
 function trimmedString(value: unknown): string {
@@ -307,6 +298,11 @@ export function integrityBytesEqual(left: Uint8Array, right: Uint8Array): boolea
 
 export function integrityBytesToHex(bytes: Uint8Array): string {
     return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+export function integrityBytesToValueHex(bytes: Uint8Array, byteOrder: IntegrityByteOrder): string {
+    const ordered = byteOrder === 'le' ? Uint8Array.from(bytes).reverse() : bytes;
+    return integrityBytesToHex(ordered);
 }
 
 export function mergeIntegrityEdits(groups: IntegrityEdit[][]): IntegrityValidation<IntegrityEdit[]> {

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -10,6 +10,10 @@ const INTEGRITY_ALGORITHMS = [
 export type IntegrityAlgorithm = typeof INTEGRITY_ALGORITHMS[number];
 export type IntegrityByteOrder = 'be' | 'le';
 
+export function isChecksumAlgorithm(algorithm: IntegrityAlgorithm): boolean {
+    return algorithm === 'crc16-ccitt-false' || algorithm === 'crc32-iso-hdlc';
+}
+
 const INTEGRITY_PROFILE_SCHEMA_VERSION = 1 as const;
 
 export interface IntegrityCheckConfig {
@@ -164,13 +168,26 @@ function normalizeIntegrityCheck(value: unknown): IntegrityCheckConfig | null {
     const raw = integrityCheckCandidate(value);
     if (!raw) { return null; }
     if (!isIntegrityCheckCore(raw)) { return null; }
-    if (!isStoredAddressValid(raw.storedAddress)) { return null; }
+    const verification = normalizeVerificationSettings(raw);
+    if (!verification.ok) { return null; }
     return {
         algorithm: raw.algorithm,
         startAddress: raw.startAddress as number,
         endAddress: raw.endAddress as number,
-        autoFixStoredValue: raw.autoFixStoredValue,
-        ...normalizedStoredAddress(raw.storedAddress),
+        ...verification.value,
+    };
+}
+
+function normalizeVerificationSettings(raw: IntegrityCheckConfig):
+    | { ok: true; value: Pick<IntegrityCheckConfig, 'autoFixStoredValue' | 'storedAddress'> }
+    | { ok: false } {
+    if (!isChecksumAlgorithm(raw.algorithm)) {
+        return { ok: true, value: { autoFixStoredValue: false } };
+    }
+    if (!isStoredAddressValid(raw.storedAddress)) { return { ok: false }; }
+    return {
+        ok: true,
+        value: { autoFixStoredValue: raw.autoFixStoredValue, ...normalizedStoredAddress(raw.storedAddress) },
     };
 }
 

--- a/src/webview/integrity.ts
+++ b/src/webview/integrity.ts
@@ -8,6 +8,24 @@ const INTEGRITY_ALGORITHMS = [
 ] as const;
 
 export type IntegrityAlgorithm = typeof INTEGRITY_ALGORITHMS[number];
+export type IntegrityByteOrder = 'be' | 'le';
+
+const INTEGRITY_PROFILE_SCHEMA_VERSION = 1 as const;
+
+export interface IntegrityCheckConfig {
+    algorithm: IntegrityAlgorithm;
+    startAddress: number;
+    endAddress: number;
+    storedAddress?: number;
+    byteOrder: IntegrityByteOrder;
+}
+
+export interface IntegrityProfile {
+    schemaVersion: typeof INTEGRITY_PROFILE_SCHEMA_VERSION;
+    id: string;
+    name: string;
+    checks: IntegrityCheckConfig[];
+}
 
 export interface IntegrityRequest {
     algorithm: IntegrityAlgorithm;
@@ -21,11 +39,116 @@ export interface IntegrityResult {
     byteCount: number;
 }
 
+export interface IntegrityStoredField {
+    startAddress: number;
+    byteLength: number;
+}
+
 export type IntegrityValidation<T> =
     | { ok: true; value: T }
     | { ok: false; error: string };
 
 const MAX_ADDRESS = 0xFFFF_FFFF;
+
+function isIntegrityAlgorithm(value: unknown): value is IntegrityAlgorithm {
+    return typeof value === 'string' && (INTEGRITY_ALGORITHMS as readonly string[]).includes(value);
+}
+
+function isUint32(value: number): boolean {
+    return Number.isSafeInteger(value) && (value >>> 0) === value;
+}
+
+export function normalizeIntegrityProfiles(value: unknown): IntegrityProfile[] {
+    if (!Array.isArray(value)) { return []; }
+    const profiles: IntegrityProfile[] = [];
+    for (const candidate of value) {
+        appendNormalizedProfile(profiles, candidate);
+    }
+    return profiles;
+}
+
+function appendNormalizedProfile(profiles: IntegrityProfile[], candidate: unknown): void {
+    const profile = normalizeIntegrityProfile(candidate);
+    if (!profile) { return; }
+    if (profiles.some(item => item.id === profile.id)) { return; }
+    if (profiles.some(item => item.name.toLocaleLowerCase() === profile.name.toLocaleLowerCase())) { return; }
+    profiles.push(profile);
+}
+
+function normalizeIntegrityProfile(value: unknown): IntegrityProfile | null {
+    const raw = integrityProfileCandidate(value);
+    if (!raw) { return null; }
+    const identity = integrityProfileIdentity(raw);
+    if (!identity) { return null; }
+    const checks = normalizeIntegrityChecks(raw.checks);
+    if (!checks) { return null; }
+    return { schemaVersion: INTEGRITY_PROFILE_SCHEMA_VERSION, ...identity, checks };
+}
+
+function integrityProfileCandidate(value: unknown): Partial<IntegrityProfile> | null {
+    if (value === null) { return null; }
+    if (typeof value !== 'object') { return null; }
+    return value as Partial<IntegrityProfile>;
+}
+
+function integrityProfileIdentity(raw: Partial<IntegrityProfile>): Pick<IntegrityProfile, 'id' | 'name'> | null {
+    if (raw.schemaVersion !== INTEGRITY_PROFILE_SCHEMA_VERSION) { return null; }
+    const id = trimmedString(raw.id);
+    if (!id) { return null; }
+    const name = trimmedString(raw.name);
+    return name ? { id, name } : null;
+}
+
+function trimmedString(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeIntegrityChecks(value: unknown): IntegrityCheckConfig[] | null {
+    if (!Array.isArray(value)) { return null; }
+    const checks = value.map(normalizeIntegrityCheck).filter((check): check is IntegrityCheckConfig => !!check);
+    if (checks.length === 0) { return null; }
+    return checks.length === value.length ? checks : null;
+}
+
+function normalizeIntegrityCheck(value: unknown): IntegrityCheckConfig | null {
+    const raw = integrityCheckCandidate(value);
+    if (!raw) { return null; }
+    if (!isIntegrityCheckCore(raw)) { return null; }
+    if (!isStoredAddressValid(raw.storedAddress)) { return null; }
+    return {
+        algorithm: raw.algorithm,
+        startAddress: raw.startAddress as number,
+        endAddress: raw.endAddress as number,
+        ...normalizedStoredAddress(raw.storedAddress),
+        byteOrder: raw.byteOrder,
+    };
+}
+
+function normalizedStoredAddress(value: number | undefined): { storedAddress?: number } {
+    return value === undefined ? {} : { storedAddress: value };
+}
+
+function integrityCheckCandidate(value: unknown): Partial<IntegrityCheckConfig> | null {
+    if (value === null) { return null; }
+    return typeof value === 'object' ? value as Partial<IntegrityCheckConfig> : null;
+}
+
+function isIntegrityCheckCore(raw: Partial<IntegrityCheckConfig>): raw is IntegrityCheckConfig {
+    if (!isIntegrityAlgorithm(raw.algorithm)) { return false; }
+    if (!isIntegrityRange(raw.startAddress, raw.endAddress)) { return false; }
+    return raw.byteOrder === 'be' || raw.byteOrder === 'le';
+}
+
+function isIntegrityRange(start: unknown, end: unknown): start is number {
+    if (!isUint32(start as number)) { return false; }
+    if (!isUint32(end as number)) { return false; }
+    return (end as number) >= (start as number);
+}
+
+function isStoredAddressValid(value: unknown): boolean {
+    if (value === undefined) { return true; }
+    return isUint32(value as number);
+}
 
 export function parseIntegrityAddress(raw: string, label: string): IntegrityValidation<number> {
     const text = raw.trim();
@@ -39,10 +162,6 @@ export function parseIntegrityAddress(raw: string, label: string): IntegrityVali
         return { ok: false, error: `${label} address must be between 0x00000000 and 0xFFFFFFFF.` };
     }
     return { ok: true, value };
-}
-
-function isUint32(value: number): boolean {
-    return Number.isSafeInteger(value) && (value >>> 0) === value;
 }
 
 export function validateIntegrityRange(
@@ -63,19 +182,64 @@ export function validateIntegrityRange(
 export function collectIntegrityBytes(
     request: IntegrityRequest,
     readByte: (address: number) => number | undefined,
+    excluded?: IntegrityStoredField,
 ): IntegrityValidation<Uint8Array> {
-    const length = request.endAddress - request.startAddress + 1;
-    for (let offset = 0; offset < length; offset++) {
-        const address = request.startAddress + offset;
-        if (readByte(address) === undefined) {
+    const values: number[] = [];
+    for (let address = request.startAddress; address <= request.endAddress; address++) {
+        if (isExcludedIntegrityAddress(address, excluded)) { continue; }
+        const value = readByte(address);
+        if (value === undefined) {
             return { ok: false, error: `No mapped byte at ${formatIntegrityAddress(address)}.` };
         }
+        values.push(value);
     }
-    const bytes = new Uint8Array(length);
-    for (let offset = 0; offset < length; offset++) {
-        bytes[offset] = readByte(request.startAddress + offset)!;
+    return { ok: true, value: Uint8Array.from(values) };
+}
+
+function isExcludedIntegrityAddress(address: number, excluded?: IntegrityStoredField): boolean {
+    if (!excluded) { return false; }
+    if (address < excluded.startAddress) { return false; }
+    return address < excluded.startAddress + excluded.byteLength;
+}
+
+export function integrityValueToBytes(value: string, byteOrder: IntegrityByteOrder): Uint8Array {
+    if (value.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(value)) {
+        throw new Error('Integrity value must contain complete hexadecimal bytes.');
+    }
+    const bytes = Uint8Array.from(value.match(/../g)!, pair => Number.parseInt(pair, 16));
+    return byteOrder === 'le' ? bytes.reverse() : bytes;
+}
+
+export function readStoredIntegrityBytes(
+    field: IntegrityStoredField,
+    readByte: (address: number) => number | undefined,
+): IntegrityValidation<Uint8Array> {
+    if (!isStoredFieldInAddressSpace(field)) {
+        return { ok: false, error: 'Stored value extends beyond 0xFFFFFFFF.' };
+    }
+    const bytes = new Uint8Array(field.byteLength);
+    for (let offset = 0; offset < field.byteLength; offset++) {
+        const address = field.startAddress + offset;
+        const value = readByte(address);
+        if (value === undefined) {
+            return { ok: false, error: `No mapped stored byte at ${formatIntegrityAddress(address)}.` };
+        }
+        bytes[offset] = value;
     }
     return { ok: true, value: bytes };
+}
+
+function isStoredFieldInAddressSpace(field: IntegrityStoredField): boolean {
+    if (field.byteLength < 1) { return false; }
+    return field.startAddress + field.byteLength - 1 <= MAX_ADDRESS;
+}
+
+export function integrityBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+export function integrityBytesToHex(bytes: Uint8Array): string {
+    return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('').toUpperCase();
 }
 
 export async function calculateIntegrity(

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -6,6 +6,7 @@ import {
     formatIntegrityAddress,
     integrityBytesEqual,
     integrityBytesToHex,
+    integrityBytesToValueHex,
     integrityValueToBytes,
     isChecksumAlgorithm,
     mergeIntegrityEdits,
@@ -35,7 +36,7 @@ const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
     ['sha-256', 'SHA-256'],
     ['sha-512', 'SHA-512'],
 ];
-const EMPTY_INTEGRITY_CHECK_SET: IntegrityCheckSet = { schemaVersion: 1, byteOrder: 'le', checks: [] };
+const EMPTY_INTEGRITY_CHECK_SET: IntegrityCheckSet = { schemaVersion: 1, checks: [] };
 const INTEGRITY_STATUS_SYMBOLS: Record<string, string> = {
     Match: '✓', Mismatch: '✕', Calculated: '∑', Calculating: '…', Error: '!', 'Not configured': '?',
 };
@@ -83,7 +84,6 @@ let highlightedCheckId: number | null = null;
 
 const integrityState = {
     initialized: false,
-    byteOrder: 'le' as 'be' | 'le',
     checks: [] as IntegrityCheckState[],
 };
 
@@ -165,7 +165,6 @@ function integrityInitPayload(value: unknown): { profiles: unknown; activeChecks
 export function setIntegrityChecks(value: unknown): void {
     const saved = normalizedIntegrityCheckSet(value);
     cancelIntegrityCalculations();
-    integrityState.byteOrder = saved.byteOrder;
     integrityState.checks = saved.checks.map(newCheck);
     addCheckDraft = null;
     editingCheckId = null;
@@ -200,7 +199,6 @@ function integrityShellHtml(): string {
         <div class="integrity-shell">
             <div class="si-hdr-row integrity-hdr-row">
                 <span class="sb-hdr" style="margin:0">Integrity Checks ${integrityBadgeHtml()}</span>
-                ${endianToggleHtml()}
                 <button id="integrity-fix-all" class="struct-btn struct-btn-apply" type="button"${fixAllDisabledAttr()}>Fix all</button>
                 <button id="integrity-add-btn" class="si-add-btn"${addCheckDisabledAttr()}>＋ Add</button>
             </div>
@@ -240,17 +238,6 @@ function checkCardsHtml(): string {
         return '<div class="sb-empty integrity-empty">No integrity checks configured.</div>';
     }
     return integrityState.checks.map(checkCardHtml).join('');
-}
-
-function endianToggleHtml(): string {
-    return `
-        <div class="si-toggle-group" title="Stored-value byte order for all integrity checks">
-            <span class="si-toggle-label">Endian</span>
-            <div class="endian-tabs integrity-endian-tabs">
-                <button id="integrity-btn-le" class="${integrityState.byteOrder === 'le' ? 'active' : ''}">LE</button>
-                <button id="integrity-btn-be" class="${integrityState.byteOrder === 'be' ? 'active' : ''}">BE</button>
-            </div>
-        </div>`;
 }
 
 function profileLibraryHtml(): string {
@@ -411,8 +398,6 @@ export function notifyIntegrityEditsDiscarded(): void {
 }
 
 function wireHeaderControls(): void {
-    document.getElementById('integrity-btn-le')?.addEventListener('click', () => setSharedEndian('le'));
-    document.getElementById('integrity-btn-be')?.addEventListener('click', () => setSharedEndian('be'));
     document.getElementById('integrity-fix-all')?.addEventListener('click', fixAllMismatches);
     document.getElementById('integrity-add-btn')?.addEventListener('click', () => {
         addCheckDraft = addDraft();
@@ -422,11 +407,8 @@ function wireHeaderControls(): void {
     });
 }
 
-function setSharedEndian(endian: 'le' | 'be'): void {
-    if (integrityState.byteOrder === endian) { return; }
-    integrityState.byteOrder = endian;
+export function notifyIntegrityEndianChanged(): void {
     integrityState.checks.forEach(clearAutoFixSuppression);
-    persistIntegrityChecks();
     renderIntegrity();
     integrityState.checks.forEach(check => scheduleIntegrityCalculation(check, true));
 }
@@ -459,7 +441,7 @@ function copyCalculatedValue(event: MouseEvent): void {
     if (!button) { return; }
     const check = integrityState.checks.find(item => item.id === Number(button.dataset.checkId));
     if (!check?.result) { return; }
-    const display = calculatedDisplay(check, check.result);
+    const display = calculatedDisplay(check.result);
     vscode.postMessage({
         type: 'copyText',
         text: `0x${display.value}`,
@@ -746,7 +728,7 @@ function applyCalculatedResultIfCurrent(
 ): void {
     if (token !== check.token) { return; }
     check.result = result;
-    check.expectedBytes = integrityValueToBytes(result.value, integrityState.byteOrder);
+    check.expectedBytes = integrityValueToBytes(result.value, S.endian);
     check.storedBytes = null;
     check.calculating = false;
     check.meta = formatByteCount(result.byteCount);
@@ -830,7 +812,7 @@ function pendingResultBodyHtml(check: IntegrityCheckState): string {
         <div class="integrity-comparison${singleComparisonClass(stored)}">
             <div class="integrity-value-pane calculated pending">
                 <div class="integrity-value-hdr">
-                    <span>${calculatedLabel(check)}</span>
+                    <span>Calculated</span>
                     <button class="integrity-copy-btn" type="button" title="Copy calculated value" aria-label="Copy calculated value" disabled>⧉</button>
                 </div>
                 <code>${formatHexHtml('0x—')}</code>
@@ -842,14 +824,14 @@ function pendingResultBodyHtml(check: IntegrityCheckState): string {
 
 function pendingStoredResultHtml(check: IntegrityCheckState): string {
     return `<div class="integrity-value-pane stored unverified pending">
-        <div class="integrity-value-hdr"><span>Stored</span>${autoFixToggleHtml(check)}</div>
+        <div class="integrity-value-hdr"><span>Stored (${S.endian.toUpperCase()})</span>${autoFixToggleHtml(check)}</div>
         <code>${formatHexHtml('0x—')}</code>
     </div>`;
 }
 
 function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityResult): string {
     const stored = storedResultHtml(check);
-    const display = calculatedDisplay(check, result);
+    const display = calculatedDisplay(result);
     return `
         <div class="integrity-comparison${singleComparisonClass(stored)}">
             <div class="integrity-value-pane calculated">
@@ -865,21 +847,9 @@ function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityR
 }
 
 function calculatedDisplay(
-    check: IntegrityCheckState,
     result: IntegrityResult,
 ): { label: string; value: string; title: string } {
-    if (!hasStoredChecksum(check) || !check.expectedBytes) {
-        return { label: 'Calculated', value: result.value, title: '' };
-    }
-    return {
-        label: calculatedLabel(check),
-        value: integrityBytesToHex(check.expectedBytes),
-        title: `Canonical checksum: 0x${result.value}`,
-    };
-}
-
-function calculatedLabel(check: IntegrityCheckState): string {
-    return hasStoredChecksum(check) ? `Calculated (${integrityState.byteOrder.toUpperCase()})` : 'Calculated';
+    return { label: 'Calculated', value: result.value, title: '' };
 }
 
 function hasStoredChecksum(check: IntegrityCheckState): boolean {
@@ -893,9 +863,11 @@ function singleComparisonClass(storedHtml: string): string {
 function storedResultHtml(check: IntegrityCheckState): string {
     if (!isChecksumAlgorithm(check.algorithm) || !check.storedBytes) { return ''; }
     const state = integrityHighlightStatus(check);
+    const raw = integrityBytesToHex(check.storedBytes);
+    const value = integrityBytesToValueHex(check.storedBytes, S.endian);
     return `<div class="integrity-value-pane stored ${state}">
-        <div class="integrity-value-hdr"><span>Stored</span>${autoFixToggleHtml(check)}</div>
-        <code>${formatHexHtml(`0x${integrityBytesToHex(check.storedBytes)}`)}</code>
+        <div class="integrity-value-hdr"><span>Stored (${S.endian.toUpperCase()})</span>${autoFixToggleHtml(check)}</div>
+        <code title="Raw bytes: 0x${raw}">${formatHexHtml(`0x${value}`)}</code>
     </div>`;
 }
 
@@ -939,7 +911,7 @@ function autoFixMismatchKey(check: IntegrityCheckState): string {
         check.startRaw,
         check.endRaw,
         check.storedRaw,
-        integrityState.byteOrder,
+        S.endian,
         integrityBytesToHex(check.expectedBytes),
         integrityBytesToHex(check.storedBytes),
     ].join('|');
@@ -1069,7 +1041,7 @@ function persistIntegrityChecks(): void {
     }
     vscode.postMessage({
         type: 'saveIntegrityChecks',
-        state: { schemaVersion: 1, byteOrder: integrityState.byteOrder, checks },
+        state: { schemaVersion: 1, checks },
     });
 }
 
@@ -1078,7 +1050,6 @@ function applySelectedProfile(): void {
     if (!profile) { return; }
     integrityState.checks.forEach(cancelPendingCalculation);
     integrityState.checks = profile.checks.map(newCheck);
-    integrityState.byteOrder = profile.byteOrder;
     addCheckDraft = null;
     editingCheckId = null;
     clearHighlightedCheck();
@@ -1095,14 +1066,14 @@ function saveProfileAs(): void {
     if (profileNameExists(name)) { setProfileError(`A profile named “${name}” already exists.`); return; }
     const id = `integrity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     selectedProfileId = id;
-    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, byteOrder: integrityState.byteOrder, checks } });
+    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, checks } });
 }
 
 function updateSelectedProfile(): void {
     const current = profiles.find(profile => profile.id === selectedProfileId);
     const checks = activeConfigs();
     if (!current || !checks) { return; }
-    vscode.postMessage({ type: 'updateIntegrityProfile', profile: { ...current, byteOrder: integrityState.byteOrder, checks } });
+    vscode.postMessage({ type: 'updateIntegrityProfile', profile: { ...current, checks } });
 }
 
 function renameSelectedProfile(): void {

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -7,12 +7,14 @@ import {
     integrityBytesEqual,
     integrityBytesToHex,
     integrityValueToBytes,
+    mergeIntegrityEdits,
+    normalizeIntegrityCheckSet,
     normalizeIntegrityProfiles,
     parseIntegrityAddress,
     readStoredIntegrityBytes,
     type IntegrityAlgorithm,
-    type IntegrityByteOrder,
     type IntegrityCheckConfig,
+    type IntegrityCheckSet,
     type IntegrityProfile,
     type IntegrityRequest,
     type IntegrityResult,
@@ -20,7 +22,8 @@ import {
     validateIntegrityRange,
 } from './integrity';
 import { S } from './state';
-import { esc } from './utils';
+import { rerender } from './render';
+import { actionBtnsHtml, esc, formatHexHtml } from './utils';
 
 const DEBOUNCE_MS = 250;
 const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
@@ -31,6 +34,8 @@ const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
     ['sha-256', 'SHA-256'],
     ['sha-512', 'SHA-512'],
 ];
+const EMPTY_INTEGRITY_CHECK_SET: IntegrityCheckSet = { schemaVersion: 1, byteOrder: 'be', checks: [] };
+const INTEGRITY_STATUS_SYMBOLS: Record<string, string> = { Match: '✓', Mismatch: '✕', Calculated: '∑' };
 
 interface IntegrityCheckState {
     id: number;
@@ -38,57 +43,79 @@ interface IntegrityCheckState {
     startRaw: string;
     endRaw: string;
     storedRaw: string;
-    byteOrder: IntegrityByteOrder;
+    autoFixStoredValue: boolean;
     result: IntegrityResult | null;
     expectedBytes: Uint8Array | null;
     storedBytes: Uint8Array | null;
+    error: string;
+    meta: string;
+    calculating: boolean;
     timer: number | null;
     token: number;
 }
 
+interface IntegrityDraft {
+    algorithm: IntegrityAlgorithm;
+    startRaw: string;
+    endRaw: string;
+    storedRaw: string;
+}
+
 type PreparedCheck = { request: IntegrityRequest; storedField?: IntegrityStoredField };
 type IntegrityEditHandler = (edits: Array<[number, number]>) => void;
+type DraftValidation = { ok: true; value: IntegrityDraft } | { ok: false; error: string };
 
 let nextCheckId = 1;
 let editHandler: IntegrityEditHandler = () => {};
 let profiles: IntegrityProfile[] = [];
 let selectedProfileId = '';
 let profileError = '';
+let actionError = '';
+let addCheckDraft: IntegrityDraft | null = null;
+let editingCheckId: number | null = null;
+let highlightedCheckId: number | null = null;
 
 const integrityState = {
     initialized: false,
-    checks: [newCheck()],
+    byteOrder: 'be' as 'be' | 'le',
+    checks: [] as IntegrityCheckState[],
 };
 
 function newCheck(config?: IntegrityCheckConfig): IntegrityCheckState {
-    const persisted = config ? persistedCheckState(config) : blankCheckState();
+    const draft = config ? draftFromConfig(config) : blankDraft();
     return {
         id: nextCheckId++,
-        ...persisted,
+        ...draft,
+        autoFixStoredValue: config?.autoFixStoredValue ?? false,
         result: null,
         expectedBytes: null,
         storedBytes: null,
+        error: '',
+        meta: '',
+        calculating: false,
         timer: null,
         token: 0,
     };
 }
 
-function blankCheckState(): Pick<IntegrityCheckState, 'algorithm' | 'startRaw' | 'endRaw' | 'storedRaw' | 'byteOrder'> {
-    return { algorithm: 'crc32-iso-hdlc', startRaw: '', endRaw: '', storedRaw: '', byteOrder: 'be' };
+function blankDraft(): IntegrityDraft {
+    return { algorithm: 'crc32-iso-hdlc', startRaw: '', endRaw: '', storedRaw: '' };
 }
 
-function persistedCheckState(config: IntegrityCheckConfig): Pick<IntegrityCheckState, 'algorithm' | 'startRaw' | 'endRaw' | 'storedRaw' | 'byteOrder'> {
+function addDraft(): IntegrityDraft {
+    const draft = blankDraft();
+    if (S.selStart !== null) { draft.startRaw = formatIntegrityAddress(S.selStart); }
+    if (S.selEnd !== null) { draft.endRaw = formatIntegrityAddress(S.selEnd); }
+    return draft;
+}
+
+function draftFromConfig(config: IntegrityCheckConfig): IntegrityDraft {
     return {
         algorithm: config.algorithm,
         startRaw: formatIntegrityAddress(config.startAddress),
         endRaw: formatIntegrityAddress(config.endAddress),
-        storedRaw: formatOptionalAddress(config.storedAddress),
-        byteOrder: config.byteOrder,
+        storedRaw: config.storedAddress === undefined ? '' : formatIntegrityAddress(config.storedAddress),
     };
-}
-
-function formatOptionalAddress(address: number | undefined): string {
-    return address === undefined ? '' : formatIntegrityAddress(address);
 }
 
 export function setIntegrityEditHandler(handler: IntegrityEditHandler): void {
@@ -96,34 +123,126 @@ export function setIntegrityEditHandler(handler: IntegrityEditHandler): void {
 }
 
 export function setIntegrityProfiles(value: unknown, error = ''): void {
-    profiles = normalizeIntegrityProfiles(value);
+    const payload = integrityInitPayload(value);
+    profiles = normalizeIntegrityProfiles(integrityProfileValues(payload, value));
+    restoreIntegrityChecks(payload);
     profileError = error;
-    if (selectedProfileId && !profiles.some(profile => profile.id === selectedProfileId)) {
-        selectedProfileId = '';
-    }
-    if (document.getElementById('s-integrity')) { renderIntegrity(); }
+    clearMissingSelectedProfile();
+    refreshProfilesIfRendered();
+}
+
+function integrityProfileValues(payload: ReturnType<typeof integrityInitPayload>, fallback: unknown): unknown {
+    return payload ? payload.profiles : fallback;
+}
+
+function restoreIntegrityChecks(payload: ReturnType<typeof integrityInitPayload>): void {
+    if (payload) { setIntegrityChecks(payload.activeChecks); }
+}
+
+function clearMissingSelectedProfile(): void {
+    if (!selectedProfileId) { return; }
+    if (!profiles.some(profile => profile.id === selectedProfileId)) { selectedProfileId = ''; }
+}
+
+function refreshProfilesIfRendered(): void {
+    if (document.getElementById('s-integrity')) { refreshProfileLibrary(); }
+}
+
+function integrityInitPayload(value: unknown): { profiles: unknown; activeChecks: unknown } | null {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) { return null; }
+    const payload = value as { profiles?: unknown; activeChecks?: unknown };
+    return { profiles: payload.profiles, activeChecks: payload.activeChecks };
+}
+
+export function setIntegrityChecks(value: unknown): void {
+    const saved = normalizedIntegrityCheckSet(value);
+    cancelIntegrityCalculations();
+    integrityState.byteOrder = saved.byteOrder;
+    integrityState.checks = saved.checks.map(newCheck);
+    addCheckDraft = null;
+    editingCheckId = null;
+    highlightedCheckId = null;
+    clearIntegrityHighlight();
+}
+
+function normalizedIntegrityCheckSet(value: unknown): IntegrityCheckSet {
+    return normalizeIntegrityCheckSet(value) ?? EMPTY_INTEGRITY_CHECK_SET;
+}
+
+function cancelIntegrityCalculations(): void {
+    integrityState.checks.forEach(cancelPendingCalculation);
+}
+
+function refreshProfileLibrary(): void {
+    const current = document.querySelector<HTMLElement>('.integrity-profiles');
+    if (!current) { renderIntegrity(); return; }
+    current.outerHTML = profileLibraryHtml();
+    wireProfileControls();
 }
 
 export function renderIntegrity(): void {
     const panel = document.getElementById('s-integrity');
     if (!panel) { return; }
-    panel.innerHTML = `
+    panel.innerHTML = integrityShellHtml();
+    wireRenderedIntegrity(panel);
+}
+
+function integrityShellHtml(): string {
+    return `
         <div class="integrity-shell">
-            <div class="integrity-title">Integrity Checks</div>
-            <div class="integrity-help">Calculate and verify multiple inclusive mapped memory ranges.</div>
-            ${profileLibraryHtml()}
-            <div id="integrity-check-list">
-                ${integrityState.checks.map((check, index) => checkHtml(check, index)).join('')}
+            <div class="si-hdr-row integrity-hdr-row">
+                <span class="sb-hdr" style="margin:0">Integrity Checks ${integrityBadgeHtml()}</span>
+                ${endianToggleHtml()}
+                <button id="integrity-fix-all" class="struct-btn struct-btn-apply" type="button"${fixAllDisabledAttr()}>Fix all</button>
+                <button id="integrity-add-btn" class="si-add-btn"${addCheckDisabledAttr()}>＋ Add</button>
             </div>
-            <button id="integrity-add-check" class="integrity-add" type="button">+ Add check</button>
+            <div id="integrity-action-error" class="integrity-error" role="alert">${esc(actionError)}</div>
+            ${profileLibraryHtml()}
+            ${addCheckFormHtml()}
+            <div id="integrity-check-list">${checkCardsHtml()}</div>
         </div>`;
+}
+
+function fixAllDisabledAttr(): string {
+    return hasFixableMismatches() ? '' : ' disabled';
+}
+
+function addCheckDisabledAttr(): string {
+    return addCheckDraft ? ' disabled' : '';
+}
+
+function wireRenderedIntegrity(panel: HTMLElement): void {
+    wireHeaderControls();
     wireProfileControls();
-    integrityState.checks.forEach((check, index) => wireCheckControls(check, index));
-    document.getElementById('integrity-add-check')?.addEventListener('click', () => {
-        integrityState.checks.push(newCheck());
-        renderIntegrity();
-    });
-    if (integrityState.initialized) { integrityState.checks.forEach(scheduleIntegrityCalculation); }
+    if (addCheckDraft) { wireCheckForm('add'); }
+    wireCheckCards(panel);
+    integrityState.checks.forEach(updateCheckCard);
+}
+
+function integrityBadgeHtml(): string {
+    return integrityState.checks.length > 0 ? `<span class="sb-badge">${integrityState.checks.length}</span>` : '';
+}
+
+function addCheckFormHtml(): string {
+    return addCheckDraft ? checkFormHtml('add', addCheckDraft) : '';
+}
+
+function checkCardsHtml(): string {
+    if (integrityState.checks.length === 0) {
+        return '<div class="sb-empty integrity-empty">No integrity checks configured.</div>';
+    }
+    return integrityState.checks.map(checkCardHtml).join('');
+}
+
+function endianToggleHtml(): string {
+    return `
+        <div class="si-toggle-group" title="Stored-value byte order for all integrity checks">
+            <span class="si-toggle-label">Endian</span>
+            <div class="endian-tabs integrity-endian-tabs">
+                <button id="integrity-btn-le" class="${integrityState.byteOrder === 'le' ? 'active' : ''}">LE</button>
+                <button id="integrity-btn-be" class="${integrityState.byteOrder === 'be' ? 'active' : ''}">BE</button>
+            </div>
+        </div>`;
 }
 
 function profileLibraryHtml(): string {
@@ -132,75 +251,105 @@ function profileLibraryHtml(): string {
     ).join('');
     return `
         <div class="integrity-profiles">
-            <label class="integrity-field">
-                <span>Profile</span>
-                <select id="integrity-profile-select">
-                    <option value="">Select a saved profile…</option>${options}
-                </select>
-            </label>
+            <select id="integrity-profile-select" class="struct-sel" title="Saved integrity profile">
+                <option value="">Saved profiles…</option>${options}
+            </select>
             <div class="integrity-profile-actions">
-                <button id="integrity-profile-apply" type="button">Apply</button>
-                <button id="integrity-profile-save" type="button">Save as</button>
-                <button id="integrity-profile-update" type="button">Update</button>
-                <button id="integrity-profile-rename" type="button">Rename</button>
-                <button id="integrity-profile-delete" type="button">Delete</button>
+                <button id="integrity-profile-apply" class="struct-btn struct-btn-apply" type="button">Apply</button>
+                <button id="integrity-profile-save" class="struct-btn struct-btn-secondary" type="button">Save as</button>
+                <button id="integrity-profile-update" class="si-icon-btn" title="Update profile" type="button">↻</button>
+                <button id="integrity-profile-rename" class="si-icon-btn" title="Rename profile" type="button">✎</button>
+                <button id="integrity-profile-delete" class="si-icon-btn" title="Delete profile" type="button">🗑︎</button>
             </div>
             <div id="integrity-profile-error" class="integrity-error" role="alert">${esc(profileError)}</div>
         </div>`;
 }
 
-function checkHtml(check: IntegrityCheckState, index: number): string {
-    const suffix = checkControlSuffix(check, index);
-    const algorithmOptions = algorithmOptionsHtml(check.algorithm);
-    const byteOrderOptions = byteOrderOptionsHtml(check.byteOrder);
+function checkCardHtml(check: IntegrityCheckState): string {
     return `
-        <section class="integrity-check" data-check-id="${check.id}">
-            <div class="integrity-check-header">
-                <span>Check ${index + 1}</span>
-                <div class="integrity-check-actions">
-                    <button data-check-action="up" title="Move up"${disabledAttr(index === 0)}>↑</button>
-                    <button data-check-action="down" title="Move down"${disabledAttr(index === integrityState.checks.length - 1)}>↓</button>
-                    <button data-check-action="remove" title="Remove"${disabledAttr(integrityState.checks.length === 1)}>×</button>
+        <div class="${checkCardClass(check.id)}" data-check-id="${check.id}">
+            <div class="si-card-hdr" data-check-toggle>
+                <span class="integrity-card-status" data-check-status></span>
+                <div class="integrity-card-info">
+                    <div class="integrity-card-title">${esc(algorithmLabel(check.algorithm))}</div>
+                    <div class="integrity-card-meta">${esc(checkRangeSummary(check))}</div>
                 </div>
+                ${autoFixToggleHtml(check)}
+                ${actionBtnsHtml(`data-check-id="${check.id}"`, `data-check-id="${check.id}"`)}
             </div>
-            <label class="integrity-field"><span>Algorithm</span>
-                <select id="integrity-algorithm${suffix}" data-control="algorithm">
-                    ${algorithmOptions}
-                </select>
+            ${checkCardBodyHtml(check)}
+        </div>`;
+}
+
+function checkCardClass(id: number): string {
+    const selected = highlightedCheckId === id ? ' integrity-card-selected' : '';
+    return `si-card integrity-card si-expanded${selected}`;
+}
+
+function autoFixToggleHtml(check: IntegrityCheckState): string {
+    const disabled = !check.storedRaw;
+    const checked = !disabled && check.autoFixStoredValue;
+    return `<label class="integrity-auto-fix${disabledClass(disabled)}" title="Automatically stage mismatched stored values">
+        <input type="checkbox" data-auto-fix data-check-id="${check.id}"${checkedAttr(checked)}${disabledAttr(disabled)}>
+        <span class="integrity-auto-fix-label">Auto fix</span>
+        <span class="integrity-auto-fix-track" aria-hidden="true"><span class="integrity-auto-fix-knob"></span></span>
+    </label>`;
+}
+
+function disabledClass(disabled: boolean): string { return disabled ? ' disabled' : ''; }
+function checkedAttr(checked: boolean): string { return checked ? ' checked' : ''; }
+function disabledAttr(disabled: boolean): string { return disabled ? ' disabled' : ''; }
+
+function isMismatchedCheck(check: IntegrityCheckState): boolean {
+    return hasComparableStoredValue(check) && !integrityBytesEqual(check.expectedBytes, check.storedBytes);
+}
+
+function checkCardBodyHtml(check: IntegrityCheckState): string {
+    if (editingCheckId === check.id) { return checkFormHtml(`edit-${check.id}`, draftFromCheck(check)); }
+    return '<div class="integrity-card-body" data-check-body></div>';
+}
+
+function checkFormHtml(formId: string, draft: IntegrityDraft): string {
+    const presentation = checkFormPresentation(formId);
+    return `
+        <div class="integrity-check-form ${presentation.formClass}" data-integrity-form="${formId}">
+            <div class="sa-form-hdr ${presentation.headerClass}">${presentation.title}</div>
+            <label class="integrity-form-field"><span>Algorithm</span>
+                <select data-draft-control="algorithm" class="struct-sel">${algorithmOptionsHtml(draft.algorithm)}</select>
             </label>
-            <div class="integrity-address-grid">
-                <label class="integrity-field"><span>Start address</span>
-                    <input id="integrity-start${suffix}" data-control="start" type="text" spellcheck="false"
-                        placeholder="0x08000000" value="${esc(check.startRaw)}">
-                </label>
-                <label class="integrity-field"><span>End address <small>(inclusive)</small></span>
-                    <input id="integrity-end${suffix}" data-control="end" type="text" spellcheck="false"
-                        placeholder="0x080000FF" value="${esc(check.endRaw)}">
-                </label>
+            <div class="integrity-form-grid">
+                ${addressInputHtml('Start address', 'start', draft.startRaw, '08000000')}
+                ${addressInputHtml('End address (inclusive)', 'end', draft.endRaw, '080000FF')}
             </div>
-            <div class="integrity-address-grid stored">
-                <label class="integrity-field"><span>Stored value address <small>(optional)</small></span>
-                    <input id="integrity-stored${suffix}" data-control="stored" type="text" spellcheck="false"
-                        placeholder="0x08000100" value="${esc(check.storedRaw)}">
-                </label>
-                <label class="integrity-field"><span>Stored byte order</span>
-                    <select id="integrity-byte-order${suffix}" data-control="byte-order">
-                        ${byteOrderOptions}
-                    </select>
-                </label>
+            ${addressInputHtml('Stored value address (optional)', 'stored', draft.storedRaw, '08000100')}
+            <div class="integrity-form-error" data-form-error></div>
+            <div class="sa-row sa-btn-row">
+                <button class="struct-btn struct-btn-apply" data-form-action="save">${presentation.saveLabel}</button>
+                <button class="struct-btn struct-btn-cancel" data-form-action="cancel">Cancel</button>
             </div>
-            <div id="integrity-meta${suffix}" data-output="meta" class="integrity-meta"></div>
-            <div id="integrity-error${suffix}" data-output="error" class="integrity-error" role="alert"></div>
-            <div id="integrity-result${suffix}" data-output="result" class="integrity-result" hidden></div>
-        </section>`;
+        </div>`;
 }
 
-function checkControlSuffix(check: IntegrityCheckState, index: number): string {
-    return index === 0 ? '' : `-${check.id}`;
+function checkFormPresentation(formId: string): {
+    formClass: string;
+    headerClass: string;
+    title: string;
+    saveLabel: string;
+} {
+    if (formId === 'add') {
+        return { formClass: 'integrity-add-form', headerClass: 'sa-form-hdr-new', title: '＋ New Check', saveLabel: 'Add' };
+    }
+    return { formClass: 'integrity-edit-form', headerClass: 'sa-form-hdr-edit', title: '✎ Edit Check', saveLabel: 'Save' };
 }
 
-function disabledAttr(disabled: boolean): string {
-    return disabled ? ' disabled' : '';
+function addressInputHtml(label: string, control: string, value: string, placeholder: string): string {
+    return `
+        <label class="integrity-form-field"><span>${label}</span>
+            <div class="integrity-address-input"><span class="struct-addr-pfx">0x</span>
+                <input data-draft-control="${control}" class="struct-addr-inp" type="text" maxlength="8"
+                    placeholder="${placeholder}" value="${esc(stripHexPrefix(value))}" autocomplete="off" spellcheck="false">
+            </div>
+        </label>`;
 }
 
 function algorithmOptionsHtml(selected: IntegrityAlgorithm): string {
@@ -208,25 +357,28 @@ function algorithmOptionsHtml(selected: IntegrityAlgorithm): string {
         `<option value="${value}"${value === selected ? ' selected' : ''}>${label}</option>`).join('');
 }
 
-function byteOrderOptionsHtml(selected: IntegrityByteOrder): string {
-    return `<option value="be"${selected === 'be' ? ' selected' : ''}>Big-endian</option>` +
-        `<option value="le"${selected === 'le' ? ' selected' : ''}>Little-endian</option>`;
+function stripHexPrefix(value: string): string {
+    return value.replace(/^0x/i, '');
+}
+
+function draftFromCheck(check: IntegrityCheckState): IntegrityDraft {
+    return { algorithm: check.algorithm, startRaw: check.startRaw, endRaw: check.endRaw, storedRaw: check.storedRaw };
+}
+
+function algorithmLabel(algorithm: IntegrityAlgorithm): string {
+    return ALGORITHM_LABELS.find(([value]) => value === algorithm)?.[1] ?? algorithm;
+}
+
+function checkRangeSummary(check: IntegrityCheckState): string {
+    const range = check.startRaw && check.endRaw ? `${check.startRaw}–${check.endRaw}` : 'Not configured';
+    return check.storedRaw ? `${range} · stored ${check.storedRaw}` : range;
 }
 
 export function activateIntegrity(): void {
     if (integrityState.initialized) { return; }
     integrityState.initialized = true;
-    prefillFirstCheckFromSelection();
     renderIntegrity();
-}
-
-function prefillFirstCheckFromSelection(): void {
-    const first = integrityState.checks[0];
-    if (first.startRaw || first.endRaw) { return; }
-    const selection = selectedIntegrityRange();
-    if (!selection) { return; }
-    first.startRaw = formatIntegrityAddress(selection.start);
-    first.endRaw = formatIntegrityAddress(selection.end);
+    integrityState.checks.forEach(check => scheduleIntegrityCalculation(check));
 }
 
 function selectedIntegrityRange(): { start: number; end: number } | null {
@@ -236,48 +388,231 @@ function selectedIntegrityRange(): { start: number; end: number } | null {
 }
 
 export function notifyIntegrityBytesChanged(): void {
-    if (integrityState.initialized) { integrityState.checks.forEach(scheduleIntegrityCalculation); }
+    if (integrityState.initialized) {
+        integrityState.checks.forEach(check => scheduleIntegrityCalculation(check, true));
+    }
 }
 
-function wireCheckControls(check: IntegrityCheckState, index: number): void {
-    const card = cardFor(check);
-    if (!card) { return; }
-    const algorithm = card.querySelector<HTMLSelectElement>('[data-control="algorithm"]')!;
-    const start = card.querySelector<HTMLInputElement>('[data-control="start"]')!;
-    const end = card.querySelector<HTMLInputElement>('[data-control="end"]')!;
-    const stored = card.querySelector<HTMLInputElement>('[data-control="stored"]')!;
-    const byteOrder = card.querySelector<HTMLSelectElement>('[data-control="byte-order"]')!;
-    algorithm.addEventListener('change', () => { check.algorithm = algorithm.value as IntegrityAlgorithm; scheduleIntegrityCalculation(check); });
-    start.addEventListener('input', () => { check.startRaw = start.value; scheduleIntegrityCalculation(check); });
-    end.addEventListener('input', () => { check.endRaw = end.value; scheduleIntegrityCalculation(check); });
-    stored.addEventListener('input', () => { check.storedRaw = stored.value; scheduleIntegrityCalculation(check); });
-    byteOrder.addEventListener('change', () => { check.byteOrder = byteOrder.value as IntegrityByteOrder; scheduleIntegrityCalculation(check); });
-    card.querySelector('[data-check-action="up"]')?.addEventListener('click', () => moveCheck(index, -1));
-    card.querySelector('[data-check-action="down"]')?.addEventListener('click', () => moveCheck(index, 1));
-    card.querySelector('[data-check-action="remove"]')?.addEventListener('click', () => removeCheck(index));
+function wireHeaderControls(): void {
+    document.getElementById('integrity-btn-le')?.addEventListener('click', () => setSharedEndian('le'));
+    document.getElementById('integrity-btn-be')?.addEventListener('click', () => setSharedEndian('be'));
+    document.getElementById('integrity-fix-all')?.addEventListener('click', fixAllMismatches);
+    document.getElementById('integrity-add-btn')?.addEventListener('click', () => {
+        addCheckDraft = addDraft();
+        editingCheckId = null;
+        renderIntegrity();
+        document.querySelector<HTMLInputElement>('[data-integrity-form="add"] [data-draft-control="start"]')?.focus();
+    });
 }
 
-function moveCheck(index: number, direction: number): void {
-    const target = index + direction;
-    if (target < 0 || target >= integrityState.checks.length) { return; }
-    [integrityState.checks[index], integrityState.checks[target]] =
-        [integrityState.checks[target], integrityState.checks[index]];
+function setSharedEndian(endian: 'le' | 'be'): void {
+    if (integrityState.byteOrder === endian) { return; }
+    integrityState.byteOrder = endian;
+    persistIntegrityChecks();
+    renderIntegrity();
+    integrityState.checks.forEach(check => scheduleIntegrityCalculation(check));
+}
+
+function wireCheckCards(panel: HTMLElement): void {
+    panel.querySelectorAll<HTMLElement>('[data-check-toggle]').forEach(header => {
+        header.addEventListener('click', event => {
+            if ((event.target as HTMLElement).closest('.act-btn, .integrity-auto-fix')) { return; }
+            const card = header.closest<HTMLElement>('[data-check-id]');
+            if (!card || editingCheckId === Number(card.dataset.checkId)) { return; }
+            toggleHighlightedCheck(Number(card.dataset.checkId));
+        });
+    });
+    panel.querySelectorAll<HTMLInputElement>('[data-auto-fix]').forEach(toggle => {
+        toggle.addEventListener('change', () => setAutoFix(Number(toggle.dataset.checkId), toggle.checked));
+    });
+    panel.querySelectorAll<HTMLElement>('.integrity-card .act-btn-edit').forEach(button => {
+        button.addEventListener('click', () => editCheck(Number(button.dataset.checkId)));
+    });
+    panel.querySelectorAll<HTMLElement>('.integrity-card .act-btn-del').forEach(button => {
+        button.addEventListener('click', () => deleteCheck(Number(button.dataset.checkId)));
+    });
+    if (editingCheckId !== null) { wireCheckForm(`edit-${editingCheckId}`); }
+}
+
+function toggleHighlightedCheck(id: number): void {
+    if (highlightedCheckId === id) { clearHighlightedCheck(); }
+    else { highlightedCheckId = id; }
+    renderIntegrity();
+    syncIntegrityHighlight();
+}
+
+function editCheck(id: number): void {
+    addCheckDraft = null;
+    editingCheckId = id;
     renderIntegrity();
 }
 
-function removeCheck(index: number): void {
-    if (integrityState.checks.length === 1) { return; }
-    cancelPendingCalculation(integrityState.checks[index]);
-    integrityState.checks.splice(index, 1);
+function deleteCheck(id: number): void {
+    const check = integrityState.checks.find(item => item.id === id);
+    if (check) { cancelPendingCalculation(check); }
+    integrityState.checks = integrityState.checks.filter(item => item.id !== id);
+    if (editingCheckId === id) { editingCheckId = null; }
+    if (highlightedCheckId === id) { clearHighlightedCheck(); }
+    persistIntegrityChecks();
     renderIntegrity();
 }
 
-function scheduleIntegrityCalculation(check: IntegrityCheckState): void {
+function setAutoFix(id: number, enabled: boolean): void {
+    const check = integrityState.checks.find(item => item.id === id);
+    if (!check) { return; }
+    applyAutoFixSetting(check, enabled);
+}
+
+function applyAutoFixSetting(check: IntegrityCheckState, enabled: boolean): void {
+    if (!check.storedRaw) { return; }
+    check.autoFixStoredValue = enabled;
+    persistIntegrityChecks();
+    fixEnabledMismatch(check, enabled);
+}
+
+function fixEnabledMismatch(check: IntegrityCheckState, enabled: boolean): void {
+    if (!enabled) { return; }
+    if (isMismatchedCheck(check)) { updateStoredValue(check); }
+}
+
+type FixableIntegrityCheck = {
+    check: IntegrityCheckState;
+    update: { address: number; expected: Uint8Array };
+};
+
+function fixableIntegrityChecks(): FixableIntegrityCheck[] {
+    const fixable: FixableIntegrityCheck[] = [];
+    for (const check of integrityState.checks) {
+        if (!isMismatchedCheck(check)) { continue; }
+        const update = storedValueUpdate(check);
+        if (update) { fixable.push({ check, update }); }
+    }
+    return fixable;
+}
+
+function hasFixableMismatches(): boolean {
+    return integrityState.checks.some(isMismatchedCheck);
+}
+
+function fixAllMismatches(): void {
+    const fixable = fixableIntegrityChecks();
+    const edits = mergeIntegrityEdits(fixable.map(fixableCheckEdits));
+    if (!edits.ok) { setActionError(edits.error); return; }
+    if (edits.value.length === 0) { return; }
+    setActionError('');
+    editHandler(edits.value);
+    for (const item of fixable) {
+        item.check.storedBytes = Uint8Array.from(item.update.expected);
+        updateCheckCard(item.check);
+    }
+    syncIntegrityHighlight();
+}
+
+function fixableCheckEdits(item: FixableIntegrityCheck): Array<[number, number]> {
+    return Array.from(item.update.expected, (value, offset) => [item.update.address + offset, value]);
+}
+
+function setActionError(message: string): void {
+    actionError = message;
+    const error = document.getElementById('integrity-action-error');
+    if (error) { error.textContent = message; }
+}
+
+function wireCheckForm(formId: string): void {
+    const form = document.querySelector<HTMLElement>(`[data-integrity-form="${formId}"]`);
+    if (!form) { return; }
+    form.querySelector('[data-form-action="save"]')?.addEventListener('click', () => saveCheckForm(formId, form));
+    form.querySelector('[data-form-action="cancel"]')?.addEventListener('click', () => cancelCheckForm(formId));
+}
+
+function saveCheckForm(formId: string, form: HTMLElement): void {
+    const draft = readDraft(form);
+    if (!draft.ok) { showFormError(form, draft.error); return; }
+    if (formId === 'add') { saveNewCheck(draft.value); return; }
+    saveEditedCheck(Number(formId.replace('edit-', '')), draft.value);
+}
+
+function readDraft(form: HTMLElement): DraftValidation {
+    const algorithm = form.querySelector<HTMLSelectElement>('[data-draft-control="algorithm"]')!.value as IntegrityAlgorithm;
+    const startRaw = form.querySelector<HTMLInputElement>('[data-draft-control="start"]')!.value;
+    const endRaw = form.querySelector<HTMLInputElement>('[data-draft-control="end"]')!.value;
+    const storedRaw = form.querySelector<HTMLInputElement>('[data-draft-control="stored"]')!.value;
+    const range = validateIntegrityRange(startRaw, endRaw, algorithm);
+    if (!range.ok) { return range; }
+    if (storedRaw.trim()) {
+        const stored = parseIntegrityAddress(storedRaw, 'Stored value');
+        if (!stored.ok) { return stored; }
+    }
+    return {
+        ok: true,
+        value: {
+            algorithm,
+            startRaw: formatIntegrityAddress(range.value.startAddress),
+            endRaw: formatIntegrityAddress(range.value.endAddress),
+            storedRaw: normalizedOptionalAddress(storedRaw),
+        },
+    };
+}
+
+function normalizedOptionalAddress(raw: string): string {
+    if (!raw.trim()) { return ''; }
+    const parsed = parseIntegrityAddress(raw, 'Stored value');
+    return parsed.ok ? formatIntegrityAddress(parsed.value) : '';
+}
+
+function showFormError(form: HTMLElement, message: string): void {
+    const error = form.querySelector<HTMLElement>('[data-form-error]');
+    if (error) { error.textContent = message; }
+}
+
+function saveNewCheck(draft: IntegrityDraft): void {
+    const check = newCheck();
+    applyDraft(check, draft);
+    integrityState.checks.push(check);
+    addCheckDraft = null;
+    persistIntegrityChecks();
+    renderIntegrity();
+    scheduleIntegrityCalculation(check);
+}
+
+function saveEditedCheck(id: number, draft: IntegrityDraft): void {
+    const check = integrityState.checks.find(item => item.id === id);
+    if (!check) { return; }
+    applyDraft(check, draft);
+    if (!check.storedRaw) { check.autoFixStoredValue = false; }
+    editingCheckId = null;
+    persistIntegrityChecks();
+    renderIntegrity();
+    syncIntegrityHighlight();
+    scheduleIntegrityCalculation(check);
+}
+
+function applyDraft(check: IntegrityCheckState, draft: IntegrityDraft): void {
+    check.algorithm = draft.algorithm;
+    check.startRaw = draft.startRaw;
+    check.endRaw = draft.endRaw;
+    check.storedRaw = draft.storedRaw;
+    clearCheckResult(check);
+}
+
+function cancelCheckForm(formId: string): void {
+    if (formId === 'add') { addCheckDraft = null; }
+    else {
+        editingCheckId = null;
+    }
+    renderIntegrity();
+}
+
+function scheduleIntegrityCalculation(check: IntegrityCheckState, preserveResult = false): void {
     const token = ++check.token;
     cancelPendingCalculation(check);
-    clearResult(check);
+    if (preserveResult) { check.error = ''; }
+    else { clearCheckResult(check); }
     const prepared = prepareIntegrityRequest(check);
-    if (!prepared) { return; }
+    if (!prepared) { updateCheckCard(check); return; }
+    check.calculating = true;
+    check.meta = `Calculating ${formatByteCount(preparedByteCount(prepared))}…`;
+    updateCheckCard(check);
     check.timer = window.setTimeout(() => {
         check.timer = null;
         void calculateAndRender(check, token, prepared);
@@ -289,45 +624,45 @@ function cancelPendingCalculation(check: IntegrityCheckState): void {
     check.timer = null;
 }
 
-function prepareIntegrityRequest(check: IntegrityCheckState): PreparedCheck | null {
-    if (isBlankIntegrityRange(check)) {
-        showMeta(check, 'Enter a start and end address.');
-        showError(check, '');
-        return null;
-    }
-    const validation = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
-    if (!validation.ok) { showMeta(check, ''); showError(check, validation.error); return null; }
-    const stored = parseStoredField(check);
-    if (!stored.ok) { showMeta(check, ''); showError(check, stored.error); return null; }
-    showPreparedMeta(check, validation.value, stored.value);
-    showError(check, '');
-    return { request: validation.value, storedField: stored.value };
+function clearCheckResult(check: IntegrityCheckState): void {
+    check.result = null;
+    check.expectedBytes = null;
+    check.storedBytes = null;
+    check.error = '';
+    check.meta = '';
+    check.calculating = false;
 }
 
-function isBlankIntegrityRange(check: IntegrityCheckState): boolean {
-    return check.startRaw.trim() === '' && check.endRaw.trim() === '';
+function prepareIntegrityRequest(check: IntegrityCheckState): PreparedCheck | null {
+    if (isUnconfiguredCheck(check)) {
+        check.meta = 'Not configured';
+        return null;
+    }
+    const range = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
+    if (!range.ok) { check.error = range.error; return null; }
+    const stored = parseStoredField(check);
+    if (!stored.ok) { check.error = stored.error; return null; }
+    return { request: range.value, storedField: stored.value };
+}
+
+function isUnconfiguredCheck(check: IntegrityCheckState): boolean {
+    return !check.startRaw && !check.endRaw;
 }
 
 function parseStoredField(check: IntegrityCheckState): { ok: true; value?: IntegrityStoredField } | { ok: false; error: string } {
-    if (check.storedRaw.trim() === '') { return { ok: true, value: undefined }; }
+    if (!check.storedRaw) { return { ok: true, value: undefined }; }
     const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
     if (!stored.ok) { return stored; }
     return { ok: true, value: { startAddress: stored.value, byteLength: integrityOutputByteLength(check.algorithm) } };
 }
 
-function showPreparedMeta(check: IntegrityCheckState, request: IntegrityRequest, storedField?: IntegrityStoredField): void {
-    const excluded = storedField ? overlapByteCount(request, storedField) : 0;
-    const byteCount = request.endAddress - request.startAddress + 1 - excluded;
-    showMeta(check, `${formatByteCount(byteCount)}${excludedBytesLabel(excluded)}`);
-}
-
-function excludedBytesLabel(excluded: number): string {
-    if (excluded === 0) { return ''; }
-    return ` · ${excluded} stored byte${excluded === 1 ? '' : 's'} excluded`;
-}
-
 function integrityOutputByteLength(algorithm: IntegrityAlgorithm): number {
     return { 'crc16-ccitt-false': 2, 'crc32-iso-hdlc': 4, md5: 16, 'sha-1': 20, 'sha-256': 32, 'sha-512': 64 }[algorithm];
+}
+
+function preparedByteCount(prepared: PreparedCheck): number {
+    const total = prepared.request.endAddress - prepared.request.startAddress + 1;
+    return total - (prepared.storedField ? overlapByteCount(prepared.request, prepared.storedField) : 0);
 }
 
 function overlapByteCount(request: IntegrityRequest, field: IntegrityStoredField): number {
@@ -337,19 +672,26 @@ function overlapByteCount(request: IntegrityRequest, field: IntegrityStoredField
 }
 
 async function calculateAndRender(check: IntegrityCheckState, token: number, prepared: PreparedCheck): Promise<void> {
-    const readByte = (address: number) => S.edits.get(address) ?? getByte(address);
+    const readByte = getByte;
     const bytes = collectIntegrityBytes(prepared.request, readByte, prepared.storedField);
-    if (!bytes.ok) { showCurrentError(check, token, bytes.error); return; }
-    showMeta(check, `Calculating ${formatByteCount(bytes.value.length)}…`);
+    if (!bytes.ok) { applyCurrentError(check, token, bytes.error); return; }
     try {
         const result = await calculateIntegrity(prepared.request.algorithm, bytes.value);
-        renderCalculatedIfCurrent(check, token, result, prepared.storedField, readByte);
+        applyCalculatedResultIfCurrent(check, token, result, prepared.storedField, readByte);
     } catch (error) {
-        showCurrentError(check, token, calculationErrorMessage(error));
+        applyCurrentError(check, token, error instanceof Error ? error.message : 'Integrity calculation failed.');
     }
 }
 
-function renderCalculatedIfCurrent(
+function applyCurrentError(check: IntegrityCheckState, token: number, error: string): void {
+    if (token !== check.token) { return; }
+    check.calculating = false;
+    check.error = error;
+    updateCheckCard(check);
+    syncIntegrityHighlight();
+}
+
+function applyCalculatedResultIfCurrent(
     check: IntegrityCheckState,
     token: number,
     result: IntegrityResult,
@@ -357,123 +699,169 @@ function renderCalculatedIfCurrent(
     readByte: (address: number) => number | undefined,
 ): void {
     if (token !== check.token) { return; }
-    const storedError = applyCalculatedResult(check, result, storedField, readByte);
-    if (storedError) { showError(check, storedError); return; }
-    showMeta(check, formatByteCount(result.byteCount));
-    showResult(check, storedField);
-}
-
-function showCurrentError(check: IntegrityCheckState, token: number, message: string): void {
-    if (token === check.token) { showError(check, message); }
-}
-
-function calculationErrorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : 'Integrity calculation failed.';
-}
-
-function applyCalculatedResult(
-    check: IntegrityCheckState,
-    result: IntegrityResult,
-    storedField: IntegrityStoredField | undefined,
-    readByte: (address: number) => number | undefined,
-): string | null {
     check.result = result;
-    check.expectedBytes = integrityValueToBytes(result.value, check.byteOrder);
+    check.expectedBytes = integrityValueToBytes(result.value, integrityState.byteOrder);
     check.storedBytes = null;
-    if (!storedField) { return null; }
-    const stored = readStoredIntegrityBytes(storedField, readByte);
-    if (!stored.ok) { return stored.error; }
-    check.storedBytes = stored.value;
-    return null;
+    check.calculating = false;
+    check.meta = formatByteCount(result.byteCount);
+    if (storedField) {
+        const stored = readStoredIntegrityBytes(storedField, readByte);
+        if (!stored.ok) { check.error = stored.error; updateCheckCard(check); return; }
+        check.storedBytes = stored.value;
+    }
+    updateCheckCard(check);
+    maybeAutoFix(check);
+    syncIntegrityHighlight();
 }
 
-function showResult(check: IntegrityCheckState, storedField?: IntegrityStoredField): void {
-    const context = integrityResultContext(check);
-    if (!context) { return; }
-    const { result, calculated, expected } = context;
-    const matches = check.storedBytes ? integrityBytesEqual(expected, check.storedBytes) : null;
-    const suffix = resultControlSuffix(check);
-    result.innerHTML = `
-        ${comparisonStatusHtml(matches)}
-        <div class="integrity-result-label">Calculated</div>
-        <code id="integrity-value${suffix}" data-output="calculated">${esc(calculated.value)}</code>
-        ${storedValueHtml(check.storedBytes)}
-        <div class="integrity-result-actions">
-            <button id="integrity-copy${suffix}" data-result-action="copy" type="button">Copy</button>
-            ${updateStoredButtonHtml(matches, storedField)}
-        </div>`;
-    result.hidden = false;
-    result.querySelector('[data-result-action="copy"]')?.addEventListener('click', () => copyIntegrityResult(check));
-    result.querySelector('[data-result-action="update"]')?.addEventListener('click', () => updateStoredValue(check, storedField!));
+function updateCheckCard(check: IntegrityCheckState): void {
+    const card = document.querySelector<HTMLElement>(`.integrity-card[data-check-id="${check.id}"]`);
+    if (!card) { return; }
+    updateCheckCardStatus(card, check);
+    updateCheckCardBody(card, check);
+    updateFixAllControl();
 }
 
-function integrityResultContext(check: IntegrityCheckState): {
-    result: HTMLElement;
-    calculated: IntegrityResult;
-    expected: Uint8Array;
-} | null {
-    const result = cardFor(check)?.querySelector<HTMLElement>('[data-output="result"]');
-    if (!result) { return null; }
-    if (!check.result) { return null; }
+function updateCheckCardStatus(card: HTMLElement, check: IntegrityCheckState): void {
+    const status = card.querySelector<HTMLElement>('[data-check-status]');
+    if (!status) { return; }
+    const label = checkStatusLabel(check);
+    status.className = `integrity-card-status ${checkStatusClass(check)}`;
+    status.textContent = INTEGRITY_STATUS_SYMBOLS[label] ?? label;
+    status.title = label;
+    status.setAttribute('aria-label', label);
+}
+
+function updateCheckCardBody(card: HTMLElement, check: IntegrityCheckState): void {
+    const body = card.querySelector<HTMLElement>('[data-check-body]');
+    if (!body) { return; }
+    body.innerHTML = resultBodyHtml(check);
+}
+
+function updateFixAllControl(): void {
+    const button = document.getElementById('integrity-fix-all') as HTMLButtonElement | null;
+    if (button) { button.disabled = !hasFixableMismatches(); }
+}
+
+function checkStatusLabel(check: IntegrityCheckState): string {
+    if (check.error) { return 'Error'; }
+    if (check.result) { return completedCheckStatus(check); }
+    if (check.calculating) { return 'Calculating'; }
+    return completedCheckStatus(check);
+}
+
+function completedCheckStatus(check: IntegrityCheckState): string {
+    if (!check.result) { return 'Not configured'; }
+    if (!hasComparableStoredValue(check)) { return 'Calculated'; }
+    return integrityBytesEqual(check.expectedBytes, check.storedBytes) ? 'Match' : 'Mismatch';
+}
+
+function hasComparableStoredValue(check: IntegrityCheckState): check is IntegrityCheckState & {
+    expectedBytes: Uint8Array;
+    storedBytes: Uint8Array;
+} {
+    return !!check.storedBytes && !!check.expectedBytes;
+}
+
+function checkStatusClass(check: IntegrityCheckState): string {
+    return checkStatusLabel(check).toLocaleLowerCase().replace(' ', '-');
+}
+
+function resultBodyHtml(check: IntegrityCheckState): string {
+    if (check.error) { return `<div class="integrity-error">${esc(check.error)}</div>`; }
+    if (!check.result) { return `<div class="integrity-card-empty">${esc(check.meta || 'No result yet.')}</div>`; }
+    return calculatedResultBodyHtml(check, check.result);
+}
+
+function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityResult): string {
+    const stored = storedResultHtml(check);
+    return `
+        <div class="integrity-comparison${singleComparisonClass(stored)}">
+            <div class="integrity-value-pane calculated"><span>Calculated</span><code>${formatHexHtml(`0x${result.value}`)}</code></div>
+            ${stored}
+        </div>
+        <div class="integrity-result-meta">${esc(check.meta)}</div>`;
+}
+
+function singleComparisonClass(storedHtml: string): string {
+    return storedHtml ? '' : ' integrity-comparison-single';
+}
+
+function storedResultHtml(check: IntegrityCheckState): string {
+    if (!check.storedBytes) { return ''; }
+    const state = integrityHighlightStatus(check);
+    return `<div class="integrity-value-pane stored ${state}"><span>Stored</span><code>${formatHexHtml(`0x${integrityBytesToHex(check.storedBytes)}`)}</code></div>`;
+}
+
+function updateStoredValue(check: IntegrityCheckState): void {
+    const update = storedValueUpdate(check);
+    if (!update) { return; }
+    editHandler(Array.from(update.expected, (byte, offset) => [update.address + offset, byte]));
+    check.storedBytes = update.expected;
+    updateCheckCard(check);
+    syncIntegrityHighlight();
+}
+
+function maybeAutoFix(check: IntegrityCheckState): void {
+    if (check.autoFixStoredValue && isMismatchedCheck(check)) { updateStoredValue(check); }
+}
+
+function syncIntegrityHighlight(): void {
+    const check = integrityState.checks.find(item => item.id === highlightedCheckId);
+    if (!check) { clearIntegrityHighlight(); return; }
+    const highlight = integrityHighlightForCheck(check);
+    if (!highlight) { clearIntegrityHighlight(); return; }
+    S.integrityHighlight = highlight;
+    rerenderIntegrityMemory();
+}
+
+type IntegrityHighlight = NonNullable<typeof S.integrityHighlight>;
+
+function integrityHighlightForCheck(check: IntegrityCheckState): IntegrityHighlight | null {
+    const range = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
+    if (!range.ok) { return null; }
+    const highlight: IntegrityHighlight = {
+        rangeStart: range.value.startAddress,
+        rangeEnd: range.value.endAddress,
+        status: integrityHighlightStatus(check),
+    };
+    addStoredIntegrityHighlight(highlight, check);
+    return highlight;
+}
+
+function addStoredIntegrityHighlight(highlight: IntegrityHighlight, check: IntegrityCheckState): void {
+    if (!check.storedRaw) { return; }
+    const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
+    if (!stored.ok) { return; }
+    highlight.storedStart = stored.value;
+    highlight.storedLength = integrityOutputByteLength(check.algorithm);
+}
+
+function integrityHighlightStatus(check: IntegrityCheckState): 'match' | 'mismatch' | 'unverified' {
+    if (!hasComparableStoredValue(check)) { return 'unverified'; }
+    return integrityBytesEqual(check.expectedBytes, check.storedBytes) ? 'match' : 'mismatch';
+}
+
+function clearHighlightedCheck(): void {
+    highlightedCheckId = null;
+    clearIntegrityHighlight();
+}
+
+function clearIntegrityHighlight(): void {
+    S.integrityHighlight = null;
+    rerenderIntegrityMemory();
+}
+
+function rerenderIntegrityMemory(): void {
+    if (S.currentView === 'memory') { rerender.memory(); }
+}
+
+function storedValueUpdate(check: IntegrityCheckState): { address: number; expected: Uint8Array } | null {
     if (!check.expectedBytes) { return null; }
-    return { result, calculated: check.result, expected: check.expectedBytes };
-}
-
-function resultControlSuffix(check: IntegrityCheckState): string {
-    return check === integrityState.checks[0] ? '' : `-${check.id}`;
-}
-
-function comparisonStatusHtml(matches: boolean | null): string {
-    if (matches === null) { return ''; }
-    const state = matches ? 'match' : 'mismatch';
-    const label = matches ? 'Match' : 'Mismatch';
-    return `<div class="integrity-status ${state}">${label}</div>`;
-}
-
-function storedValueHtml(bytes: Uint8Array | null): string {
-    if (!bytes) { return ''; }
-    return `<div class="integrity-result-label stored-label">Stored</div><code>${integrityBytesToHex(bytes)}</code>`;
-}
-
-function updateStoredButtonHtml(matches: boolean | null, field?: IntegrityStoredField): string {
-    if (matches !== false) { return ''; }
-    return field ? '<button data-result-action="update" type="button">Update stored value</button>' : '';
-}
-
-function updateStoredValue(check: IntegrityCheckState, field: IntegrityStoredField): void {
-    if (!check.expectedBytes) { return; }
-    editHandler(Array.from(check.expectedBytes, (byte, offset) => [field.startAddress + offset, byte]));
-}
-
-function copyIntegrityResult(check: IntegrityCheckState): void {
-    if (!check.result) { return; }
-    vscode.postMessage({
-        type: 'copyText',
-        text: check.result.value,
-        label: ALGORITHM_LABELS.find(([value]) => value === check.result?.algorithm)?.[1] ?? 'integrity value',
-    });
-}
-
-function clearResult(check: IntegrityCheckState): void {
-    check.result = null;
-    check.expectedBytes = null;
-    check.storedBytes = null;
-    const result = cardFor(check)?.querySelector<HTMLElement>('[data-output="result"]');
-    if (result) { result.hidden = true; result.textContent = ''; }
-}
-
-function cardFor(check: IntegrityCheckState): HTMLElement | null {
-    return document.querySelector<HTMLElement>(`.integrity-check[data-check-id="${check.id}"]`);
-}
-
-function showMeta(check: IntegrityCheckState, message: string): void {
-    const meta = cardFor(check)?.querySelector<HTMLElement>('[data-output="meta"]');
-    if (meta) { meta.textContent = message; }
-}
-
-function showError(check: IntegrityCheckState, message: string): void {
-    const error = cardFor(check)?.querySelector<HTMLElement>('[data-output="error"]');
-    if (error) { error.textContent = message; }
+    if (!check.storedRaw) { return null; }
+    const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
+    if (!stored.ok) { return null; }
+    return { address: stored.value, expected: Uint8Array.from(check.expectedBytes) };
 }
 
 function formatByteCount(byteCount: number): string {
@@ -496,14 +884,20 @@ function wireProfileControls(): void {
 }
 
 function updateProfileButtonState(): void {
-    const disabled = !selectedProfileId;
-    ['apply', 'update', 'rename', 'delete'].forEach(action => {
+    const noProfile = !selectedProfileId;
+    ['apply', 'rename', 'delete'].forEach(action => {
         const button = document.getElementById(`integrity-profile-${action}`) as HTMLButtonElement | null;
-        if (button) { button.disabled = disabled; }
+        if (button) { button.disabled = noProfile; }
     });
+    const noChecks = integrityState.checks.length === 0;
+    const save = document.getElementById('integrity-profile-save') as HTMLButtonElement | null;
+    const update = document.getElementById('integrity-profile-update') as HTMLButtonElement | null;
+    if (save) { save.disabled = noChecks; }
+    if (update) { update.disabled = noProfile || noChecks; }
 }
 
 function activeConfigs(): IntegrityCheckConfig[] | null {
+    if (integrityState.checks.length === 0) { setProfileError('Add at least one integrity check.'); return null; }
     const configs: IntegrityCheckConfig[] = [];
     for (const check of integrityState.checks) {
         const config = activeConfig(check);
@@ -516,18 +910,23 @@ function activeConfigs(): IntegrityCheckConfig[] | null {
 function activeConfig(check: IntegrityCheckState): { ok: true; value: IntegrityCheckConfig } | { ok: false; error: string } {
     const range = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
     if (!range.ok) { return range; }
-    const stored = parseOptionalStoredAddress(check.storedRaw);
+    if (!check.storedRaw) { return { ok: true, value: { ...range.value, autoFixStoredValue: false } }; }
+    const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
     if (!stored.ok) { return stored; }
-    return { ok: true, value: { ...range.value, ...storedAddressProperty(stored.value), byteOrder: check.byteOrder } };
+    return { ok: true, value: { ...range.value, storedAddress: stored.value, autoFixStoredValue: check.autoFixStoredValue } };
 }
 
-function parseOptionalStoredAddress(raw: string): { ok: true; value?: number } | { ok: false; error: string } {
-    if (!raw.trim()) { return { ok: true, value: undefined }; }
-    return parseIntegrityAddress(raw, 'Stored value');
-}
-
-function storedAddressProperty(value: number | undefined): { storedAddress?: number } {
-    return value === undefined ? {} : { storedAddress: value };
+function persistIntegrityChecks(): void {
+    const checks: IntegrityCheckConfig[] = [];
+    for (const check of integrityState.checks) {
+        const config = activeConfig(check);
+        if (!config.ok) { return; }
+        checks.push(config.value);
+    }
+    vscode.postMessage({
+        type: 'saveIntegrityChecks',
+        state: { schemaVersion: 1, byteOrder: integrityState.byteOrder, checks },
+    });
 }
 
 function applySelectedProfile(): void {
@@ -535,7 +934,13 @@ function applySelectedProfile(): void {
     if (!profile) { return; }
     integrityState.checks.forEach(cancelPendingCalculation);
     integrityState.checks = profile.checks.map(newCheck);
+    integrityState.byteOrder = profile.byteOrder;
+    addCheckDraft = null;
+    editingCheckId = null;
+    clearHighlightedCheck();
+    persistIntegrityChecks();
     renderIntegrity();
+    integrityState.checks.forEach(check => scheduleIntegrityCalculation(check));
 }
 
 function saveProfileAs(): void {
@@ -546,14 +951,14 @@ function saveProfileAs(): void {
     if (profileNameExists(name)) { setProfileError(`A profile named “${name}” already exists.`); return; }
     const id = `integrity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     selectedProfileId = id;
-    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, checks } });
+    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, byteOrder: integrityState.byteOrder, checks } });
 }
 
 function updateSelectedProfile(): void {
     const current = profiles.find(profile => profile.id === selectedProfileId);
     const checks = activeConfigs();
     if (!current || !checks) { return; }
-    vscode.postMessage({ type: 'updateIntegrityProfile', profile: { ...current, checks } });
+    vscode.postMessage({ type: 'updateIntegrityProfile', profile: { ...current, byteOrder: integrityState.byteOrder, checks } });
 }
 
 function renameSelectedProfile(): void {
@@ -573,7 +978,7 @@ function promptedProfileName(currentName: string): string | null {
 
 function deleteSelectedProfile(): void {
     const current = profiles.find(profile => profile.id === selectedProfileId);
-    if (!current || !window.confirm(`Delete integrity profile “${current.name}”?`)) { return; }
+    if (!current) { return; }
     vscode.postMessage({ type: 'deleteIntegrityProfile', id: current.id });
 }
 

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -4,9 +4,19 @@ import {
     calculateIntegrity,
     collectIntegrityBytes,
     formatIntegrityAddress,
+    integrityBytesEqual,
+    integrityBytesToHex,
+    integrityValueToBytes,
+    normalizeIntegrityProfiles,
+    parseIntegrityAddress,
+    readStoredIntegrityBytes,
     type IntegrityAlgorithm,
+    type IntegrityByteOrder,
+    type IntegrityCheckConfig,
+    type IntegrityProfile,
     type IntegrityRequest,
     type IntegrityResult,
+    type IntegrityStoredField,
     validateIntegrityRange,
 } from './integrity';
 import { S } from './state';
@@ -22,15 +32,77 @@ const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
     ['sha-512', 'SHA-512'],
 ];
 
+interface IntegrityCheckState {
+    id: number;
+    algorithm: IntegrityAlgorithm;
+    startRaw: string;
+    endRaw: string;
+    storedRaw: string;
+    byteOrder: IntegrityByteOrder;
+    result: IntegrityResult | null;
+    expectedBytes: Uint8Array | null;
+    storedBytes: Uint8Array | null;
+    timer: number | null;
+    token: number;
+}
+
+type PreparedCheck = { request: IntegrityRequest; storedField?: IntegrityStoredField };
+type IntegrityEditHandler = (edits: Array<[number, number]>) => void;
+
+let nextCheckId = 1;
+let editHandler: IntegrityEditHandler = () => {};
+let profiles: IntegrityProfile[] = [];
+let selectedProfileId = '';
+let profileError = '';
+
 const integrityState = {
     initialized: false,
-    algorithm: 'crc32-iso-hdlc' as IntegrityAlgorithm,
-    startRaw: '',
-    endRaw: '',
-    result: null as IntegrityResult | null,
-    timer: null as number | null,
-    token: 0,
+    checks: [newCheck()],
 };
+
+function newCheck(config?: IntegrityCheckConfig): IntegrityCheckState {
+    const persisted = config ? persistedCheckState(config) : blankCheckState();
+    return {
+        id: nextCheckId++,
+        ...persisted,
+        result: null,
+        expectedBytes: null,
+        storedBytes: null,
+        timer: null,
+        token: 0,
+    };
+}
+
+function blankCheckState(): Pick<IntegrityCheckState, 'algorithm' | 'startRaw' | 'endRaw' | 'storedRaw' | 'byteOrder'> {
+    return { algorithm: 'crc32-iso-hdlc', startRaw: '', endRaw: '', storedRaw: '', byteOrder: 'be' };
+}
+
+function persistedCheckState(config: IntegrityCheckConfig): Pick<IntegrityCheckState, 'algorithm' | 'startRaw' | 'endRaw' | 'storedRaw' | 'byteOrder'> {
+    return {
+        algorithm: config.algorithm,
+        startRaw: formatIntegrityAddress(config.startAddress),
+        endRaw: formatIntegrityAddress(config.endAddress),
+        storedRaw: formatOptionalAddress(config.storedAddress),
+        byteOrder: config.byteOrder,
+    };
+}
+
+function formatOptionalAddress(address: number | undefined): string {
+    return address === undefined ? '' : formatIntegrityAddress(address);
+}
+
+export function setIntegrityEditHandler(handler: IntegrityEditHandler): void {
+    editHandler = handler;
+}
+
+export function setIntegrityProfiles(value: unknown, error = ''): void {
+    profiles = normalizeIntegrityProfiles(value);
+    profileError = error;
+    if (selectedProfileId && !profiles.some(profile => profile.id === selectedProfileId)) {
+        selectedProfileId = '';
+    }
+    if (document.getElementById('s-integrity')) { renderIntegrity(); }
+}
 
 export function renderIntegrity(): void {
     const panel = document.getElementById('s-integrity');
@@ -38,181 +110,480 @@ export function renderIntegrity(): void {
     panel.innerHTML = `
         <div class="integrity-shell">
             <div class="integrity-title">Integrity Checks</div>
-            <div class="integrity-help">Calculate over an inclusive mapped memory range.</div>
+            <div class="integrity-help">Calculate and verify multiple inclusive mapped memory ranges.</div>
+            ${profileLibraryHtml()}
+            <div id="integrity-check-list">
+                ${integrityState.checks.map((check, index) => checkHtml(check, index)).join('')}
+            </div>
+            <button id="integrity-add-check" class="integrity-add" type="button">+ Add check</button>
+        </div>`;
+    wireProfileControls();
+    integrityState.checks.forEach((check, index) => wireCheckControls(check, index));
+    document.getElementById('integrity-add-check')?.addEventListener('click', () => {
+        integrityState.checks.push(newCheck());
+        renderIntegrity();
+    });
+    if (integrityState.initialized) { integrityState.checks.forEach(scheduleIntegrityCalculation); }
+}
+
+function profileLibraryHtml(): string {
+    const options = profiles.map(profile =>
+        `<option value="${esc(profile.id)}"${profile.id === selectedProfileId ? ' selected' : ''}>${esc(profile.name)}</option>`
+    ).join('');
+    return `
+        <div class="integrity-profiles">
             <label class="integrity-field">
-                <span>Algorithm</span>
-                <select id="integrity-algorithm">
-                    ${ALGORITHM_LABELS.map(([value, label]) =>
-        `<option value="${value}"${value === integrityState.algorithm ? ' selected' : ''}>${label}</option>`).join('')}
+                <span>Profile</span>
+                <select id="integrity-profile-select">
+                    <option value="">Select a saved profile…</option>${options}
                 </select>
             </label>
-            <label class="integrity-field">
-                <span>Start address</span>
-                <input id="integrity-start" type="text" inputmode="text" spellcheck="false"
-                    placeholder="0x08000000" value="${esc(integrityState.startRaw)}">
-            </label>
-            <label class="integrity-field">
-                <span>End address <small>(inclusive)</small></span>
-                <input id="integrity-end" type="text" inputmode="text" spellcheck="false"
-                    placeholder="0x080000FF" value="${esc(integrityState.endRaw)}">
-            </label>
-            <div id="integrity-meta" class="integrity-meta"></div>
-            <div id="integrity-error" class="integrity-error" role="alert"></div>
-            <div id="integrity-result" class="integrity-result" hidden>
-                <div class="integrity-result-label">Result</div>
-                <code id="integrity-value"></code>
-                <button id="integrity-copy" type="button">Copy</button>
+            <div class="integrity-profile-actions">
+                <button id="integrity-profile-apply" type="button">Apply</button>
+                <button id="integrity-profile-save" type="button">Save as</button>
+                <button id="integrity-profile-update" type="button">Update</button>
+                <button id="integrity-profile-rename" type="button">Rename</button>
+                <button id="integrity-profile-delete" type="button">Delete</button>
             </div>
+            <div id="integrity-profile-error" class="integrity-error" role="alert">${esc(profileError)}</div>
         </div>`;
-    wireIntegrityControls();
-    if (integrityState.initialized) { scheduleIntegrityCalculation(); }
+}
+
+function checkHtml(check: IntegrityCheckState, index: number): string {
+    const suffix = checkControlSuffix(check, index);
+    const algorithmOptions = algorithmOptionsHtml(check.algorithm);
+    const byteOrderOptions = byteOrderOptionsHtml(check.byteOrder);
+    return `
+        <section class="integrity-check" data-check-id="${check.id}">
+            <div class="integrity-check-header">
+                <span>Check ${index + 1}</span>
+                <div class="integrity-check-actions">
+                    <button data-check-action="up" title="Move up"${disabledAttr(index === 0)}>↑</button>
+                    <button data-check-action="down" title="Move down"${disabledAttr(index === integrityState.checks.length - 1)}>↓</button>
+                    <button data-check-action="remove" title="Remove"${disabledAttr(integrityState.checks.length === 1)}>×</button>
+                </div>
+            </div>
+            <label class="integrity-field"><span>Algorithm</span>
+                <select id="integrity-algorithm${suffix}" data-control="algorithm">
+                    ${algorithmOptions}
+                </select>
+            </label>
+            <div class="integrity-address-grid">
+                <label class="integrity-field"><span>Start address</span>
+                    <input id="integrity-start${suffix}" data-control="start" type="text" spellcheck="false"
+                        placeholder="0x08000000" value="${esc(check.startRaw)}">
+                </label>
+                <label class="integrity-field"><span>End address <small>(inclusive)</small></span>
+                    <input id="integrity-end${suffix}" data-control="end" type="text" spellcheck="false"
+                        placeholder="0x080000FF" value="${esc(check.endRaw)}">
+                </label>
+            </div>
+            <div class="integrity-address-grid stored">
+                <label class="integrity-field"><span>Stored value address <small>(optional)</small></span>
+                    <input id="integrity-stored${suffix}" data-control="stored" type="text" spellcheck="false"
+                        placeholder="0x08000100" value="${esc(check.storedRaw)}">
+                </label>
+                <label class="integrity-field"><span>Stored byte order</span>
+                    <select id="integrity-byte-order${suffix}" data-control="byte-order">
+                        ${byteOrderOptions}
+                    </select>
+                </label>
+            </div>
+            <div id="integrity-meta${suffix}" data-output="meta" class="integrity-meta"></div>
+            <div id="integrity-error${suffix}" data-output="error" class="integrity-error" role="alert"></div>
+            <div id="integrity-result${suffix}" data-output="result" class="integrity-result" hidden></div>
+        </section>`;
+}
+
+function checkControlSuffix(check: IntegrityCheckState, index: number): string {
+    return index === 0 ? '' : `-${check.id}`;
+}
+
+function disabledAttr(disabled: boolean): string {
+    return disabled ? ' disabled' : '';
+}
+
+function algorithmOptionsHtml(selected: IntegrityAlgorithm): string {
+    return ALGORITHM_LABELS.map(([value, label]) =>
+        `<option value="${value}"${value === selected ? ' selected' : ''}>${label}</option>`).join('');
+}
+
+function byteOrderOptionsHtml(selected: IntegrityByteOrder): string {
+    return `<option value="be"${selected === 'be' ? ' selected' : ''}>Big-endian</option>` +
+        `<option value="le"${selected === 'le' ? ' selected' : ''}>Little-endian</option>`;
 }
 
 export function activateIntegrity(): void {
-    if (!integrityState.initialized) {
-        integrityState.initialized = true;
-        if (S.selStart !== null && S.selEnd !== null) {
-            integrityState.startRaw = formatIntegrityAddress(S.selStart);
-            integrityState.endRaw = formatIntegrityAddress(S.selEnd);
-        }
-        renderIntegrity();
-    }
+    if (integrityState.initialized) { return; }
+    integrityState.initialized = true;
+    prefillFirstCheckFromSelection();
+    renderIntegrity();
+}
+
+function prefillFirstCheckFromSelection(): void {
+    const first = integrityState.checks[0];
+    if (first.startRaw || first.endRaw) { return; }
+    const selection = selectedIntegrityRange();
+    if (!selection) { return; }
+    first.startRaw = formatIntegrityAddress(selection.start);
+    first.endRaw = formatIntegrityAddress(selection.end);
+}
+
+function selectedIntegrityRange(): { start: number; end: number } | null {
+    if (S.selStart === null) { return null; }
+    if (S.selEnd === null) { return null; }
+    return { start: S.selStart, end: S.selEnd };
 }
 
 export function notifyIntegrityBytesChanged(): void {
-    if (integrityState.initialized) { scheduleIntegrityCalculation(); }
+    if (integrityState.initialized) { integrityState.checks.forEach(scheduleIntegrityCalculation); }
 }
 
-function wireIntegrityControls(): void {
-    const algorithm = document.getElementById('integrity-algorithm') as HTMLSelectElement;
-    const start = document.getElementById('integrity-start') as HTMLInputElement;
-    const end = document.getElementById('integrity-end') as HTMLInputElement;
-
-    algorithm.addEventListener('change', () => {
-        integrityState.algorithm = algorithm.value as IntegrityAlgorithm;
-        scheduleIntegrityCalculation();
-    });
-    start.addEventListener('input', () => {
-        integrityState.startRaw = start.value;
-        scheduleIntegrityCalculation();
-    });
-    end.addEventListener('input', () => {
-        integrityState.endRaw = end.value;
-        scheduleIntegrityCalculation();
-    });
-    document.getElementById('integrity-copy')?.addEventListener('click', copyIntegrityResult);
+function wireCheckControls(check: IntegrityCheckState, index: number): void {
+    const card = cardFor(check);
+    if (!card) { return; }
+    const algorithm = card.querySelector<HTMLSelectElement>('[data-control="algorithm"]')!;
+    const start = card.querySelector<HTMLInputElement>('[data-control="start"]')!;
+    const end = card.querySelector<HTMLInputElement>('[data-control="end"]')!;
+    const stored = card.querySelector<HTMLInputElement>('[data-control="stored"]')!;
+    const byteOrder = card.querySelector<HTMLSelectElement>('[data-control="byte-order"]')!;
+    algorithm.addEventListener('change', () => { check.algorithm = algorithm.value as IntegrityAlgorithm; scheduleIntegrityCalculation(check); });
+    start.addEventListener('input', () => { check.startRaw = start.value; scheduleIntegrityCalculation(check); });
+    end.addEventListener('input', () => { check.endRaw = end.value; scheduleIntegrityCalculation(check); });
+    stored.addEventListener('input', () => { check.storedRaw = stored.value; scheduleIntegrityCalculation(check); });
+    byteOrder.addEventListener('change', () => { check.byteOrder = byteOrder.value as IntegrityByteOrder; scheduleIntegrityCalculation(check); });
+    card.querySelector('[data-check-action="up"]')?.addEventListener('click', () => moveCheck(index, -1));
+    card.querySelector('[data-check-action="down"]')?.addEventListener('click', () => moveCheck(index, 1));
+    card.querySelector('[data-check-action="remove"]')?.addEventListener('click', () => removeCheck(index));
 }
 
-function scheduleIntegrityCalculation(): void {
-    const token = ++integrityState.token;
-    cancelPendingCalculation();
-    clearResult();
+function moveCheck(index: number, direction: number): void {
+    const target = index + direction;
+    if (target < 0 || target >= integrityState.checks.length) { return; }
+    [integrityState.checks[index], integrityState.checks[target]] =
+        [integrityState.checks[target], integrityState.checks[index]];
+    renderIntegrity();
+}
 
-    const request = prepareIntegrityRequest();
-    if (!request) { return; }
-    integrityState.timer = window.setTimeout(() => {
-        integrityState.timer = null;
-        void calculateAndRender(token, request);
+function removeCheck(index: number): void {
+    if (integrityState.checks.length === 1) { return; }
+    cancelPendingCalculation(integrityState.checks[index]);
+    integrityState.checks.splice(index, 1);
+    renderIntegrity();
+}
+
+function scheduleIntegrityCalculation(check: IntegrityCheckState): void {
+    const token = ++check.token;
+    cancelPendingCalculation(check);
+    clearResult(check);
+    const prepared = prepareIntegrityRequest(check);
+    if (!prepared) { return; }
+    check.timer = window.setTimeout(() => {
+        check.timer = null;
+        void calculateAndRender(check, token, prepared);
     }, DEBOUNCE_MS);
 }
 
-function cancelPendingCalculation(): void {
-    if (integrityState.timer !== null) { window.clearTimeout(integrityState.timer); }
-    integrityState.timer = null;
+function cancelPendingCalculation(check: IntegrityCheckState): void {
+    if (check.timer !== null) { window.clearTimeout(check.timer); }
+    check.timer = null;
 }
 
-function prepareIntegrityRequest(): IntegrityRequest | null {
-    if (integrityState.startRaw.trim() === '' && integrityState.endRaw.trim() === '') {
-        showMeta('Enter a start and end address.');
-        showError('');
+function prepareIntegrityRequest(check: IntegrityCheckState): PreparedCheck | null {
+    if (isBlankIntegrityRange(check)) {
+        showMeta(check, 'Enter a start and end address.');
+        showError(check, '');
         return null;
     }
-
-    const validation = validateIntegrityRange(
-        integrityState.startRaw,
-        integrityState.endRaw,
-        integrityState.algorithm,
-    );
-    if (!validation.ok) {
-        showMeta('');
-        showError(validation.error);
-        return null;
-    }
-
-    const byteCount = validation.value.endAddress - validation.value.startAddress + 1;
-    showMeta(formatByteCount(byteCount));
-    showError('');
-    return validation.value;
+    const validation = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
+    if (!validation.ok) { showMeta(check, ''); showError(check, validation.error); return null; }
+    const stored = parseStoredField(check);
+    if (!stored.ok) { showMeta(check, ''); showError(check, stored.error); return null; }
+    showPreparedMeta(check, validation.value, stored.value);
+    showError(check, '');
+    return { request: validation.value, storedField: stored.value };
 }
 
-async function calculateAndRender(token: number, request: IntegrityRequest): Promise<void> {
-    const bytes = collectBytesOrShowError(token, request);
-    if (!bytes) { return; }
-    showMeta(`Calculating ${formatByteCount(bytes.length)}…`);
+function isBlankIntegrityRange(check: IntegrityCheckState): boolean {
+    return check.startRaw.trim() === '' && check.endRaw.trim() === '';
+}
+
+function parseStoredField(check: IntegrityCheckState): { ok: true; value?: IntegrityStoredField } | { ok: false; error: string } {
+    if (check.storedRaw.trim() === '') { return { ok: true, value: undefined }; }
+    const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
+    if (!stored.ok) { return stored; }
+    return { ok: true, value: { startAddress: stored.value, byteLength: integrityOutputByteLength(check.algorithm) } };
+}
+
+function showPreparedMeta(check: IntegrityCheckState, request: IntegrityRequest, storedField?: IntegrityStoredField): void {
+    const excluded = storedField ? overlapByteCount(request, storedField) : 0;
+    const byteCount = request.endAddress - request.startAddress + 1 - excluded;
+    showMeta(check, `${formatByteCount(byteCount)}${excludedBytesLabel(excluded)}`);
+}
+
+function excludedBytesLabel(excluded: number): string {
+    if (excluded === 0) { return ''; }
+    return ` · ${excluded} stored byte${excluded === 1 ? '' : 's'} excluded`;
+}
+
+function integrityOutputByteLength(algorithm: IntegrityAlgorithm): number {
+    return { 'crc16-ccitt-false': 2, 'crc32-iso-hdlc': 4, md5: 16, 'sha-1': 20, 'sha-256': 32, 'sha-512': 64 }[algorithm];
+}
+
+function overlapByteCount(request: IntegrityRequest, field: IntegrityStoredField): number {
+    const start = Math.max(request.startAddress, field.startAddress);
+    const end = Math.min(request.endAddress, field.startAddress + field.byteLength - 1);
+    return Math.max(0, end - start + 1);
+}
+
+async function calculateAndRender(check: IntegrityCheckState, token: number, prepared: PreparedCheck): Promise<void> {
+    const readByte = (address: number) => S.edits.get(address) ?? getByte(address);
+    const bytes = collectIntegrityBytes(prepared.request, readByte, prepared.storedField);
+    if (!bytes.ok) { showCurrentError(check, token, bytes.error); return; }
+    showMeta(check, `Calculating ${formatByteCount(bytes.value.length)}…`);
     try {
-        const result = await calculateIntegrity(request.algorithm, bytes);
-        applyResultIfCurrent(token, result);
+        const result = await calculateIntegrity(prepared.request.algorithm, bytes.value);
+        renderCalculatedIfCurrent(check, token, result, prepared.storedField, readByte);
     } catch (error) {
-        showCalculationErrorIfCurrent(token, error);
+        showCurrentError(check, token, calculationErrorMessage(error));
     }
 }
 
-function collectBytesOrShowError(token: number, request: IntegrityRequest): Uint8Array | null {
-    const bytes = collectIntegrityBytes(request, address => S.edits.get(address) ?? getByte(address));
-    if (!bytes.ok) {
-        if (token === integrityState.token) { showError(bytes.error); }
-        return null;
-    }
-    return bytes.value;
+function renderCalculatedIfCurrent(
+    check: IntegrityCheckState,
+    token: number,
+    result: IntegrityResult,
+    storedField: IntegrityStoredField | undefined,
+    readByte: (address: number) => number | undefined,
+): void {
+    if (token !== check.token) { return; }
+    const storedError = applyCalculatedResult(check, result, storedField, readByte);
+    if (storedError) { showError(check, storedError); return; }
+    showMeta(check, formatByteCount(result.byteCount));
+    showResult(check, storedField);
 }
 
-function applyResultIfCurrent(token: number, result: IntegrityResult): void {
-    if (token !== integrityState.token) { return; }
-    integrityState.result = result;
-    showMeta(formatByteCount(result.byteCount));
-    showResult(result.value);
+function showCurrentError(check: IntegrityCheckState, token: number, message: string): void {
+    if (token === check.token) { showError(check, message); }
 }
 
-function showCalculationErrorIfCurrent(token: number, error: unknown): void {
-    if (token !== integrityState.token) { return; }
-    showError(error instanceof Error ? error.message : 'Integrity calculation failed.');
+function calculationErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Integrity calculation failed.';
+}
+
+function applyCalculatedResult(
+    check: IntegrityCheckState,
+    result: IntegrityResult,
+    storedField: IntegrityStoredField | undefined,
+    readByte: (address: number) => number | undefined,
+): string | null {
+    check.result = result;
+    check.expectedBytes = integrityValueToBytes(result.value, check.byteOrder);
+    check.storedBytes = null;
+    if (!storedField) { return null; }
+    const stored = readStoredIntegrityBytes(storedField, readByte);
+    if (!stored.ok) { return stored.error; }
+    check.storedBytes = stored.value;
+    return null;
+}
+
+function showResult(check: IntegrityCheckState, storedField?: IntegrityStoredField): void {
+    const context = integrityResultContext(check);
+    if (!context) { return; }
+    const { result, calculated, expected } = context;
+    const matches = check.storedBytes ? integrityBytesEqual(expected, check.storedBytes) : null;
+    const suffix = resultControlSuffix(check);
+    result.innerHTML = `
+        ${comparisonStatusHtml(matches)}
+        <div class="integrity-result-label">Calculated</div>
+        <code id="integrity-value${suffix}" data-output="calculated">${esc(calculated.value)}</code>
+        ${storedValueHtml(check.storedBytes)}
+        <div class="integrity-result-actions">
+            <button id="integrity-copy${suffix}" data-result-action="copy" type="button">Copy</button>
+            ${updateStoredButtonHtml(matches, storedField)}
+        </div>`;
+    result.hidden = false;
+    result.querySelector('[data-result-action="copy"]')?.addEventListener('click', () => copyIntegrityResult(check));
+    result.querySelector('[data-result-action="update"]')?.addEventListener('click', () => updateStoredValue(check, storedField!));
+}
+
+function integrityResultContext(check: IntegrityCheckState): {
+    result: HTMLElement;
+    calculated: IntegrityResult;
+    expected: Uint8Array;
+} | null {
+    const result = cardFor(check)?.querySelector<HTMLElement>('[data-output="result"]');
+    if (!result) { return null; }
+    if (!check.result) { return null; }
+    if (!check.expectedBytes) { return null; }
+    return { result, calculated: check.result, expected: check.expectedBytes };
+}
+
+function resultControlSuffix(check: IntegrityCheckState): string {
+    return check === integrityState.checks[0] ? '' : `-${check.id}`;
+}
+
+function comparisonStatusHtml(matches: boolean | null): string {
+    if (matches === null) { return ''; }
+    const state = matches ? 'match' : 'mismatch';
+    const label = matches ? 'Match' : 'Mismatch';
+    return `<div class="integrity-status ${state}">${label}</div>`;
+}
+
+function storedValueHtml(bytes: Uint8Array | null): string {
+    if (!bytes) { return ''; }
+    return `<div class="integrity-result-label stored-label">Stored</div><code>${integrityBytesToHex(bytes)}</code>`;
+}
+
+function updateStoredButtonHtml(matches: boolean | null, field?: IntegrityStoredField): string {
+    if (matches !== false) { return ''; }
+    return field ? '<button data-result-action="update" type="button">Update stored value</button>' : '';
+}
+
+function updateStoredValue(check: IntegrityCheckState, field: IntegrityStoredField): void {
+    if (!check.expectedBytes) { return; }
+    editHandler(Array.from(check.expectedBytes, (byte, offset) => [field.startAddress + offset, byte]));
+}
+
+function copyIntegrityResult(check: IntegrityCheckState): void {
+    if (!check.result) { return; }
+    vscode.postMessage({
+        type: 'copyText',
+        text: check.result.value,
+        label: ALGORITHM_LABELS.find(([value]) => value === check.result?.algorithm)?.[1] ?? 'integrity value',
+    });
+}
+
+function clearResult(check: IntegrityCheckState): void {
+    check.result = null;
+    check.expectedBytes = null;
+    check.storedBytes = null;
+    const result = cardFor(check)?.querySelector<HTMLElement>('[data-output="result"]');
+    if (result) { result.hidden = true; result.textContent = ''; }
+}
+
+function cardFor(check: IntegrityCheckState): HTMLElement | null {
+    return document.querySelector<HTMLElement>(`.integrity-check[data-check-id="${check.id}"]`);
+}
+
+function showMeta(check: IntegrityCheckState, message: string): void {
+    const meta = cardFor(check)?.querySelector<HTMLElement>('[data-output="meta"]');
+    if (meta) { meta.textContent = message; }
+}
+
+function showError(check: IntegrityCheckState, message: string): void {
+    const error = cardFor(check)?.querySelector<HTMLElement>('[data-output="error"]');
+    if (error) { error.textContent = message; }
 }
 
 function formatByteCount(byteCount: number): string {
     return `${byteCount.toLocaleString()} byte${byteCount === 1 ? '' : 's'}`;
 }
 
-function copyIntegrityResult(): void {
-    if (!integrityState.result) { return; }
-    vscode.postMessage({
-        type: 'copyText',
-        text: integrityState.result.value,
-        label: ALGORITHM_LABELS.find(([value]) => value === integrityState.result?.algorithm)?.[1] ?? 'integrity value',
+function wireProfileControls(): void {
+    const select = document.getElementById('integrity-profile-select') as HTMLSelectElement;
+    select.addEventListener('change', () => {
+        selectedProfileId = select.value;
+        setProfileError('');
+        updateProfileButtonState();
+    });
+    document.getElementById('integrity-profile-apply')?.addEventListener('click', applySelectedProfile);
+    document.getElementById('integrity-profile-save')?.addEventListener('click', saveProfileAs);
+    document.getElementById('integrity-profile-update')?.addEventListener('click', updateSelectedProfile);
+    document.getElementById('integrity-profile-rename')?.addEventListener('click', renameSelectedProfile);
+    document.getElementById('integrity-profile-delete')?.addEventListener('click', deleteSelectedProfile);
+    updateProfileButtonState();
+}
+
+function updateProfileButtonState(): void {
+    const disabled = !selectedProfileId;
+    ['apply', 'update', 'rename', 'delete'].forEach(action => {
+        const button = document.getElementById(`integrity-profile-${action}`) as HTMLButtonElement | null;
+        if (button) { button.disabled = disabled; }
     });
 }
 
-function clearResult(): void {
-    integrityState.result = null;
-    const result = document.getElementById('integrity-result');
-    if (result) { result.hidden = true; }
-    const value = document.getElementById('integrity-value');
-    if (value) { value.textContent = ''; }
+function activeConfigs(): IntegrityCheckConfig[] | null {
+    const configs: IntegrityCheckConfig[] = [];
+    for (const check of integrityState.checks) {
+        const config = activeConfig(check);
+        if (!config.ok) { setProfileError(`Check ${configs.length + 1}: ${config.error}`); return null; }
+        configs.push(config.value);
+    }
+    return configs;
 }
 
-function showResult(value: string): void {
-    showError('');
-    const output = document.getElementById('integrity-value');
-    const result = document.getElementById('integrity-result');
-    if (output) { output.textContent = value; }
-    if (result) { result.hidden = false; }
+function activeConfig(check: IntegrityCheckState): { ok: true; value: IntegrityCheckConfig } | { ok: false; error: string } {
+    const range = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
+    if (!range.ok) { return range; }
+    const stored = parseOptionalStoredAddress(check.storedRaw);
+    if (!stored.ok) { return stored; }
+    return { ok: true, value: { ...range.value, ...storedAddressProperty(stored.value), byteOrder: check.byteOrder } };
 }
 
-function showMeta(message: string): void {
-    const meta = document.getElementById('integrity-meta');
-    if (meta) { meta.textContent = message; }
+function parseOptionalStoredAddress(raw: string): { ok: true; value?: number } | { ok: false; error: string } {
+    if (!raw.trim()) { return { ok: true, value: undefined }; }
+    return parseIntegrityAddress(raw, 'Stored value');
 }
 
-function showError(message: string): void {
-    const error = document.getElementById('integrity-error');
+function storedAddressProperty(value: number | undefined): { storedAddress?: number } {
+    return value === undefined ? {} : { storedAddress: value };
+}
+
+function applySelectedProfile(): void {
+    const profile = profiles.find(item => item.id === selectedProfileId);
+    if (!profile) { return; }
+    integrityState.checks.forEach(cancelPendingCalculation);
+    integrityState.checks = profile.checks.map(newCheck);
+    renderIntegrity();
+}
+
+function saveProfileAs(): void {
+    const checks = activeConfigs();
+    if (!checks) { return; }
+    const name = window.prompt('Profile name')?.trim();
+    if (!name) { return; }
+    if (profileNameExists(name)) { setProfileError(`A profile named “${name}” already exists.`); return; }
+    const id = `integrity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    selectedProfileId = id;
+    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, checks } });
+}
+
+function updateSelectedProfile(): void {
+    const current = profiles.find(profile => profile.id === selectedProfileId);
+    const checks = activeConfigs();
+    if (!current || !checks) { return; }
+    vscode.postMessage({ type: 'updateIntegrityProfile', profile: { ...current, checks } });
+}
+
+function renameSelectedProfile(): void {
+    const current = profiles.find(profile => profile.id === selectedProfileId);
+    if (!current) { return; }
+    const name = promptedProfileName(current.name);
+    if (!name) { return; }
+    if (profileNameExists(name, current.id)) { setProfileError(`A profile named “${name}” already exists.`); return; }
+    vscode.postMessage({ type: 'renameIntegrityProfile', id: current.id, name });
+}
+
+function promptedProfileName(currentName: string): string | null {
+    const name = window.prompt('Rename profile', currentName)?.trim();
+    if (!name) { return null; }
+    return name === currentName ? null : name;
+}
+
+function deleteSelectedProfile(): void {
+    const current = profiles.find(profile => profile.id === selectedProfileId);
+    if (!current || !window.confirm(`Delete integrity profile “${current.name}”?`)) { return; }
+    vscode.postMessage({ type: 'deleteIntegrityProfile', id: current.id });
+}
+
+function profileNameExists(name: string, exceptId = ''): boolean {
+    const normalized = name.toLocaleLowerCase();
+    return profiles.some(profile => profile.id !== exceptId && profile.name.toLocaleLowerCase() === normalized);
+}
+
+function setProfileError(message: string): void {
+    profileError = message;
+    const error = document.getElementById('integrity-profile-error');
     if (error) { error.textContent = message; }
 }

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -78,6 +78,7 @@ let profiles: IntegrityProfile[] = [];
 let selectedProfileId = '';
 let profileError = '';
 let actionError = '';
+let profileNameMode: 'create' | 'rename' | null = null;
 let addCheckDraft: IntegrityDraft | null = null;
 let editingCheckId: number | null = null;
 let highlightedCheckId: number | null = null;
@@ -256,8 +257,28 @@ function profileLibraryHtml(): string {
                 <button id="integrity-profile-rename" class="si-icon-btn" title="Rename profile" type="button">✎</button>
                 <button id="integrity-profile-delete" class="si-icon-btn" title="Delete profile" type="button">🗑︎</button>
             </div>
+            ${profileNameFormHtml()}
             <div id="integrity-profile-error" class="integrity-error" role="alert">${esc(profileError)}</div>
         </div>`;
+}
+
+function profileNameFormHtml(): string {
+    if (!profileNameMode) { return ''; }
+    return `<div class="integrity-profile-name-form">
+        <input id="integrity-profile-name" class="struct-addr-inp" type="text" maxlength="80"
+            value="${esc(profileNameValue())}" placeholder="Profile name" autocomplete="off" spellcheck="false">
+        <button id="integrity-profile-name-save" class="struct-btn struct-btn-apply" type="button">${profileNameAction()}</button>
+        <button id="integrity-profile-name-cancel" class="struct-btn struct-btn-cancel" type="button">Cancel</button>
+    </div>`;
+}
+
+function profileNameValue(): string {
+    if (profileNameMode !== 'rename') { return ''; }
+    return profiles.find(profile => profile.id === selectedProfileId)?.name ?? '';
+}
+
+function profileNameAction(): string {
+    return profileNameMode === 'rename' ? 'Rename' : 'Save';
 }
 
 function checkCardHtml(check: IntegrityCheckState): string {
@@ -996,7 +1017,19 @@ function wireProfileControls(): void {
     document.getElementById('integrity-profile-update')?.addEventListener('click', updateSelectedProfile);
     document.getElementById('integrity-profile-rename')?.addEventListener('click', renameSelectedProfile);
     document.getElementById('integrity-profile-delete')?.addEventListener('click', deleteSelectedProfile);
+    wireProfileNameForm();
     updateProfileButtonState();
+}
+
+function wireProfileNameForm(): void {
+    const input = document.getElementById('integrity-profile-name') as HTMLInputElement | null;
+    if (!input) { return; }
+    document.getElementById('integrity-profile-name-save')?.addEventListener('click', submitProfileName);
+    document.getElementById('integrity-profile-name-cancel')?.addEventListener('click', closeProfileNameForm);
+    input.addEventListener('keydown', event => {
+        if (event.key === 'Enter') { submitProfileName(); }
+        if (event.key === 'Escape') { closeProfileNameForm(); }
+    });
 }
 
 function updateProfileButtonState(): void {
@@ -1059,14 +1092,8 @@ function applySelectedProfile(): void {
 }
 
 function saveProfileAs(): void {
-    const checks = activeConfigs();
-    if (!checks) { return; }
-    const name = window.prompt('Profile name')?.trim();
-    if (!name) { return; }
-    if (profileNameExists(name)) { setProfileError(`A profile named “${name}” already exists.`); return; }
-    const id = `integrity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    selectedProfileId = id;
-    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, checks } });
+    if (!activeConfigs()) { return; }
+    openProfileNameForm('create');
 }
 
 function updateSelectedProfile(): void {
@@ -1079,16 +1106,51 @@ function updateSelectedProfile(): void {
 function renameSelectedProfile(): void {
     const current = profiles.find(profile => profile.id === selectedProfileId);
     if (!current) { return; }
-    const name = promptedProfileName(current.name);
-    if (!name) { return; }
-    if (profileNameExists(name, current.id)) { setProfileError(`A profile named “${name}” already exists.`); return; }
-    vscode.postMessage({ type: 'renameIntegrityProfile', id: current.id, name });
+    openProfileNameForm('rename');
 }
 
-function promptedProfileName(currentName: string): string | null {
-    const name = window.prompt('Rename profile', currentName)?.trim();
-    if (!name) { return null; }
-    return name === currentName ? null : name;
+function openProfileNameForm(mode: 'create' | 'rename'): void {
+    profileNameMode = mode;
+    setProfileError('');
+    refreshProfileLibrary();
+    document.getElementById('integrity-profile-name')?.focus();
+}
+
+function closeProfileNameForm(): void {
+    profileNameMode = null;
+    setProfileError('');
+    refreshProfileLibrary();
+}
+
+function submitProfileName(): void {
+    const input = document.getElementById('integrity-profile-name') as HTMLInputElement | null;
+    if (!input) { return; }
+    const name = input.value.trim();
+    if (!name) { setProfileError('Profile name is required.'); return; }
+    submitValidProfileName(name);
+}
+
+function submitValidProfileName(name: string): void {
+    if (profileNameMode === 'create') { createNamedProfile(name); return; }
+    if (profileNameMode === 'rename') { renameProfileTo(name); }
+}
+
+function createNamedProfile(name: string): void {
+    const checks = activeConfigs();
+    if (!checks) { return; }
+    if (profileNameExists(name)) { setProfileError(`A profile named “${name}” already exists.`); return; }
+    const id = `integrity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    selectedProfileId = id;
+    profileNameMode = null;
+    vscode.postMessage({ type: 'createIntegrityProfile', profile: { schemaVersion: 1, id, name, checks } });
+}
+
+function renameProfileTo(name: string): void {
+    const current = profiles.find(profile => profile.id === selectedProfileId);
+    if (!current || name === current.name) { closeProfileNameForm(); return; }
+    if (profileNameExists(name, current.id)) { setProfileError(`A profile named “${name}” already exists.`); return; }
+    profileNameMode = null;
+    vscode.postMessage({ type: 'renameIntegrityProfile', id: current.id, name });
 }
 
 function deleteSelectedProfile(): void {

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -274,7 +274,6 @@ function checkCardHtml(check: IntegrityCheckState): string {
                     <div class="integrity-card-title">${esc(algorithmLabel(check.algorithm))}</div>
                     <div class="integrity-card-meta">${esc(checkRangeSummary(check))}</div>
                 </div>
-                ${autoFixToggleHtml(check)}
                 ${actionBtnsHtml(`data-check-id="${check.id}"`, `data-check-id="${check.id}"`)}
             </div>
             ${checkCardBodyHtml(check)}
@@ -287,18 +286,13 @@ function checkCardClass(id: number): string {
 }
 
 function autoFixToggleHtml(check: IntegrityCheckState): string {
-    const disabled = !check.storedRaw;
-    const checked = !disabled && check.autoFixStoredValue;
-    return `<label class="integrity-auto-fix${disabledClass(disabled)}" title="Automatically stage mismatched stored values">
-        <input type="checkbox" data-auto-fix data-check-id="${check.id}"${checkedAttr(checked)}${disabledAttr(disabled)}>
+    const checked = check.autoFixStoredValue ? ' checked' : '';
+    return `<label class="integrity-auto-fix" title="Automatically stage mismatched stored values">
+        <input type="checkbox" data-auto-fix data-check-id="${check.id}"${checked}>
         <span class="integrity-auto-fix-label">Auto fix</span>
         <span class="integrity-auto-fix-track" aria-hidden="true"><span class="integrity-auto-fix-knob"></span></span>
     </label>`;
 }
-
-function disabledClass(disabled: boolean): string { return disabled ? ' disabled' : ''; }
-function checkedAttr(checked: boolean): string { return checked ? ' checked' : ''; }
-function disabledAttr(disabled: boolean): string { return disabled ? ' disabled' : ''; }
 
 function isMismatchedCheck(check: IntegrityCheckState): boolean {
     return hasComparableStoredValue(check) && !integrityBytesEqual(check.expectedBytes, check.storedBytes);
@@ -422,8 +416,9 @@ function wireCheckCards(panel: HTMLElement): void {
             toggleHighlightedCheck(Number(card.dataset.checkId));
         });
     });
-    panel.querySelectorAll<HTMLInputElement>('[data-auto-fix]').forEach(toggle => {
-        toggle.addEventListener('change', () => setAutoFix(Number(toggle.dataset.checkId), toggle.checked));
+    panel.addEventListener('change', event => {
+        const toggle = (event.target as HTMLElement).closest<HTMLInputElement>('[data-auto-fix]');
+        if (toggle) { setAutoFix(Number(toggle.dataset.checkId), toggle.checked); }
     });
     panel.querySelectorAll<HTMLElement>('.integrity-card .act-btn-edit').forEach(button => {
         button.addEventListener('click', () => editCheck(Number(button.dataset.checkId)));
@@ -431,7 +426,20 @@ function wireCheckCards(panel: HTMLElement): void {
     panel.querySelectorAll<HTMLElement>('.integrity-card .act-btn-del').forEach(button => {
         button.addEventListener('click', () => deleteCheck(Number(button.dataset.checkId)));
     });
+    panel.addEventListener('click', copyCalculatedValue);
     if (editingCheckId !== null) { wireCheckForm(`edit-${editingCheckId}`); }
+}
+
+function copyCalculatedValue(event: MouseEvent): void {
+    const button = (event.target as HTMLElement).closest<HTMLElement>('[data-copy-calculated]');
+    if (!button) { return; }
+    const check = integrityState.checks.find(item => item.id === Number(button.dataset.checkId));
+    if (!check?.result) { return; }
+    vscode.postMessage({
+        type: 'copyText',
+        text: `0x${check.result.value}`,
+        label: `${algorithmLabel(check.algorithm)} calculated value`,
+    });
 }
 
 function toggleHighlightedCheck(id: number): void {
@@ -777,7 +785,13 @@ function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityR
     const stored = storedResultHtml(check);
     return `
         <div class="integrity-comparison${singleComparisonClass(stored)}">
-            <div class="integrity-value-pane calculated"><span>Calculated</span><code>${formatHexHtml(`0x${result.value}`)}</code></div>
+            <div class="integrity-value-pane calculated">
+                <div class="integrity-value-hdr">
+                    <span>Calculated</span>
+                    <button class="integrity-copy-btn" type="button" data-copy-calculated data-check-id="${check.id}" title="Copy calculated value" aria-label="Copy calculated value">⧉</button>
+                </div>
+                <code>${formatHexHtml(`0x${result.value}`)}</code>
+            </div>
             ${stored}
         </div>
         <div class="integrity-result-meta">${esc(check.meta)}</div>`;
@@ -790,7 +804,10 @@ function singleComparisonClass(storedHtml: string): string {
 function storedResultHtml(check: IntegrityCheckState): string {
     if (!check.storedBytes) { return ''; }
     const state = integrityHighlightStatus(check);
-    return `<div class="integrity-value-pane stored ${state}"><span>Stored</span><code>${formatHexHtml(`0x${integrityBytesToHex(check.storedBytes)}`)}</code></div>`;
+    return `<div class="integrity-value-pane stored ${state}">
+        <div class="integrity-value-hdr"><span>Stored</span>${autoFixToggleHtml(check)}</div>
+        <code>${formatHexHtml(`0x${integrityBytesToHex(check.storedBytes)}`)}</code>
+    </div>`;
 }
 
 function updateStoredValue(check: IntegrityCheckState): void {

--- a/src/webview/integrityView.ts
+++ b/src/webview/integrityView.ts
@@ -7,6 +7,7 @@ import {
     integrityBytesEqual,
     integrityBytesToHex,
     integrityValueToBytes,
+    isChecksumAlgorithm,
     mergeIntegrityEdits,
     normalizeIntegrityCheckSet,
     normalizeIntegrityProfiles,
@@ -34,8 +35,10 @@ const ALGORITHM_LABELS: ReadonlyArray<readonly [IntegrityAlgorithm, string]> = [
     ['sha-256', 'SHA-256'],
     ['sha-512', 'SHA-512'],
 ];
-const EMPTY_INTEGRITY_CHECK_SET: IntegrityCheckSet = { schemaVersion: 1, byteOrder: 'be', checks: [] };
-const INTEGRITY_STATUS_SYMBOLS: Record<string, string> = { Match: '✓', Mismatch: '✕', Calculated: '∑' };
+const EMPTY_INTEGRITY_CHECK_SET: IntegrityCheckSet = { schemaVersion: 1, byteOrder: 'le', checks: [] };
+const INTEGRITY_STATUS_SYMBOLS: Record<string, string> = {
+    Match: '✓', Mismatch: '✕', Calculated: '∑', Calculating: '…', Error: '!', 'Not configured': '?',
+};
 
 interface IntegrityCheckState {
     id: number;
@@ -50,6 +53,8 @@ interface IntegrityCheckState {
     error: string;
     meta: string;
     calculating: boolean;
+    suppressAutoFixOnNextResult: boolean;
+    suppressedAutoFixMismatch: string;
     timer: number | null;
     token: number;
 }
@@ -64,6 +69,7 @@ interface IntegrityDraft {
 type PreparedCheck = { request: IntegrityRequest; storedField?: IntegrityStoredField };
 type IntegrityEditHandler = (edits: Array<[number, number]>) => void;
 type DraftValidation = { ok: true; value: IntegrityDraft } | { ok: false; error: string };
+type StoredDraftValidation = { ok: true; value: string } | { ok: false; error: string };
 
 let nextCheckId = 1;
 let editHandler: IntegrityEditHandler = () => {};
@@ -77,7 +83,7 @@ let highlightedCheckId: number | null = null;
 
 const integrityState = {
     initialized: false,
-    byteOrder: 'be' as 'be' | 'le',
+    byteOrder: 'le' as 'be' | 'le',
     checks: [] as IntegrityCheckState[],
 };
 
@@ -93,6 +99,8 @@ function newCheck(config?: IntegrityCheckConfig): IntegrityCheckState {
         error: '',
         meta: '',
         calculating: false,
+        suppressAutoFixOnNextResult: false,
+        suppressedAutoFixMismatch: '',
         timer: null,
         token: 0,
     };
@@ -287,7 +295,11 @@ function checkCardClass(id: number): string {
 
 function autoFixToggleHtml(check: IntegrityCheckState): string {
     const checked = check.autoFixStoredValue ? ' checked' : '';
-    return `<label class="integrity-auto-fix" title="Automatically stage mismatched stored values">
+    const paused = isAutoFixSuppressed(check);
+    const title = paused
+        ? 'Auto fix paused for this discarded mismatch. Toggle off and on or use Fix all to re-apply.'
+        : 'Automatically stage mismatched stored values';
+    return `<label class="integrity-auto-fix${paused ? ' paused' : ''}" title="${title}">
         <input type="checkbox" data-auto-fix data-check-id="${check.id}"${checked}>
         <span class="integrity-auto-fix-label">Auto fix</span>
         <span class="integrity-auto-fix-track" aria-hidden="true"><span class="integrity-auto-fix-knob"></span></span>
@@ -295,7 +307,8 @@ function autoFixToggleHtml(check: IntegrityCheckState): string {
 }
 
 function isMismatchedCheck(check: IntegrityCheckState): boolean {
-    return hasComparableStoredValue(check) && !integrityBytesEqual(check.expectedBytes, check.storedBytes);
+    return !check.calculating && hasComparableStoredValue(check) &&
+        !integrityBytesEqual(check.expectedBytes, check.storedBytes);
 }
 
 function checkCardBodyHtml(check: IntegrityCheckState): string {
@@ -315,7 +328,9 @@ function checkFormHtml(formId: string, draft: IntegrityDraft): string {
                 ${addressInputHtml('Start address', 'start', draft.startRaw, '08000000')}
                 ${addressInputHtml('End address (inclusive)', 'end', draft.endRaw, '080000FF')}
             </div>
-            ${addressInputHtml('Stored value address (optional)', 'stored', draft.storedRaw, '08000100')}
+            <div data-stored-field${isChecksumAlgorithm(draft.algorithm) ? '' : ' hidden'}>
+                ${addressInputHtml('Stored value address (optional)', 'stored', draft.storedRaw, '08000100')}
+            </div>
             <div class="integrity-form-error" data-form-error></div>
             <div class="sa-row sa-btn-row">
                 <button class="struct-btn struct-btn-apply" data-form-action="save">${presentation.saveLabel}</button>
@@ -387,6 +402,14 @@ export function notifyIntegrityBytesChanged(): void {
     }
 }
 
+export function notifyIntegrityEditsDiscarded(): void {
+    if (!integrityState.initialized) { return; }
+    for (const check of integrityState.checks) {
+        check.suppressAutoFixOnNextResult = check.autoFixStoredValue && !!check.storedRaw;
+        scheduleIntegrityCalculation(check, true);
+    }
+}
+
 function wireHeaderControls(): void {
     document.getElementById('integrity-btn-le')?.addEventListener('click', () => setSharedEndian('le'));
     document.getElementById('integrity-btn-be')?.addEventListener('click', () => setSharedEndian('be'));
@@ -402,9 +425,10 @@ function wireHeaderControls(): void {
 function setSharedEndian(endian: 'le' | 'be'): void {
     if (integrityState.byteOrder === endian) { return; }
     integrityState.byteOrder = endian;
+    integrityState.checks.forEach(clearAutoFixSuppression);
     persistIntegrityChecks();
     renderIntegrity();
-    integrityState.checks.forEach(check => scheduleIntegrityCalculation(check));
+    integrityState.checks.forEach(check => scheduleIntegrityCalculation(check, true));
 }
 
 function wireCheckCards(panel: HTMLElement): void {
@@ -435,9 +459,10 @@ function copyCalculatedValue(event: MouseEvent): void {
     if (!button) { return; }
     const check = integrityState.checks.find(item => item.id === Number(button.dataset.checkId));
     if (!check?.result) { return; }
+    const display = calculatedDisplay(check, check.result);
     vscode.postMessage({
         type: 'copyText',
-        text: `0x${check.result.value}`,
+        text: `0x${display.value}`,
         label: `${algorithmLabel(check.algorithm)} calculated value`,
     });
 }
@@ -472,7 +497,8 @@ function setAutoFix(id: number, enabled: boolean): void {
 }
 
 function applyAutoFixSetting(check: IntegrityCheckState, enabled: boolean): void {
-    if (!check.storedRaw) { return; }
+    if (!isChecksumAlgorithm(check.algorithm) || !check.storedRaw) { return; }
+    clearAutoFixSuppression(check);
     check.autoFixStoredValue = enabled;
     persistIntegrityChecks();
     fixEnabledMismatch(check, enabled);
@@ -508,6 +534,7 @@ function fixAllMismatches(): void {
     if (!edits.ok) { setActionError(edits.error); return; }
     if (edits.value.length === 0) { return; }
     setActionError('');
+    fixable.forEach(item => clearAutoFixSuppression(item.check));
     editHandler(edits.value);
     for (const item of fixable) {
         item.check.storedBytes = Uint8Array.from(item.update.expected);
@@ -531,6 +558,14 @@ function wireCheckForm(formId: string): void {
     if (!form) { return; }
     form.querySelector('[data-form-action="save"]')?.addEventListener('click', () => saveCheckForm(formId, form));
     form.querySelector('[data-form-action="cancel"]')?.addEventListener('click', () => cancelCheckForm(formId));
+    form.querySelector<HTMLSelectElement>('[data-draft-control="algorithm"]')?.addEventListener('change', event => {
+        updateStoredFieldVisibility(form, (event.target as HTMLSelectElement).value as IntegrityAlgorithm);
+    });
+}
+
+function updateStoredFieldVisibility(form: HTMLElement, algorithm: IntegrityAlgorithm): void {
+    const field = form.querySelector<HTMLElement>('[data-stored-field]');
+    if (field) { field.hidden = !isChecksumAlgorithm(algorithm); }
 }
 
 function saveCheckForm(formId: string, form: HTMLElement): void {
@@ -544,28 +579,28 @@ function readDraft(form: HTMLElement): DraftValidation {
     const algorithm = form.querySelector<HTMLSelectElement>('[data-draft-control="algorithm"]')!.value as IntegrityAlgorithm;
     const startRaw = form.querySelector<HTMLInputElement>('[data-draft-control="start"]')!.value;
     const endRaw = form.querySelector<HTMLInputElement>('[data-draft-control="end"]')!.value;
-    const storedRaw = form.querySelector<HTMLInputElement>('[data-draft-control="stored"]')!.value;
     const range = validateIntegrityRange(startRaw, endRaw, algorithm);
     if (!range.ok) { return range; }
-    if (storedRaw.trim()) {
-        const stored = parseIntegrityAddress(storedRaw, 'Stored value');
-        if (!stored.ok) { return stored; }
-    }
+    const stored = readStoredDraft(form, algorithm);
+    if (!stored.ok) { return stored; }
     return {
         ok: true,
         value: {
             algorithm,
             startRaw: formatIntegrityAddress(range.value.startAddress),
             endRaw: formatIntegrityAddress(range.value.endAddress),
-            storedRaw: normalizedOptionalAddress(storedRaw),
+            storedRaw: stored.value,
         },
     };
 }
 
-function normalizedOptionalAddress(raw: string): string {
-    if (!raw.trim()) { return ''; }
+function readStoredDraft(form: HTMLElement, algorithm: IntegrityAlgorithm): StoredDraftValidation {
+    if (!isChecksumAlgorithm(algorithm)) { return { ok: true, value: '' }; }
+    const raw = form.querySelector<HTMLInputElement>('[data-draft-control="stored"]')!.value;
+    if (!raw.trim()) { return { ok: true, value: '' }; }
     const parsed = parseIntegrityAddress(raw, 'Stored value');
-    return parsed.ok ? formatIntegrityAddress(parsed.value) : '';
+    if (!parsed.ok) { return parsed; }
+    return { ok: true, value: formatIntegrityAddress(parsed.value) };
 }
 
 function showFormError(form: HTMLElement, message: string): void {
@@ -599,7 +634,9 @@ function applyDraft(check: IntegrityCheckState, draft: IntegrityDraft): void {
     check.algorithm = draft.algorithm;
     check.startRaw = draft.startRaw;
     check.endRaw = draft.endRaw;
-    check.storedRaw = draft.storedRaw;
+    check.storedRaw = isChecksumAlgorithm(draft.algorithm) ? draft.storedRaw : '';
+    if (!check.storedRaw) { check.autoFixStoredValue = false; }
+    clearAutoFixSuppression(check);
     clearCheckResult(check);
 }
 
@@ -619,7 +656,7 @@ function scheduleIntegrityCalculation(check: IntegrityCheckState, preserveResult
     const prepared = prepareIntegrityRequest(check);
     if (!prepared) { updateCheckCard(check); return; }
     check.calculating = true;
-    check.meta = `Calculating ${formatByteCount(preparedByteCount(prepared))}…`;
+    if (!check.result) { check.meta = `Calculating ${formatByteCount(preparedByteCount(prepared))}…`; }
     updateCheckCard(check);
     check.timer = window.setTimeout(() => {
         check.timer = null;
@@ -658,6 +695,7 @@ function isUnconfiguredCheck(check: IntegrityCheckState): boolean {
 }
 
 function parseStoredField(check: IntegrityCheckState): { ok: true; value?: IntegrityStoredField } | { ok: false; error: string } {
+    if (!isChecksumAlgorithm(check.algorithm)) { return { ok: true, value: undefined }; }
     if (!check.storedRaw) { return { ok: true, value: undefined }; }
     const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
     if (!stored.ok) { return stored; }
@@ -753,8 +791,8 @@ function updateFixAllControl(): void {
 
 function checkStatusLabel(check: IntegrityCheckState): string {
     if (check.error) { return 'Error'; }
-    if (check.result) { return completedCheckStatus(check); }
     if (check.calculating) { return 'Calculating'; }
+    if (check.result) { return completedCheckStatus(check); }
     return completedCheckStatus(check);
 }
 
@@ -777,24 +815,75 @@ function checkStatusClass(check: IntegrityCheckState): string {
 
 function resultBodyHtml(check: IntegrityCheckState): string {
     if (check.error) { return `<div class="integrity-error">${esc(check.error)}</div>`; }
-    if (!check.result) { return `<div class="integrity-card-empty">${esc(check.meta || 'No result yet.')}</div>`; }
-    return calculatedResultBodyHtml(check, check.result);
+    if (check.result) { return calculatedResultBodyHtml(check, check.result); }
+    if (check.calculating) { return pendingResultBodyHtml(check); }
+    return emptyResultBodyHtml(check.meta);
 }
 
-function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityResult): string {
-    const stored = storedResultHtml(check);
+function emptyResultBodyHtml(meta: string): string {
+    return `<div class="integrity-card-empty">${esc(meta || 'No result yet.')}</div>`;
+}
+
+function pendingResultBodyHtml(check: IntegrityCheckState): string {
+    const stored = hasStoredChecksum(check) ? pendingStoredResultHtml(check) : '';
     return `
         <div class="integrity-comparison${singleComparisonClass(stored)}">
-            <div class="integrity-value-pane calculated">
+            <div class="integrity-value-pane calculated pending">
                 <div class="integrity-value-hdr">
-                    <span>Calculated</span>
-                    <button class="integrity-copy-btn" type="button" data-copy-calculated data-check-id="${check.id}" title="Copy calculated value" aria-label="Copy calculated value">⧉</button>
+                    <span>${calculatedLabel(check)}</span>
+                    <button class="integrity-copy-btn" type="button" title="Copy calculated value" aria-label="Copy calculated value" disabled>⧉</button>
                 </div>
-                <code>${formatHexHtml(`0x${result.value}`)}</code>
+                <code>${formatHexHtml('0x—')}</code>
             </div>
             ${stored}
         </div>
         <div class="integrity-result-meta">${esc(check.meta)}</div>`;
+}
+
+function pendingStoredResultHtml(check: IntegrityCheckState): string {
+    return `<div class="integrity-value-pane stored unverified pending">
+        <div class="integrity-value-hdr"><span>Stored</span>${autoFixToggleHtml(check)}</div>
+        <code>${formatHexHtml('0x—')}</code>
+    </div>`;
+}
+
+function calculatedResultBodyHtml(check: IntegrityCheckState, result: IntegrityResult): string {
+    const stored = storedResultHtml(check);
+    const display = calculatedDisplay(check, result);
+    return `
+        <div class="integrity-comparison${singleComparisonClass(stored)}">
+            <div class="integrity-value-pane calculated">
+                <div class="integrity-value-hdr">
+                    <span title="${display.title}">${display.label}</span>
+                    <button class="integrity-copy-btn" type="button" data-copy-calculated data-check-id="${check.id}" title="Copy calculated value" aria-label="Copy calculated value">⧉</button>
+                </div>
+                <code title="${display.title}">${formatHexHtml(`0x${display.value}`)}</code>
+            </div>
+            ${stored}
+        </div>
+        <div class="integrity-result-meta">${esc(check.meta)}</div>`;
+}
+
+function calculatedDisplay(
+    check: IntegrityCheckState,
+    result: IntegrityResult,
+): { label: string; value: string; title: string } {
+    if (!hasStoredChecksum(check) || !check.expectedBytes) {
+        return { label: 'Calculated', value: result.value, title: '' };
+    }
+    return {
+        label: calculatedLabel(check),
+        value: integrityBytesToHex(check.expectedBytes),
+        title: `Canonical checksum: 0x${result.value}`,
+    };
+}
+
+function calculatedLabel(check: IntegrityCheckState): string {
+    return hasStoredChecksum(check) ? `Calculated (${integrityState.byteOrder.toUpperCase()})` : 'Calculated';
+}
+
+function hasStoredChecksum(check: IntegrityCheckState): boolean {
+    return isChecksumAlgorithm(check.algorithm) && !!check.storedRaw;
 }
 
 function singleComparisonClass(storedHtml: string): string {
@@ -802,7 +891,7 @@ function singleComparisonClass(storedHtml: string): string {
 }
 
 function storedResultHtml(check: IntegrityCheckState): string {
-    if (!check.storedBytes) { return ''; }
+    if (!isChecksumAlgorithm(check.algorithm) || !check.storedBytes) { return ''; }
     const state = integrityHighlightStatus(check);
     return `<div class="integrity-value-pane stored ${state}">
         <div class="integrity-value-hdr"><span>Stored</span>${autoFixToggleHtml(check)}</div>
@@ -820,7 +909,45 @@ function updateStoredValue(check: IntegrityCheckState): void {
 }
 
 function maybeAutoFix(check: IntegrityCheckState): void {
-    if (check.autoFixStoredValue && isMismatchedCheck(check)) { updateStoredValue(check); }
+    if (!check.autoFixStoredValue) { return; }
+    const mismatch = autoFixMismatchKey(check);
+    if (!mismatch) { clearAutoFixSuppression(check); return; }
+    if (consumeAutoFixSuppression(check, mismatch)) { return; }
+    clearAutoFixSuppression(check);
+    updateStoredValue(check);
+}
+
+function consumeAutoFixSuppression(check: IntegrityCheckState, mismatch: string): boolean {
+    if (check.suppressAutoFixOnNextResult) {
+        check.suppressAutoFixOnNextResult = false;
+        check.suppressedAutoFixMismatch = mismatch;
+        updateCheckCard(check);
+        return true;
+    }
+    return check.suppressedAutoFixMismatch === mismatch;
+}
+
+function isAutoFixSuppressed(check: IntegrityCheckState): boolean {
+    const mismatch = autoFixMismatchKey(check);
+    return !!mismatch && check.suppressedAutoFixMismatch === mismatch;
+}
+
+function autoFixMismatchKey(check: IntegrityCheckState): string {
+    if (!isMismatchedCheck(check) || !check.expectedBytes || !check.storedBytes) { return ''; }
+    return [
+        check.algorithm,
+        check.startRaw,
+        check.endRaw,
+        check.storedRaw,
+        integrityState.byteOrder,
+        integrityBytesToHex(check.expectedBytes),
+        integrityBytesToHex(check.storedBytes),
+    ].join('|');
+}
+
+function clearAutoFixSuppression(check: IntegrityCheckState): void {
+    check.suppressAutoFixOnNextResult = false;
+    check.suppressedAutoFixMismatch = '';
 }
 
 function syncIntegrityHighlight(): void {
@@ -847,7 +974,7 @@ function integrityHighlightForCheck(check: IntegrityCheckState): IntegrityHighli
 }
 
 function addStoredIntegrityHighlight(highlight: IntegrityHighlight, check: IntegrityCheckState): void {
-    if (!check.storedRaw) { return; }
+    if (!hasStoredChecksum(check)) { return; }
     const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
     if (!stored.ok) { return; }
     highlight.storedStart = stored.value;
@@ -927,7 +1054,7 @@ function activeConfigs(): IntegrityCheckConfig[] | null {
 function activeConfig(check: IntegrityCheckState): { ok: true; value: IntegrityCheckConfig } | { ok: false; error: string } {
     const range = validateIntegrityRange(check.startRaw, check.endRaw, check.algorithm);
     if (!range.ok) { return range; }
-    if (!check.storedRaw) { return { ok: true, value: { ...range.value, autoFixStoredValue: false } }; }
+    if (!hasStoredChecksum(check)) { return { ok: true, value: { ...range.value, autoFixStoredValue: false } }; }
     const stored = parseIntegrityAddress(check.storedRaw, 'Stored value');
     if (!stored.ok) { return stored; }
     return { ok: true, value: { ...range.value, storedAddress: stored.value, autoFixStoredValue: check.autoFixStoredValue } };

--- a/src/webview/layout.css
+++ b/src/webview/layout.css
@@ -25,6 +25,21 @@
     background: var(--panel-bg); border-left: 1px solid var(--border);
     display: flex; flex-direction: column; overflow: hidden;
 }
+
+#sidebar-common-settings {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    color: var(--addr-fg);
+    display: flex;
+    flex-shrink: 0;
+    font-family: var(--font-ui);
+    font-size: 9px;
+    justify-content: space-between;
+    padding: 5px 12px;
+    text-transform: uppercase;
+}
+
+.sidebar-endian-tabs button { font-size: 9px; padding: 1px 6px; }
 .sb-section { padding: 10px 12px; border-bottom: 1px solid var(--border); }
 
 .sb-hdr {

--- a/src/webview/memory-view.css
+++ b/src/webview/memory-view.css
@@ -71,6 +71,19 @@
 /* Edited / dirty byte — amber underline */
 .data-cell.dirty, .char-cell.dirty { text-decoration: underline; text-decoration-color: #e5a800; text-underline-offset: 2px; color: #e5a800; }
 
+.data-cell.integrity-range, .char-cell.integrity-range {
+    background: rgba(70, 140, 255, .24) !important;
+}
+.data-cell.integrity-stored-match, .char-cell.integrity-stored-match {
+    background: rgba(55, 190, 105, .34) !important;
+}
+.data-cell.integrity-stored-mismatch, .char-cell.integrity-stored-mismatch {
+    background: rgba(235, 75, 85, .38) !important;
+}
+.data-cell.integrity-stored-unverified, .char-cell.integrity-stored-unverified {
+    background: rgba(225, 165, 45, .32) !important;
+}
+
 /* ── ASCII char cell (0.7× width, mirrors text cell) ─────────── */
 .char-cell {
     font-family: var(--font-editor); font-size: var(--font-size);

--- a/src/webview/memoryView.ts
+++ b/src/webview/memoryView.ts
@@ -359,9 +359,10 @@ function renderRow(base: number): string {
         } else {
             const hex   = val.toString(16).toUpperCase().padStart(2, '0');
             const dirty = S.edits.has(addr) ? ' dirty' : '';
-            hexCells.push(`<span class="data-cell ${byteClass(val)}${dirty}" data-col="${col}" data-addr="${ah}" data-val="${val}">${hex}</span>`);
+            const integrity = integrityHighlightClass(addr);
+            hexCells.push(`<span class="data-cell ${byteClass(val)}${dirty}${integrity}" data-col="${col}" data-addr="${ah}" data-val="${val}">${hex}</span>`);
             const p = val >= 0x20 && val < 0x7F;
-            chrCells.push(`<span class="char-cell ${p ? 'cp' : 'cd'}${dirty}" data-col="${col}" data-addr="${ah}">${p ? esc(String.fromCharCode(val)) : ''}</span>`);
+            chrCells.push(`<span class="char-cell ${p ? 'cp' : 'cd'}${dirty}${integrity}" data-col="${col}" data-addr="${ah}">${p ? esc(String.fromCharCode(val)) : ''}</span>`);
         }
     }
 
@@ -370,6 +371,26 @@ function renderRow(base: number): string {
         <div class="cell-group">${hexCells.join('')}</div>
         <div class="cell-group">${chrCells.join('')}</div>
     </div>`;
+}
+
+export function integrityHighlightClass(address: number): string {
+    const highlight = S.integrityHighlight;
+    if (!highlight) { return ''; }
+    if (isStoredIntegrityAddress(highlight, address)) { return ` integrity-stored-${highlight.status}`; }
+    if (isIntegrityRangeAddress(highlight, address)) { return ' integrity-range'; }
+    return '';
+}
+
+type IntegrityHighlight = NonNullable<typeof S.integrityHighlight>;
+
+function isStoredIntegrityAddress(highlight: IntegrityHighlight, address: number): boolean {
+    if (highlight.storedStart === undefined) { return false; }
+    if (highlight.storedLength === undefined) { return false; }
+    return address >= highlight.storedStart && address < highlight.storedStart + highlight.storedLength;
+}
+
+function isIntegrityRangeAddress(highlight: IntegrityHighlight, address: number): boolean {
+    return address >= highlight.rangeStart && address <= highlight.rangeEnd;
 }
 
 //  Selection highlight 

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -122,17 +122,17 @@
 }
 
 /* ── Multi-byte interpreter ──────────────────────────────────── */
-.endian-tabs {
+.compact-tabs {
     display: flex; gap: 2px;
     background: rgba(0,0,0,.2); border-radius: 3px; padding: 2px;
 }
-.endian-tabs button {
+.compact-tabs button {
     flex: 1; background: transparent; color: var(--addr-fg);
     border: none; border-radius: 2px; padding: 1px 8px; cursor: pointer;
     font-size: 11px; font-family: var(--font-ui); transition: background .1s, color .1s;
 }
-.endian-tabs button.active             { background: var(--btn-bg); color: var(--btn-fg); }
-.endian-tabs button:hover:not(.active) { color: var(--fg); }
+.compact-tabs button.active             { background: var(--btn-bg); color: var(--btn-fg); }
+.compact-tabs button:hover:not(.active) { color: var(--fg); }
 
 /* two-row control area */
 /* zero-pad note */

--- a/src/webview/sidebar.css
+++ b/src/webview/sidebar.css
@@ -135,10 +135,6 @@
 .endian-tabs button:hover:not(.active) { color: var(--fg); }
 
 /* two-row control area */
-.mi-ctrl-row   { display: flex; align-items: center; justify-content: space-between;
-                 margin-bottom: 6px; }
-.mi-ctrl-lbl   { font-size: 10px; color: var(--addr-fg); text-transform: uppercase; letter-spacing: .06em; }
-
 /* zero-pad note */
 .mi-pad-row  { margin-bottom: 5px; }
 .mi-pad-note { font-size: 9px; color: var(--non-graphic); font-style: italic; }

--- a/src/webview/sidebar.ts
+++ b/src/webview/sidebar.ts
@@ -339,16 +339,6 @@ function multiValueGroupHtml(width: number, values: MultiValues): string {
     );
 }
 
-function multiEndianControlsHtml(width: number, le: boolean): string {
-    if (width < 2) { return ''; }
-    return `<div class="mi-ctrl-row">` +
-        `<span class="mi-ctrl-lbl">Byte order</span>` +
-        `<div class="endian-tabs">` +
-        `<button id="btn-le" class="${le  ? 'active' : ''}">LE</button>` +
-        `<button id="btn-be" class="${!le ? 'active' : ''}">BE</button>` +
-        `</div></div>`;
-}
-
 function multiPadNoteHtml(selLen: number, width: number): string {
     return selLen < width
         ? `<div class="mi-pad-row"><span class="mi-pad-note">zero-padded to ${width * 8}-bit</span></div>`
@@ -356,9 +346,6 @@ function multiPadNoteHtml(selLen: number, width: number): string {
 }
 
 function wireMultiInlineControls(el: HTMLElement): void {
-    document.getElementById('btn-le')?.addEventListener('click', () => { S.endian = 'le'; renderMultiInline(); });
-    document.getElementById('btn-be')?.addEventListener('click', () => { S.endian = 'be'; renderMultiInline(); });
-
     el.querySelectorAll<HTMLElement>('.mi-dec[data-copy]').forEach(span => {
         span.addEventListener('click', e => {
             e.stopPropagation();
@@ -390,7 +377,6 @@ function renderMultiInline(): void {
     const group = multiValueGroupHtml(width, readMultiValues(raw, le));
 
     el.innerHTML =
-        multiEndianControlsHtml(width, le) +
         multiPadNoteHtml(selLen, width) +
         `<div class="mi-group">${group}</div>`;
 

--- a/src/webview/state.ts
+++ b/src/webview/state.ts
@@ -26,6 +26,13 @@ export const S = {
     structs:      [] as StructDef[],           // user-defined struct definitions
     activeStructAddr: null as number | null,   // base address for struct decode
     structPins:   [] as StructPin[],           // saved (structId, addr) overlay instances
+    integrityHighlight: null as null | {
+        rangeStart: number;
+        rangeEnd: number;
+        storedStart?: number;
+        storedLength?: number;
+        status: 'match' | 'mismatch' | 'unverified';
+    },
     sidebarTab:     'inspector' as SidebarTab,  // active sidebar tab
     lockedDueToExternalChange: false as boolean,  // view is locked pending external change action
 };

--- a/src/webview/struct-codec.ts
+++ b/src/webview/struct-codec.ts
@@ -8,7 +8,6 @@ import type {
     StructDef,
     StructField,
     StructFieldType,
-    StructFieldEndian,
     StructScalarFieldType,
 } from './types';
 
@@ -267,8 +266,6 @@ function formatStructCycle(stack: string[], byId: Map<string, StructDef>): strin
 export interface DecodedField {
     fieldName: string;
     type: StructScalarFieldType;
-    /** Effective byte endianness used to decode this row. */
-    endian: 'le' | 'be';
     /** Index within the array (0 for scalars). */
     arrayIdx: number;
     byteOffset: number;
@@ -513,7 +510,6 @@ function decodeBitFieldChildren(
             bytesHex,
             decoded: hasData ? bitFieldValueText(unsignedValue, width) : '??',
             hasData,
-            endian,
             isBitField: true,
             bitWidth: width,
             bitOffset: bitPos,
@@ -543,7 +539,6 @@ function decodeAsciiField(
         bytesHex: bytesToHex(raw),
         decoded: hasData ? decodeAsciiBytes(raw) : '??',
         hasData,
-        endian,
     });
     return offset + totalBytes;
 }
@@ -568,7 +563,6 @@ function decodeScalarFieldElement(
         bytesHex: bytesToHex(raw),
         decoded: hasData ? decodeField(raw, field.type, endian) : '??',
         hasData,
-        endian,
     });
 }
 
@@ -635,22 +629,20 @@ function decodeStructRecursive(
     for (const field of def.fields) {
         const align = def.packed ? 1 : fieldAlignWithDefs(field, map, depth);
         const elemSize = fieldSizeWithDefs(field, map, depth);
-        const endian = field.endian === 'inherit' ? globalEndian : field.endian;
-
-        // ── New: named BitField container (uint8/16/32/64 with bitFields[]) ──────
+        // Named BitField container (uint8/16/32/64 with bitFields[])
         if (isBitFieldContainer(field)) {
-            offset = decodeBitFieldContainer(ctx, field, offset, align, endian);
+            offset = decodeBitFieldContainer(ctx, field, offset, align, globalEndian);
             continue;
         }
 
         offset = alignUp(offset, align);
 
         if (field.type === 'ascii') {
-            offset = decodeAsciiField(ctx, field, offset, elemSize, endian);
+            offset = decodeAsciiField(ctx, field, offset, elemSize, globalEndian);
             continue;
         }
 
-        offset = decodeFieldElements(ctx, field, offset, elemSize, endian);
+        offset = decodeFieldElements(ctx, field, offset, elemSize, globalEndian);
     }
 
     if (!def.packed) {
@@ -751,7 +743,7 @@ function appendParsedBitField(
     const unitBits = fieldByteSize(type) * 8;
     const last = fields[fields.length - 1];
     const lastUsedBits = last?.bitFields?.reduce((sum, child) => sum + child.bitWidth, 0) ?? 0;
-    if (last && last.type === type && last.count === 1 && last.endian === 'inherit' &&
+    if (last && last.type === type && last.count === 1 &&
         Array.isArray(last.bitFields) && lastUsedBits + bitWidth <= unitBits) {
         last.bitFields.push({ name, bitWidth });
         return;
@@ -761,7 +753,6 @@ function appendParsedBitField(
         name,
         type,
         count: 1,
-        endian: 'inherit',
         bitFields: [{ name, bitWidth }],
     });
 }
@@ -786,20 +777,11 @@ function preserveMultilineCommentSpacing(text: string): string {
     });
 }
 
-function stripStructLine(rawLine: string): { stripped: string; comment: string } {
-    const blockComMatch = rawLine.match(/\/\*([^*\n]*)\*\//);
-    const blockComment = blockComMatch ? blockComMatch[1].trim() : '';
+function stripStructLine(rawLine: string): string {
     const noBlock = rawLine.replace(/\/\*[^*\n]*\*\//g, '');
     const slashIdx = noBlock.indexOf('//');
-    const lineComment = slashIdx >= 0 ? noBlock.slice(slashIdx + 2).trim() : '';
     const line = (slashIdx >= 0 ? noBlock.slice(0, slashIdx) : noBlock).trim();
-    return { stripped: line.replace(/;$/, '').trim(), comment: lineComment || blockComment };
-}
-
-function endianFromComment(comment: string): StructFieldEndian {
-    if (/\bbe\b/i.test(comment)) { return 'be'; }
-    if (/\ble\b/i.test(comment)) { return 'le'; }
-    return 'inherit';
+    return line.replace(/;$/, '').trim();
 }
 
 function parseBitFieldDeclaration(
@@ -825,7 +807,7 @@ function parseBitFieldDeclaration(
 }
 
 function parseStructDeclarationLine(rawLine: string): ParsedStructLine {
-    const { stripped, comment } = stripStructLine(rawLine);
+    const stripped = stripStructLine(rawLine);
     if (shouldSkipStructDeclaration(stripped)) { return { kind: 'skip' }; }
 
     const parts = parseStructDeclarationParts(stripped);
@@ -842,7 +824,7 @@ function parseStructDeclarationLine(rawLine: string): ParsedStructLine {
 
     return {
         kind: 'field',
-        field: { name: parts.fieldName, type: mapped, count: parts.count, endian: endianFromComment(comment) },
+        field: { name: parts.fieldName, type: mapped, count: parts.count },
     };
 }
 
@@ -918,8 +900,7 @@ export function fieldsToText(fields: StructField[], defs: StructDef[] = allStruc
         }
         const cType = typeNames[i].padEnd(maxTypeLen);
         const arr = f.count > 1 ? `[${f.count}]` : '';
-        const hint = f.endian !== 'inherit' ? `  // ${f.endian}` : '';
-        return `${cType} ${f.name}${arr};${hint}`;
+        return `${cType} ${f.name}${arr};`;
     }).join('\n');
 }
 
@@ -978,11 +959,9 @@ function emitScalarStructFieldC(f: StructField, fieldIndex: number, state: Struc
     const displayFieldName = f.name || `field${fieldIndex}`;
     const arr = f.count > 1 ? `[${f.count}]` : '';
     const fieldBytes = fieldSize * f.count;
-    const endianHint = f.endian !== 'inherit' ? `  /* ${f.endian} */` : '';
-
     state.lines.push(
         `    ${cType} ${displayFieldName}${arr};`.padEnd(44) +
-        `/* +${state.offset.toString().padStart(3)}  ${fieldBytes}B${endianHint} */`
+        `/* +${state.offset.toString().padStart(3)}  ${fieldBytes}B */`
     );
     state.offset += fieldBytes;
 }

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -309,7 +309,7 @@
     line-height: 1;
     white-space: nowrap;
 }
-.si-toggle-group .endian-tabs button { font-size: 9px; padding: 1px 5px; }
+.si-toggle-group .compact-tabs button { font-size: 9px; padding: 1px 5px; }
 
 .si-add-btn {
     flex-shrink: 0;

--- a/src/webview/struct.css
+++ b/src/webview/struct.css
@@ -353,7 +353,6 @@
 
 .sa-row { display: flex; align-items: center; gap: 4px; }
 .sa-btn-row { gap: 6px; }
-.sa-endian-tabs,
 .sa-bit-order-tabs { flex-shrink: 0; }
 
 /* Inline instance-edit form inside a card */

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -253,7 +253,7 @@ function renderBinaryFromBitRows(
     const missing = hasMissingByte(rawParts) || !first.hasData;
     if (!missing) {
         const raw = bytesFromHexParts(rawParts);
-        const value = bytesToValue(raw, first.endian);
+        const value = bytesToValue(raw, S.endian);
         const unitBits = raw.length * 8;
         const mask = (1n << BigInt(usedWidth)) - 1n;
         const slicedValue = S.bitFieldAllocation === 'lsb'
@@ -294,7 +294,7 @@ function renderBinaryStorageUnit(
 
     const bytes = bytesFromHexParts(rawParts);
     const bitCount = bytes.length * 8;
-    const bits = binaryBitsForValue(bytes, r.endian);
+    const bits = binaryBitsForValue(bytes, S.endian);
     const spans = [...bits].map((bit, displayIdx) => {
         const numericBitIdx = bitCount - displayIdx - 1;
         const storageBitIdx = S.bitFieldAllocation === 'lsb' ? numericBitIdx : displayIdx;
@@ -610,7 +610,6 @@ function syncEditorDraft(sec: HTMLElement, draft: StructDef): void {
             type,
             refStructId,
             count,
-            endian: 'inherit',
         };
         if (bitFields && bitFields.length > 0) {
             result.bitFields = bitFields;
@@ -641,7 +640,7 @@ function wireEditorInSec(sec: HTMLElement): void {
     sec.querySelector('#se-add')!.addEventListener('click', () => {
         syncEditorDraft(sec, draft);
         _editorError = null;
-        draft.fields.push({ name: `field${draft.fields.length}`, type: 'uint8', count: 1, endian: 'inherit' });
+        draft.fields.push({ name: `field${draft.fields.length}`, type: 'uint8', count: 1 });
         renderStructPins();
     });
 
@@ -1020,7 +1019,7 @@ export function renderStructPins(): void {
         `<span class="sb-hdr" style="margin:0">Struct Instances ${instBadge}</span>` +
         `<div class="si-toggle-group" title="Bit-field allocation: which side receives the first declared bit field">` +
         `<span class="si-toggle-label">Bit Layout</span>` +
-        `<div class="endian-tabs sa-bit-order-tabs">` +
+        `<div class="compact-tabs sa-bit-order-tabs">` +
         `<button id="sa-btn-bit-lsb" class="${S.bitFieldAllocation === 'lsb' ? 'active' : ''}" title="Bit-field allocation: first declared bit field starts at the least significant bit">LSB</button>` +
         `<button id="sa-btn-bit-msb" class="${S.bitFieldAllocation === 'msb' ? 'active' : ''}" title="Bit-field allocation: first declared bit field starts at the most significant bit">MSB</button>` +
         `</div>` +
@@ -1075,7 +1074,7 @@ export function renderStructPins(): void {
         _editorError = null;
         const draftId = `user_${Date.now()}`;
         _editingType = {
-            draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
+            draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1 }] },
             existing: null,
             fromAdd: false,
             fromManage: true,
@@ -1136,7 +1135,7 @@ export function renderStructPins(): void {
             _addingPin = false;
             const draftId = `user_${Date.now()}`;
             _editingType = {
-                draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1, endian: 'inherit' }] },
+                draft: { id: draftId, name: '', packed: false, fields: [{ name: 'field0', type: 'uint32', count: 1 }] },
                 existing: null,
                 fromAdd: true,
                 fromManage: false,
@@ -1225,7 +1224,7 @@ function getValForType(r: DecodedField, valType: ColType): string {
     if (isBitFieldRow(r)) { return renderBitFieldValue(r, valType); }
 
     const bytes = fieldBytes(r);
-    const endian = r.endian ?? S.endian;
+    const endian = S.endian;
     const dv = dataViewForBytes(bytes);
     return renderScalarValue(r, valType, bytes, dv, endian);
 }
@@ -1416,7 +1415,7 @@ function getCopyText(r: DecodedField, valType: ColType): string {
 
 function copyNonAsciiFieldValue(r: DecodedField, valType: ColType): string {
     const bytes = fieldBytes(r);
-    const endian = r.endian ?? S.endian;
+    const endian = S.endian;
     const le = endian === 'le';
     if (r.type === 'pointer') {
         const dv = dataViewForBytes(bytes);
@@ -1602,7 +1601,7 @@ function groupSummaryLabel(rows: DecodedField[], fallback: string): string {
     const raw = bytesFromHexParts(rawParts);
     if (raw.some(v => !Number.isFinite(v) || v < 0 || v > 0xFF)) { return '??'; }
 
-    const value = bytesToValue(raw, first.endian);
+    const value = bytesToValue(raw, S.endian);
     const hex = value.toString(16).toUpperCase().padStart(raw.length * 2, '0');
     return `0x${hex} (${value.toString(10)})`;
 }
@@ -1615,7 +1614,7 @@ function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
     const rawParts = byteHexParts(first.bytesHex);
     if (usedWidth > 0 && !hasMissingByte(rawParts) && first.hasData) {
         const raw = bytesFromHexParts(rawParts);
-        const value = bytesToValue(raw, first.endian);
+        const value = bytesToValue(raw, S.endian);
         const unitBits = raw.length * 8;
         const mask = (1n << BigInt(usedWidth)) - 1n;
         const sliced = S.bitFieldAllocation === 'lsb'
@@ -1631,7 +1630,6 @@ function buildBitUnitAggregateRow(rows: DecodedField[]): DecodedField | null {
         bytesHex: first.bytesHex,
         decoded: first.decoded,
         hasData: first.hasData,
-        endian: first.endian,
         bitWidth: usedWidth,
         bitStorageByteSize: first.bitStorageByteSize,
         bitValueUnsigned: slicedValue,

--- a/src/webview/struct.ts
+++ b/src/webview/struct.ts
@@ -1018,13 +1018,6 @@ export function renderStructPins(): void {
         `<div class="si-main-panel">` +
         `<div class="si-hdr-row">` +
         `<span class="sb-hdr" style="margin:0">Struct Instances ${instBadge}</span>` +
-        `<div class="si-toggle-group" title="Byte endianness: how multi-byte scalar values are interpreted">` +
-        `<span class="si-toggle-label">Endian</span>` +
-        `<div class="endian-tabs sa-endian-tabs">` +
-        `<button id="sa-btn-le" class="${S.endian === 'le' ? 'active' : ''}" title="Interpret multi-byte scalar values as little-endian">LE</button>` +
-        `<button id="sa-btn-be" class="${S.endian === 'be' ? 'active' : ''}" title="Interpret multi-byte scalar values as big-endian">BE</button>` +
-        `</div>` +
-        `</div>` +
         `<div class="si-toggle-group" title="Bit-field allocation: which side receives the first declared bit field">` +
         `<span class="si-toggle-label">Bit Layout</span>` +
         `<div class="endian-tabs sa-bit-order-tabs">` +
@@ -1187,20 +1180,6 @@ export function renderStructPins(): void {
             renderStructPins();
         });
     }
-
-    // ── Byte endianness tabs ──
-    document.getElementById('sa-btn-le')?.addEventListener('click', () => {
-        S.endian = 'le';
-        document.getElementById('sa-btn-le')?.classList.add('active');
-        document.getElementById('sa-btn-be')?.classList.remove('active');
-        if (_expanded.size > 0) { renderStructPins(); }
-    });
-    document.getElementById('sa-btn-be')?.addEventListener('click', () => {
-        S.endian = 'be';
-        document.getElementById('sa-btn-be')?.classList.add('active');
-        document.getElementById('sa-btn-le')?.classList.remove('active');
-        if (_expanded.size > 0) { renderStructPins(); }
-    });
 
     // ── Bit-field allocation tabs ──
     document.getElementById('sa-btn-bit-lsb')?.addEventListener('click', () => {

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -58,8 +58,6 @@ export type StructScalarFieldType =
 
 export type StructFieldType = StructScalarFieldType | 'struct';
 
-export type StructFieldEndian = 'le' | 'be' | 'inherit';
-
 /** A single named child of a BitField container field. */
 export interface BitFieldChild {
     name: string;
@@ -76,7 +74,6 @@ export interface StructField {
     bitFields?: BitFieldChild[];
     /** Array element count; 1 for a scalar field. */
     count: number;
-    endian: StructFieldEndian;
     /** Whether the bit-field detail editor is collapsed. Only applies to BitField containers. */
     bitFieldsCollapsed?: boolean;
 }


### PR DESCRIPTION
Introduce a new `INTEGRITY CHECKS` tab on the HexScope viewer sidebar

<img width="712" height="584" alt="image" src="https://github.com/user-attachments/assets/0d482e33-7c74-48ab-9081-2a2be2e1203e" />

### Added

- Added an Integrity Checks sidebar for CRC16/CCITT-FALSE, CRC32/ISO-HDLC, MD5, SHA-1, SHA-256, and SHA-512 calculations
- Added multiple independently configurable integrity checks per firmware image
- Added CRC comparison against values stored in firmware, with overlap exclusion, match status, and highlighted calculation and stored-value ranges; hash checks remain calculation-only
- Added Auto fix and Fix all actions that stage stored-value corrections through the normal Save and undo flow
- Added reusable user-global integrity profiles with save, apply, update, rename, and delete controls
- Added per-file persistence for integrity checks not saved as profiles
- Added compact editable result cards with always-visible calculated and stored values and calculated-value copying

### Changed

- Consolidated Inspector, Struct Overlay, and Integrity Checks byte order into one per-file sidebar setting; all Struct fields use this setting, while Value Search byte order remains independent

### Fixed

- Fixed Edit mode using original bytes instead of staged unsaved values when rendering memory, copying selections, applying subsequent patches, and calculating integrity results