### PR TITLE
refactor(webview): split message handling

### DIFF
--- a/src/test/webview/webview-message-model.test.ts
+++ b/src/test/webview/webview-message-model.test.ts
@@ -1,0 +1,156 @@
+import * as assert from 'assert';
+
+import type { ProviderMessageHandlers } from '../../webview/webviewMessageDispatcher';
+import type { SegmentLabel, SerializedParseResult } from '../../core/types';
+import { dispatchProviderMessage } from '../../webview/webviewMessageDispatcher';
+import { S } from '../../webview/state';
+import { applyProviderMessageToModel } from '../../webview/webviewMessageModel';
+
+function resetState(): void {
+    S.parseResult = null;
+    S.labels = [];
+    S.segmentIndex = [];
+    S.memRows = [];
+    S.currentView = 'memory';
+    S.editMode = false;
+    S.edits.clear();
+    S.undoStack.length = 0;
+    S.structs = [];
+    S.structPins = [];
+    S.lockedDueToExternalChange = false;
+}
+
+suite('webview message dispatcher', () => {
+    setup(resetState);
+
+    test('ignores unknown and malformed provider messages', () => {
+        const handlers = noOpHandlers();
+
+        assert.strictEqual(dispatchProviderMessage({ type: 'unknown' }, handlers), false);
+        assert.strictEqual(dispatchProviderMessage({ nope: true }, handlers), false);
+        assert.strictEqual(dispatchProviderMessage(null, handlers), false);
+    });
+
+    test('dispatches known provider message types', () => {
+        let called = false;
+        const handlers = {
+            ...noOpHandlers(),
+            loadError: msg => {
+                called = true;
+                assert.strictEqual(msg.message, 'boom');
+            },
+        } satisfies ProviderMessageHandlers;
+
+        assert.strictEqual(dispatchProviderMessage({ type: 'loadError', message: 'boom' }, handlers), true);
+        assert.strictEqual(called, true);
+    });
+});
+
+suite('applyProviderMessageToModel()', () => {
+    setup(resetState);
+
+    test('init loads parse state and requests a full render', () => {
+        const parseResult = parseResultForTest({
+            segments: [{ startAddress: 0x1000, data: [1, 2] }],
+            totalDataBytes: 2,
+        });
+        const update = applyProviderMessageToModel({
+            type: 'init',
+            parseResult,
+            labels: [labelForTest()],
+            structs: [],
+            structPins: [],
+            endian: 'be',
+            integrityProfiles: { profiles: [], activeChecks: { schemaVersion: 1, checks: [] } },
+        });
+
+        assert.strictEqual(S.parseResult, parseResult);
+        assert.strictEqual(S.labels.length, 1);
+        assert.strictEqual(S.endian, 'be');
+        assert.strictEqual(update.invalidations.fullRender, true);
+        assert.ok(update.integrityProfiles);
+    });
+
+    test('label messages rebuild memory and invalidate labels plus memory', () => {
+        const label = labelForTest({ id: 'a', name: 'A' });
+        const update = applyProviderMessageToModel({ type: 'addLabel', label });
+
+        assert.deepStrictEqual(S.labels, [label]);
+        assert.strictEqual(update.invalidations.labelsAndMemory, true);
+    });
+
+    test('loadError preserves an empty provider message', () => {
+        const update = applyProviderMessageToModel({ type: 'loadError', message: '' });
+
+        assert.strictEqual(update.loadErrorMessage, '');
+    });
+
+    test('savedEdits reloads parsed memory and clears edit state', () => {
+        S.editMode = true;
+        S.edits.set(0x1000, 0xAA);
+
+        const parseResult = parseResultForTest({ totalDataBytes: 1 });
+        const update = applyProviderMessageToModel({ type: 'savedEdits', parseResult });
+
+        assert.strictEqual(S.parseResult, parseResult);
+        assert.strictEqual(S.editMode, false);
+        assert.strictEqual(S.edits.size, 0);
+        assert.strictEqual(update.invalidations.editControls, true);
+        assert.strictEqual(update.invalidations.integrityBytesChanged, true);
+    });
+
+    test('externalChange records lock state and conflict decision', () => {
+        S.editMode = true;
+        S.edits.set(0x1000, 0xAA);
+        const parseResult = parseResultForTest();
+        const labels = [labelForTest()];
+
+        const update = applyProviderMessageToModel({ type: 'externalChange', parseResult, labels });
+
+        assert.strictEqual(S.lockedDueToExternalChange, true);
+        assert.strictEqual(update.invalidations.lockState, true);
+        assert.strictEqual(update.removeExternalChangeBanners, true);
+        assert.deepStrictEqual(update.externalChange, {
+            incoming: { parseResult, labels },
+            hasUnsavedEdits: true,
+        });
+    });
+});
+
+function noOpHandlers(): ProviderMessageHandlers {
+    return {
+        init: () => {},
+        loadError: () => {},
+        addLabel: () => {},
+        updateLabel: () => {},
+        copyCommand: () => {},
+        savedEdits: () => {},
+        externalChange: () => {},
+        externalChangeError: () => {},
+        repairComplete: () => {},
+        integrityProfiles: () => {},
+    };
+}
+
+function parseResultForTest(overrides: Partial<SerializedParseResult> = {}): SerializedParseResult {
+    return {
+        records: [],
+        segments: [],
+        totalDataBytes: 0,
+        checksumErrors: 0,
+        malformedLines: 0,
+        format: 'ihex',
+        ...overrides,
+    };
+}
+
+function labelForTest(overrides: Partial<SegmentLabel> = {}): SegmentLabel {
+    return {
+        id: 'label-1',
+        name: 'Label 1',
+        startAddress: 0,
+        length: 1,
+        color: '#ff0000',
+        ...overrides,
+    };
+}

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -27,19 +27,12 @@ import {
 } from '../core/byte-tools';
 import { MAX_VIRTUAL_SCROLL_HEIGHT, physicalToLogicalScrollForLayout } from './render/virtualScroll';
 import {
-    addLabel,
-    applyInitialState,
     clearEditModel,
-    hasUnsavedEdits,
-    incomingFile,
     loadIncomingFile,
-    loadParsedMemory,
-    lockForExternalChange,
     rebuildMemoryRows,
     type ClearEditReason,
     type IncomingFile,
     unlockExternalChange,
-    updateLabel,
 } from './appModel';
 import {
     activateIntegrity,
@@ -50,7 +43,13 @@ import {
     setIntegrityEditHandler,
     setIntegrityProfiles,
 } from './sidebar/integrity/index';
-import { messageType, type ProviderToWebviewMessage, type WebviewToProviderMessage } from '../webviewProtocol';
+import type { ProviderToWebviewMessage, WebviewToProviderMessage } from '../webviewProtocol';
+import { dispatchProviderMessage, type ProviderMessageHandlers } from './webviewMessageDispatcher';
+import {
+    applyProviderMessageToModel,
+    type WebviewInvalidations,
+    type WebviewModelUpdate,
+} from './webviewMessageModel';
 
 postProviderMessage({ type: 'ready' });
 
@@ -69,110 +68,73 @@ function parseSidebarWidth(raw: string | null | undefined): number | null {
 
 type WebviewMessage = ProviderToWebviewMessage;
 type WebviewMessageByType<T extends WebviewMessage['type']> = Extract<WebviewMessage, { type: T }>;
-type WebviewMessageHandler = (msg: any) => void;
+type ModelUpdateEffect = (update: WebviewModelUpdate) => void;
+type InvalidationEffect = readonly [keyof WebviewInvalidations, () => void];
 
-const MESSAGE_HANDLERS: ReadonlyArray<readonly [string, WebviewMessageHandler]> = [
-    ['init', handleInitMessage],
-    ['loadError', handleLoadErrorMessage],
-    ['addLabel', handleAddLabelMessage],
-    ['updateLabel', handleUpdateLabelMessage],
-    ['copyCommand', handleCopyCommandMessage],
-    ['savedEdits', handleSavedEditsMessage],
-    ['externalChange', handleExternalChangeMessage],
-    ['externalChangeError', handleExternalChangeErrorMessage],
-    ['repairComplete', handleRepairCompleteMessage],
-    ['integrityProfiles', handleIntegrityProfilesMessage],
+const MESSAGE_HANDLERS: ProviderMessageHandlers = {
+    init: handleInitMessage,
+    loadError: handleLoadErrorMessage,
+    addLabel: handleAddLabelMessage,
+    updateLabel: handleUpdateLabelMessage,
+    copyCommand: handleCopyCommandMessage,
+    savedEdits: handleSavedEditsMessage,
+    externalChange: handleExternalChangeMessage,
+    externalChangeError: handleExternalChangeErrorMessage,
+    repairComplete: handleRepairCompleteMessage,
+    integrityProfiles: handleIntegrityProfilesMessage,
+};
+
+const MODEL_UPDATE_EFFECTS: readonly ModelUpdateEffect[] = [
+    applyIntegrityProfileUpdate,
+    applyLoadErrorUpdate,
+    applyCopyCommandUpdate,
+    applyExternalBannerUpdate,
+    applyExternalChangeUpdate,
+    applyExternalChangeErrorUpdate,
 ];
 
 window.addEventListener('message', (e: MessageEvent) => {
-    const msg = e.data as WebviewMessage;
-    const entry = MESSAGE_HANDLERS.find(([type]) => type === messageType(msg));
-    entry?.[1](msg);
+    dispatchProviderMessage(e.data, MESSAGE_HANDLERS);
 });
 
 function handleInitMessage(msg: WebviewMessageByType<'init'>): void {
-    applyInitialState(msg);
-    setIntegrityProfiles(msg.integrityProfiles);
-    render();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleIntegrityProfilesMessage(msg: WebviewMessageByType<'integrityProfiles'>): void {
-    setIntegrityProfiles(msg.profiles, typeof msg.error === 'string' ? msg.error : '');
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleLoadErrorMessage(msg: WebviewMessageByType<'loadError'>): void {
-    renderLoadError(String(msg.message ?? 'Failed to open file.'));
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleAddLabelMessage(msg: WebviewMessageByType<'addLabel'>): void {
-    addLabel(msg.label);
-    rebuildLabelsAndMemory();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleUpdateLabelMessage(msg: WebviewMessageByType<'updateLabel'>): void {
-    updateLabel(msg.label);
-    rebuildLabelsAndMemory();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleCopyCommandMessage(msg: WebviewMessageByType<'copyCommand'>): void {
-    handleCopyCommand(msg.command as string);
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleSavedEditsMessage(msg: WebviewMessageByType<'savedEdits'>): void {
-    loadParsedMemory(msg.parseResult);
-    clearEditState();
-    document.getElementById('btn-edit-mode')!.style.display = '';
-    document.getElementById('edit-mode-group')!.style.display = 'none';
-    updateDirtyBar();
-    renderStats();
-    renderSegments();
-    renderStructPins();
-    renderCurrentDataView();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleExternalChangeMessage(msg: WebviewMessageByType<'externalChange'>): void {
-    const incoming = incomingFileFromMessage(msg);
-    lockForExternalChange();
-    removeAllExternalChangeBanners();
-    updateLockState();
-    if (hasUnsavedEdits()) {
-        showExternalChangeConflict(incoming);
-    } else {
-        showExternalChangeReloadBanner(incoming);
-    }
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleExternalChangeErrorMessage(msg: WebviewMessageByType<'externalChangeError'>): void {
-    loadIncomingFile(incomingFile(msg.parseResult, msg.labels));
-    lockForExternalChange();
-    removeAllExternalChangeBanners();
-    updateLockState();
-    if (hasUnsavedEdits()) { clearEditState(); }
-
-    showExternalChangeError(
-        msg.checksumErrors as number,
-        msg.malformedLines as number,
-        msg.errorCount as number,
-        msg.canQuickRepair as boolean,
-    );
-    renderSegments();
-    renderStructPins();
-    renderCurrentDataView();
-    notifyIntegrityBytesChanged();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function handleRepairCompleteMessage(msg: WebviewMessageByType<'repairComplete'>): void {
-    loadParsedMemory(msg.parseResult);
-    clearEditState();
-    document.getElementById('ext-error-banner')?.remove();
-    unlockExternalChange();
-    updateLockState();
-    updateEditControls();
-    updateDirtyBar();
-    renderStats();
-    renderSegments();
-    renderStructPins();
-    renderCurrentDataView();
+    applyWebviewModelUpdate(applyProviderMessageToModel(msg));
 }
 
 function rebuildLabelsAndMemory(): void {
@@ -192,8 +154,72 @@ function renderCurrentDataView(): void {
     else if (S.currentView === 'record') { renderRecordView(); }
 }
 
-function incomingFileFromMessage(msg: WebviewMessageByType<'externalChange'>): IncomingFile {
-    return incomingFile(msg.parseResult, msg.labels);
+function applyWebviewModelUpdate(update: WebviewModelUpdate): void {
+    for (const effect of MODEL_UPDATE_EFFECTS) { effect(update); }
+    applyInvalidations(update.invalidations);
+}
+
+function applyIntegrityProfileUpdate(update: WebviewModelUpdate): void {
+    if (update.integrityProfiles) {
+        setIntegrityProfiles(update.integrityProfiles, update.integrityProfileError ?? '');
+    }
+}
+
+function applyLoadErrorUpdate(update: WebviewModelUpdate): void {
+    if ('loadErrorMessage' in update) { renderLoadError(update.loadErrorMessage ?? ''); }
+}
+
+function applyCopyCommandUpdate(update: WebviewModelUpdate): void {
+    if (update.copyCommand) { handleCopyCommand(update.copyCommand); }
+}
+
+function applyExternalBannerUpdate(update: WebviewModelUpdate): void {
+    if (update.removeExternalChangeBanners) { removeAllExternalChangeBanners(); }
+    if (update.removeExternalChangeErrorBanner) { document.getElementById('ext-error-banner')?.remove(); }
+}
+
+function applyExternalChangeUpdate(update: WebviewModelUpdate): void {
+    if (!update.externalChange) { return; }
+    if (update.externalChange.hasUnsavedEdits) {
+        showExternalChangeConflict(update.externalChange.incoming);
+    } else {
+        showExternalChangeReloadBanner(update.externalChange.incoming);
+    }
+}
+
+function applyExternalChangeErrorUpdate(update: WebviewModelUpdate): void {
+    if (!update.externalChangeError) { return; }
+    showExternalChangeError(
+        update.externalChangeError.checksumErrors,
+        update.externalChangeError.malformedLines,
+        update.externalChangeError.errorCount,
+        update.externalChangeError.canQuickRepair,
+    );
+}
+
+function applyInvalidations(invalidations: WebviewInvalidations): void {
+    if (invalidations.fullRender) {
+        render();
+        return;
+    }
+    applyScopedInvalidations(invalidations);
+}
+
+function applyScopedInvalidations(invalidations: WebviewInvalidations): void {
+    const effects: readonly InvalidationEffect[] = [
+        ['labelsAndMemory', rebuildLabelsAndMemory],
+        ['lockState', updateLockState],
+        ['editControls', updateEditControls],
+        ['dirtyBar', updateDirtyBar],
+        ['stats', renderStats],
+        ['segments', renderSegments],
+        ['structPins', renderStructPins],
+        ['currentDataView', renderCurrentDataView],
+        ['integrityBytesChanged', notifyIntegrityBytesChanged],
+    ];
+    for (const [key, effect] of effects) {
+        if (invalidations[key]) { effect(); }
+    }
 }
 
 // ── Helper: apply external change and unlock ──────────────────────

--- a/src/webview/webviewMessageDispatcher.ts
+++ b/src/webview/webviewMessageDispatcher.ts
@@ -1,0 +1,36 @@
+import { messageType, type ProviderToWebviewMessage } from '../webviewProtocol';
+
+type ProviderMessageType = ProviderToWebviewMessage['type'];
+type ProviderMessageByType<T extends ProviderMessageType> = Extract<ProviderToWebviewMessage, { type: T }>;
+
+export type ProviderMessageHandlers = {
+    [T in ProviderMessageType]: (msg: ProviderMessageByType<T>) => void;
+};
+
+const PROVIDER_MESSAGE_TYPES: readonly ProviderMessageType[] = [
+    'init',
+    'loadError',
+    'addLabel',
+    'updateLabel',
+    'copyCommand',
+    'savedEdits',
+    'externalChange',
+    'externalChangeError',
+    'repairComplete',
+    'integrityProfiles',
+];
+
+const PROVIDER_MESSAGE_TYPE_SET = new Set<string>(PROVIDER_MESSAGE_TYPES);
+
+function isProviderMessageType(type: string | undefined): type is ProviderMessageType {
+    return typeof type === 'string' && PROVIDER_MESSAGE_TYPE_SET.has(type);
+}
+
+export function dispatchProviderMessage(message: unknown, handlers: ProviderMessageHandlers): boolean {
+    const type = messageType(message);
+    if (!isProviderMessageType(type)) { return false; }
+
+    const handler = handlers[type] as (msg: ProviderToWebviewMessage) => void;
+    handler(message as ProviderToWebviewMessage);
+    return true;
+}

--- a/src/webview/webviewMessageModel.ts
+++ b/src/webview/webviewMessageModel.ts
@@ -1,0 +1,188 @@
+import type { CopyCommand } from '../core/byte-tools';
+import type { IntegrityCheckSet, IntegrityProfile } from '../core/integrity';
+import type { ProviderToWebviewMessage } from '../webviewProtocol';
+import {
+    addLabel,
+    applyInitialState,
+    clearEditModel,
+    hasUnsavedEdits,
+    incomingFile,
+    loadIncomingFile,
+    loadParsedMemory,
+    lockForExternalChange,
+    rebuildMemoryRows,
+    type IncomingFile,
+    unlockExternalChange,
+    updateLabel,
+} from './appModel';
+
+export type WebviewInvalidations = {
+    fullRender?: boolean;
+    labelsAndMemory?: boolean;
+    lockState?: boolean;
+    editControls?: boolean;
+    dirtyBar?: boolean;
+    stats?: boolean;
+    segments?: boolean;
+    structPins?: boolean;
+    currentDataView?: boolean;
+    integrityBytesChanged?: boolean;
+};
+
+export type ExternalChangeErrorDetails = {
+    checksumErrors: number;
+    malformedLines: number;
+    errorCount: number;
+    canQuickRepair: boolean;
+};
+
+export type WebviewModelUpdate = {
+    invalidations: WebviewInvalidations;
+    loadErrorMessage?: string;
+    copyCommand?: CopyCommand;
+    integrityProfiles?: { profiles: IntegrityProfile[]; activeChecks: IntegrityCheckSet } | IntegrityProfile[];
+    integrityProfileError?: string;
+    removeExternalChangeBanners?: boolean;
+    removeExternalChangeErrorBanner?: boolean;
+    externalChange?: { incoming: IncomingFile; hasUnsavedEdits: boolean };
+    externalChangeError?: ExternalChangeErrorDetails;
+};
+
+type WebviewMessage = ProviderToWebviewMessage;
+type WebviewMessageByType<T extends WebviewMessage['type']> = Extract<WebviewMessage, { type: T }>;
+type ModelAppliers = {
+    [T in WebviewMessage['type']]: (msg: WebviewMessageByType<T>) => WebviewModelUpdate;
+};
+
+const MODEL_APPLIERS: ModelAppliers = {
+    init: applyInitMessage,
+    integrityProfiles: applyIntegrityProfilesMessage,
+    loadError: applyLoadErrorMessage,
+    addLabel: applyAddLabelMessage,
+    updateLabel: applyUpdateLabelMessage,
+    copyCommand: applyCopyCommandMessage,
+    savedEdits: applySavedEditsMessage,
+    externalChange: applyExternalChangeMessage,
+    externalChangeError: applyExternalChangeErrorMessage,
+    repairComplete: applyRepairCompleteMessage,
+};
+
+export function applyProviderMessageToModel(msg: WebviewMessage): WebviewModelUpdate {
+    const apply = MODEL_APPLIERS[msg.type] as (message: WebviewMessage) => WebviewModelUpdate;
+    return apply(msg);
+}
+
+function applyInitMessage(msg: WebviewMessageByType<'init'>): WebviewModelUpdate {
+    applyInitialState(msg);
+    return {
+        integrityProfiles: msg.integrityProfiles,
+        invalidations: { fullRender: true },
+    };
+}
+
+function applyIntegrityProfilesMessage(msg: WebviewMessageByType<'integrityProfiles'>): WebviewModelUpdate {
+    return {
+        integrityProfiles: msg.profiles,
+        integrityProfileError: typeof msg.error === 'string' ? msg.error : '',
+        invalidations: {},
+    };
+}
+
+function applyLoadErrorMessage(msg: WebviewMessageByType<'loadError'>): WebviewModelUpdate {
+    return {
+        loadErrorMessage: String(msg.message ?? 'Failed to open file.'),
+        invalidations: {},
+    };
+}
+
+function applyAddLabelMessage(msg: WebviewMessageByType<'addLabel'>): WebviewModelUpdate {
+    addLabel(msg.label);
+    rebuildMemoryRows();
+    return { invalidations: { labelsAndMemory: true } };
+}
+
+function applyUpdateLabelMessage(msg: WebviewMessageByType<'updateLabel'>): WebviewModelUpdate {
+    updateLabel(msg.label);
+    rebuildMemoryRows();
+    return { invalidations: { labelsAndMemory: true } };
+}
+
+function applyCopyCommandMessage(msg: WebviewMessageByType<'copyCommand'>): WebviewModelUpdate {
+    return { copyCommand: msg.command, invalidations: {} };
+}
+
+function applySavedEditsMessage(msg: WebviewMessageByType<'savedEdits'>): WebviewModelUpdate {
+    loadParsedMemory(msg.parseResult);
+    clearEditModel();
+    return {
+        invalidations: {
+            editControls: true,
+            dirtyBar: true,
+            stats: true,
+            segments: true,
+            structPins: true,
+            currentDataView: true,
+            integrityBytesChanged: true,
+        },
+    };
+}
+
+function applyExternalChangeMessage(msg: WebviewMessageByType<'externalChange'>): WebviewModelUpdate {
+    lockForExternalChange();
+    return {
+        removeExternalChangeBanners: true,
+        externalChange: { incoming: incomingFileFromExternalChange(msg), hasUnsavedEdits: hasUnsavedEdits() },
+        invalidations: { lockState: true },
+    };
+}
+
+function applyExternalChangeErrorMessage(msg: WebviewMessageByType<'externalChangeError'>): WebviewModelUpdate {
+    loadIncomingFile(incomingFile(msg.parseResult, msg.labels));
+    lockForExternalChange();
+    clearUnsavedEditsForExternalError();
+    return {
+        removeExternalChangeBanners: true,
+        externalChangeError: {
+            checksumErrors: msg.checksumErrors,
+            malformedLines: msg.malformedLines,
+            errorCount: msg.errorCount,
+            canQuickRepair: msg.canQuickRepair,
+        },
+        invalidations: {
+            lockState: true,
+            segments: true,
+            structPins: true,
+            currentDataView: true,
+            integrityBytesChanged: true,
+        },
+    };
+}
+
+function clearUnsavedEditsForExternalError(): void {
+    if (hasUnsavedEdits()) { clearEditModel(); }
+}
+
+function applyRepairCompleteMessage(msg: WebviewMessageByType<'repairComplete'>): WebviewModelUpdate {
+    loadParsedMemory(msg.parseResult);
+    clearEditModel();
+    unlockExternalChange();
+    return {
+        removeExternalChangeErrorBanner: true,
+        invalidations: {
+            lockState: true,
+            editControls: true,
+            dirtyBar: true,
+            stats: true,
+            segments: true,
+            structPins: true,
+            currentDataView: true,
+            integrityBytesChanged: true,
+        },
+    };
+}
+
+function incomingFileFromExternalChange(
+    msg: Extract<WebviewMessage, { type: 'externalChange' }>,
+): IncomingFile {
+    return incomingFile(msg.parseResult, msg.labels);
+}


### PR DESCRIPTION
## Summary

Refactors webview provider-message handling into typed dispatch and model-update modules.

Moves message state transitions out of `hexViewer.ts` so the entrypoint applies UI effects and invalidations from a smaller webview model layer.
