### PR TITLE
refactor: deepen struct overlay

### DIFF
--- a/src/test/webview/struct-pins-model.test.ts
+++ b/src/test/webview/struct-pins-model.test.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+
+import type { StructDef, StructPin } from '../../core/types';
+import {
+    makeStructPin,
+    samePointerSource,
+    uniqueStructPinName,
+    upsertPointerStructPin,
+    withEditedStructPin,
+    withoutStructDefinition,
+    withoutStructPin,
+} from '../../webview/panels/structPinsModel';
+
+suite('struct pin model', () => {
+    test('creates pins with injected ids', () => {
+        const pin = makeStructPin({ structId: 's1', addr: 0x20, name: 'inst' }, () => 'pin_test');
+
+        assert.deepStrictEqual(pin, {
+            id: 'pin_test',
+            structId: 's1',
+            addr: 0x20,
+            name: 'inst',
+        });
+    });
+
+    test('keeps generated names unique', () => {
+        const pins: StructPin[] = [
+            { id: 'p1', structId: 's1', addr: 0, name: 'Packet_0' },
+            { id: 'p2', structId: 's1', addr: 1, name: 'Packet_1' },
+        ];
+
+        assert.strictEqual(uniqueStructPinName(pins, 'Packet_0', n => `Packet_${n}`), 'Packet_2');
+    });
+
+    test('edits and removes pins immutably', () => {
+        const pins: StructPin[] = [
+            { id: 'p1', structId: 'old', addr: 0x10, name: 'oldName' },
+            { id: 'p2', structId: 'keep', addr: 0x20, name: 'keepName' },
+        ];
+
+        const edited = withEditedStructPin(pins, 0, { name: '', addr: 0x30, structId: 'new' });
+        assert.notStrictEqual(edited, pins);
+        assert.deepStrictEqual(edited[0], { id: 'p1', structId: 'new', addr: 0x30, name: 'oldName' });
+        assert.deepStrictEqual(withoutStructPin(edited, 0), [pins[1]]);
+    });
+
+    test('removes struct definitions and dependent pins together', () => {
+        const structs: StructDef[] = [
+            { id: 'dead', name: 'Dead', fields: [] },
+            { id: 'live', name: 'Live', fields: [] },
+        ];
+        const pins: StructPin[] = [
+            { id: 'p1', structId: 'dead', addr: 0, name: 'deadPin' },
+            { id: 'p2', structId: 'live', addr: 1, name: 'livePin' },
+        ];
+
+        assert.deepStrictEqual(withoutStructDefinition(structs, pins, 'dead'), {
+            structs: [structs[1]],
+            pins: [pins[1]],
+        });
+    });
+
+    test('adds pointer source to existing target pin once', () => {
+        const pins: StructPin[] = [
+            { id: 'target', structId: 'child', addr: 0x200, name: 'child' },
+        ];
+        const result = upsertPointerStructPin(pins, {
+            sourcePin: { id: 'root', name: 'Root' },
+            sourceStructId: 'rootStruct',
+            sourceFieldPath: 'next',
+            sourceFieldByteOffset: 4,
+            sourceBaseAddr: 0x100,
+            targetAddress: 0x200,
+            targetStructId: 'child',
+        }, () => 'unused');
+
+        assert.strictEqual(result.pin.id, 'target');
+        assert.strictEqual(result.pins.length, 1);
+        assert.deepStrictEqual(result.pin.pointerSources, [{
+            sourcePinId: 'root',
+            sourcePinName: 'Root',
+            sourceStructId: 'rootStruct',
+            sourceFieldPath: 'next',
+            pointerStorageAddress: 0x104,
+            targetAddress: 0x200,
+        }]);
+
+        const duplicate = upsertPointerStructPin(result.pins, {
+            sourcePin: { id: 'root', name: 'Root' },
+            sourceStructId: 'rootStruct',
+            sourceFieldPath: 'next',
+            sourceFieldByteOffset: 4,
+            sourceBaseAddr: 0x100,
+            targetAddress: 0x200,
+            targetStructId: 'child',
+        }, () => 'unused');
+        assert.strictEqual(duplicate.pin.pointerSources?.length, 1);
+    });
+
+    test('creates pointer target pins with source identity and unique name', () => {
+        const pins: StructPin[] = [
+            { id: 'existing', structId: 'child', addr: 0x300, name: 'Root.next @00000200' },
+        ];
+        const result = upsertPointerStructPin(pins, {
+            sourcePin: { id: 'root', name: 'Root' },
+            sourceStructId: 'rootStruct',
+            sourceFieldPath: 'next',
+            sourceFieldByteOffset: 8,
+            sourceBaseAddr: 0x100,
+            targetAddress: 0x200,
+            targetStructId: 'child',
+        }, () => 'newPin');
+
+        assert.strictEqual(result.pins.length, 2);
+        assert.strictEqual(result.pin.id, 'newPin');
+        assert.strictEqual(result.pin.name, 'Root.next @00000200_1');
+        assert.strictEqual(result.pin.pointerSources?.[0]?.pointerStorageAddress, 0x108);
+        assert.ok(samePointerSource(result.pin.pointerSources![0], {
+            sourcePinId: 'root',
+            sourcePinName: 'different display name is ignored',
+            sourceStructId: 'rootStruct',
+            sourceFieldPath: 'next',
+            pointerStorageAddress: 0x108,
+            targetAddress: 0x200,
+        }));
+    });
+});

