### PR TITLE
chore: bump version to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.10.0] - 2026-06-29
+
+### Changed
+
+- Split reusable HexScope feature logic into `src/core` for future CLI reuse
+- Kept webview code focused on UI rendering, event wiring, state adapters, and virtual scrolling
+
 ## [2.9.0] - 2026-06-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changed

- Split reusable HexScope feature logic into \src/core\ for future CLI reuse
- Kept webview code focused on UI rendering, event wiring, state adapters, and virtual scrolling