--- a/src/webview/panels/struct.ts
+++ b/src/webview/panels/struct.ts
@@ -5,9 +5,17 @@ Pure codec logic lives in struct-codec.ts. */
 
 import { S }        from '../state';
 import { esc, actionBtnsHtml, wireActionBtns, formatDecimal, formatHex, formatHexHtml, getBigUint64, getBigInt64, asUint64, positionContextMenu, wireHoverSubmenus } from '../utils';
-import { postProviderMessage }   from '../api';
 import { rerender } from '../render';
 import { getByte }  from '../data';
+import { persistStructPins, persistStructs, persistStructState } from './structPersistence';
+import {
+    makeStructPin,
+    uniqueStructPinName as uniquePinName,
+    upsertPointerStructPin,
+    withEditedStructPin,
+    withoutStructDefinition,
+    withoutStructPin,
+} from './structPinsModel';
 import {
     FIELD_TYPES,
     fieldByteSize, structByteSize, decodeField, decodeStruct, allStructs, resolveStructFieldByPath,
@@ -15,7 +23,7 @@ import {
     normalizeStructField,
 } from '../../core/struct-codec.js';
 import type { DecodedField } from '../../core/struct-codec.js';
-import type { BitFieldChild, StructDef, StructField, StructFieldType, StructPin, StructPointerSource } from '../../core/types';
+import type { BitFieldChild, StructDef, StructField, StructFieldType, StructPin } from '../../core/types';
 
 // ── Module state ──────────────────────────────────────────────────
 
@@ -983,7 +991,7 @@ function saveEditorDraft(sec: HTMLElement, draft: StructDef): void {
 
     _editorError = null;
     S.structs = upsertStructList(S.structs, def);
-    postProviderMessage({ type: 'saveStructs', structs: S.structs });
+    persistStructs(S.structs);
     closeEditorAfterSave(def.id);
     renderStructPins();
 }
@@ -1350,11 +1358,11 @@ function wireTypesPanelControls(sec: HTMLElement): void {
         },
         btn => {
             const id = btn.dataset.structId!;
-            S.structs    = S.structs.filter(d => d.id !== id);
-            S.structPins = S.structPins.filter(p => p.structId !== id);
+            const next = withoutStructDefinition(S.structs, S.structPins, id);
+            S.structs = next.structs;
+            S.structPins = next.pins;
             if (_applyStructId === id) { _applyStructId = null; }
-            postProviderMessage({ type: 'saveStructs',    structs: S.structs });
-            postProviderMessage({ type: 'saveStructPins', pins:    S.structPins });
+            persistStructState(S.structs, S.structPins);
             renderStructPins();
         },
     );
@@ -1424,12 +1432,12 @@ function confirmAddStructPin(): void {
     const addr = parseStructApplyAddress(addrInp);
     if (addr === null) { return; }
     const name = structApplyName(nameInp);
-    const pin: StructPin = { id: `pin_${Date.now()}`, structId: _applyStructId, addr, name };
+    const pin = makeStructPin({ structId: _applyStructId, addr, name }, makePinId);
     S.structPins       = [...S.structPins, pin];
     S.activeStructAddr = addr;
     _expanded.add(pin.id);
     _addingPin = false;
-    postProviderMessage({ type: 'saveStructPins', pins: S.structPins });
+    persistStructPins(S.structPins);
     renderStructPins();
 }
 
@@ -1455,11 +1463,11 @@ function nextStructApplyName(): string {
 }
 
 function uniqueStructPinName(initialName: string, nextName: (n: number) => string): string {
-    const takenPinNames = new Set(S.structPins.map(p => p.name));
-    let candidate = initialName;
-    let n = 1;
-    while (takenPinNames.has(candidate)) { candidate = nextName(n++); }
-    return candidate;
+    return uniquePinName(S.structPins, initialName, nextName);
+}
+
+function makePinId(): string {
+    return `pin_${Date.now()}`;
 }
 
 /** Resets all transient view state for the struct panel and re-renders. Call when switching away and back. */
@@ -3533,8 +3541,8 @@ function wireInstanceCards(sec: HTMLElement): void {
                 const idx = parseInt(btn.dataset.idx!);
                 const pin = S.structPins[idx];
                 if (pin) { _expanded.delete(pin.id); }
-                S.structPins = S.structPins.filter((_, i) => i !== idx);
-                postProviderMessage({ type: 'saveStructPins', pins: S.structPins });
+                S.structPins = withoutStructPin(S.structPins, idx);
+                persistStructPins(S.structPins);
                 renderStructPins();
             },
         );
@@ -3688,9 +3696,9 @@ function applyPinEdit(editForm: HTMLElement, idx: number, addr: number): void {
     const pin = S.structPins[idx];
     const nameVal = (editForm.querySelector('.si-pe-name') as HTMLInputElement).value.trim();
     const typeVal = (editForm.querySelector('.si-pe-type') as HTMLSelectElement).value;
-    S.structPins[idx] = { ...pin, name: nameVal || pin.name, addr, structId: typeVal };
+    S.structPins = withEditedStructPin(S.structPins, idx, { name: nameVal || pin.name, addr, structId: typeVal });
     S.activeStructAddr = addr;
-    postProviderMessage({ type: 'saveStructPins', pins: S.structPins });
+    persistStructPins(S.structPins);
 }
 
 function closePinEditForm(): void {
@@ -4486,34 +4494,20 @@ function resolvedStructPointerCreateState(row: DecodedField): Exclude<StructPoin
 function createStructInstanceFromPointer(source: PointerMenuSource | null): void {
     const state = structPointerCreateState(source);
     if (!state?.ok || !source) { return; }
-    const pointerSource = makeStructPointerSource(source, state.addr);
-    const pin = ensurePointerStructPin(source, state, pointerSource);
+    const result = upsertPointerStructPin(S.structPins, {
+        sourcePin: source.pin,
+        sourceStructId: source.sourceStructId,
+        sourceFieldPath: source.row.fieldName,
+        sourceFieldByteOffset: source.row.byteOffset,
+        sourceBaseAddr: source.sourceBaseAddr,
+        targetAddress: state.addr,
+        targetStructId: state.structId,
+    }, makePinId);
+    S.structPins = result.pins;
+    const pin = result.pin;
     selectCreatedPointerPin(pin, state);
-    postProviderMessage({ type: 'saveStructPins', pins: S.structPins });
+    persistStructPins(S.structPins);
     renderStructPins();
-}
-
-function ensurePointerStructPin(
-    source: PointerMenuSource,
-    state: Extract<StructPointerCreateState, { ok: true }>,
-    pointerSource: StructPointerSource,
-): StructPin {
-    const pin = S.structPins.find(candidate => candidate.addr === state.addr && candidate.structId === state.structId);
-    if (pin) {
-        addPointerSourceToExistingPin(pin, pointerSource);
-        return pin;
-    }
-    return appendPointerStructPin(source, state, pointerSource);
-}
-
-function appendPointerStructPin(
-    source: PointerMenuSource,
-    state: Extract<StructPointerCreateState, { ok: true }>,
-    pointerSource: StructPointerSource,
-): StructPin {
-    const pin = createPointerStructPin(source, state, pointerSource);
-    S.structPins = [...S.structPins, pin];
-    return pin;
 }
 
 function selectCreatedPointerPin(pin: StructPin, state: Extract<StructPointerCreateState, { ok: true }>): void {
@@ -4523,54 +4517,6 @@ function selectCreatedPointerPin(pin: StructPin, state: Extract<StructPointerCre
     selectPointerTarget(state.addr, structByteSize(state.def, S.structs));
 }
 
-function createPointerStructPin(
-    source: PointerMenuSource,
-    state: Extract<StructPointerCreateState, { ok: true }>,
-    pointerSource: StructPointerSource,
-): StructPin {
-    return {
-        id: `pin_${Date.now()}`,
-        structId: state.structId,
-        addr: state.addr,
-        name: nextPointerStructPinName(source.pin.name, source.row.fieldName, state.addr),
-        pointerSources: [pointerSource],
-    };
-}
-
-function nextPointerStructPinName(sourceName: string, fieldPath: string, targetAddr: number): string {
-    const base = `${sourceName}.${fieldPath} @${targetAddr.toString(16).toUpperCase().padStart(8, '0')}`;
-    return uniqueStructPinName(base, n => `${base}_${n}`);
-}
-
-function makeStructPointerSource(source: PointerMenuSource, targetAddress: number): StructPointerSource {
-    return {
-        sourcePinId: source.pin.id,
-        sourcePinName: source.pin.name,
-        sourceStructId: source.sourceStructId,
-        sourceFieldPath: source.row.fieldName,
-        pointerStorageAddress: source.sourceBaseAddr + source.row.byteOffset,
-        targetAddress,
-    };
-}
-
-function addPointerSourceToExistingPin(pin: StructPin, source: StructPointerSource): void {
-    if (pin.pointerSources?.some(existing => samePointerSource(existing, source))) { return; }
-    pin.pointerSources = [...(pin.pointerSources ?? []), source];
-}
-
-function samePointerSource(a: StructPointerSource, b: StructPointerSource): boolean {
-    return pointerSourceIdentity(a).every((value, idx) => value === pointerSourceIdentity(b)[idx]);
-}
-
-function pointerSourceIdentity(source: StructPointerSource): Array<string | number> {
-    return [
-        source.sourcePinId,
-        source.sourceStructId,
-        source.sourceFieldPath,
-        source.pointerStorageAddress,
-        source.targetAddress,
-    ];
-}
 
 function selectPointerTarget(addr: number, byteCount: number): void {
     S.selStart = addr;

--- a/src/webview/panels/structPersistence.ts
+++ b/src/webview/panels/structPersistence.ts
@@ -1,0 +1,15 @@
+import type { StructDef, StructPin } from '../../core/types';
+import { postProviderMessage } from '../api';
+
+export function persistStructs(structs: StructDef[]): void {
+    postProviderMessage({ type: 'saveStructs', structs });
+}
+
+export function persistStructPins(pins: StructPin[]): void {
+    postProviderMessage({ type: 'saveStructPins', pins });
+}
+
+export function persistStructState(structs: StructDef[], pins: StructPin[]): void {
+    persistStructs(structs);
+    persistStructPins(pins);
+}

--- a/src/webview/panels/structPinsModel.ts
+++ b/src/webview/panels/structPinsModel.ts
@@ -1,0 +1,154 @@
+import type { StructDef, StructPin, StructPointerSource } from '../../core/types';
+
+export type PinIdFactory = () => string;
+
+export type StructPinDraft = {
+    structId: string;
+    addr: number;
+    name: string;
+};
+
+export type PointerStructPinInput = {
+    sourcePin: Pick<StructPin, 'id' | 'name'>;
+    sourceStructId: string;
+    sourceFieldPath: string;
+    sourceFieldByteOffset: number;
+    sourceBaseAddr: number;
+    targetAddress: number;
+    targetStructId: string;
+};
+
+export type PointerStructPinResult = {
+    pins: StructPin[];
+    pin: StructPin;
+};
+
+export function makeStructPin(draft: StructPinDraft, makeId: PinIdFactory): StructPin {
+    return {
+        id: makeId(),
+        structId: draft.structId,
+        addr: draft.addr,
+        name: draft.name,
+    };
+}
+
+export function withEditedStructPin(
+    pins: StructPin[],
+    index: number,
+    edit: { name: string; addr: number; structId: string },
+): StructPin[] {
+    const pin = pins[index];
+    if (!pin) { return pins; }
+    const next = [...pins];
+    next[index] = {
+        ...pin,
+        name: edit.name || pin.name,
+        addr: edit.addr,
+        structId: edit.structId,
+    };
+    return next;
+}
+
+export function withoutStructPin(pins: StructPin[], index: number): StructPin[] {
+    return pins.filter((_, i) => i !== index);
+}
+
+export function withoutStructDefinition(
+    structs: StructDef[],
+    pins: StructPin[],
+    structId: string,
+): { structs: StructDef[]; pins: StructPin[] } {
+    return {
+        structs: structs.filter(d => d.id !== structId),
+        pins: pins.filter(p => p.structId !== structId),
+    };
+}
+
+export function uniqueStructPinName(
+    pins: readonly StructPin[],
+    initialName: string,
+    nextName: (n: number) => string,
+): string {
+    const takenPinNames = new Set(pins.map(p => p.name));
+    let candidate = initialName;
+    let n = 1;
+    while (takenPinNames.has(candidate)) { candidate = nextName(n++); }
+    return candidate;
+}
+
+export function upsertPointerStructPin(
+    pins: readonly StructPin[],
+    input: PointerStructPinInput,
+    makeId: PinIdFactory,
+): PointerStructPinResult {
+    const pointerSource = makeStructPointerSource(input);
+    const existingIndex = pins.findIndex(candidate =>
+        candidate.addr === input.targetAddress && candidate.structId === input.targetStructId,
+    );
+    if (existingIndex >= 0) {
+        const nextPins = [...pins];
+        nextPins[existingIndex] = withPointerSource(nextPins[existingIndex], pointerSource);
+        return { pins: nextPins, pin: nextPins[existingIndex] };
+    }
+
+    const pin = createPointerStructPin(pins, input, pointerSource, makeId);
+    return { pins: [...pins, pin], pin };
+}
+
+function makeStructPointerSource(input: PointerStructPinInput): StructPointerSource {
+    return {
+        sourcePinId: input.sourcePin.id,
+        sourcePinName: input.sourcePin.name,
+        sourceStructId: input.sourceStructId,
+        sourceFieldPath: input.sourceFieldPath,
+        pointerStorageAddress: input.sourceBaseAddr + input.sourceFieldByteOffset,
+        targetAddress: input.targetAddress,
+    };
+}
+
+export function samePointerSource(a: StructPointerSource, b: StructPointerSource): boolean {
+    return pointerSourceIdentity(a).every((value, idx) => value === pointerSourceIdentity(b)[idx]);
+}
+
+function createPointerStructPin(
+    pins: readonly StructPin[],
+    input: PointerStructPinInput,
+    pointerSource: StructPointerSource,
+    makeId: PinIdFactory,
+): StructPin {
+    return {
+        id: makeId(),
+        structId: input.targetStructId,
+        addr: input.targetAddress,
+        name: nextPointerStructPinName(pins, input.sourcePin.name, input.sourceFieldPath, input.targetAddress),
+        pointerSources: [pointerSource],
+    };
+}
+
+function withPointerSource(pin: StructPin, source: StructPointerSource): StructPin {
+    if (pin.pointerSources?.some(existing => samePointerSource(existing, source))) { return pin; }
+    return {
+        ...pin,
+        pointerSources: [...(pin.pointerSources ?? []), source],
+    };
+}
+
+function nextPointerStructPinName(
+    pins: readonly StructPin[],
+    sourceName: string,
+    fieldPath: string,
+    targetAddr: number,
+): string {
+    const base = `${sourceName}.${fieldPath} @${targetAddr.toString(16).toUpperCase().padStart(8, '0')}`;
+    return uniqueStructPinName(pins, base, n => `${base}_${n}`);
+}
+
+function pointerSourceIdentity(source: StructPointerSource): Array<string | number> {
+    return [
+        source.sourcePinId,
+        source.sourceStructId,
+        source.sourceFieldPath,
+        source.pointerStorageAddress,
+        source.targetAddress,
+    ];
+}


### PR DESCRIPTION
## Summary
- Deepen the struct overlay by moving persistence posts into `structPersistence`.
- Move struct pin naming, edit/delete, definition cleanup, and pointer-target pin upsert logic into `structPinsModel`.
- Add focused tests for the extracted struct pin model.