### PR TITLE
fix: preserve record formatting on save

### DIFF
--- a/src/core/document.ts
+++ b/src/core/document.ts
@@ -42,12 +42,38 @@ function serializeEditedRecords(
     if (edits.size === 0) { return originalRaw; }
 
     const eol = originalRaw.includes('\r\n') ? '\r\n' : '\n';
-    const lines = parseResult.records.map(rec => {
-        if (rec.error || !canEditRecord(rec)) { return rec.raw; }
-        const edited = applyRecordEdits(rec, edits);
-        return edited ? rebuildRecord(rec, edited) : rec.raw;
-    });
+    const lines = originalRaw.split(/\r?\n/);
+    for (const rec of parseResult.records) {
+        applySerializedRecordEdit(lines, rec, edits, canEditRecord, rebuildRecord);
+    }
     return lines.join(eol);
+}
+
+function applySerializedRecordEdit(
+    lines: string[],
+    rec: ParsedRecord,
+    edits: Map<number, number>,
+    canEditRecord: (rec: ParsedRecord) => boolean,
+    rebuildRecord: (rec: ParsedRecord, data: number[]) => string,
+): void {
+    const rebuiltRecord = editedRecordText(rec, edits, canEditRecord, rebuildRecord);
+    if (rebuiltRecord) { lines[rec.lineNumber - 1] = replaceRecordText(lines[rec.lineNumber - 1], rebuiltRecord); }
+}
+
+function editedRecordText(
+    rec: ParsedRecord,
+    edits: Map<number, number>,
+    canEditRecord: (rec: ParsedRecord) => boolean,
+    rebuildRecord: (rec: ParsedRecord, data: number[]) => string,
+): string | null {
+    if (rec.error || !canEditRecord(rec)) { return null; }
+    const edited = applyRecordEdits(rec, edits);
+    return edited ? rebuildRecord(rec, edited) : null;
+}
+
+function replaceRecordText(originalLine: string | undefined, rebuiltRecord: string): string {
+    const match = originalLine?.match(/^(\s*)\S+(\s*)$/);
+    return match ? `${match[1]}${rebuiltRecord}${match[2]}` : rebuiltRecord;
 }
 
 function applyRecordEdits(rec: ParsedRecord, edits: Map<number, number>): number[] | null {

--- a/src/test/core/provider-utils.test.ts
+++ b/src/test/core/provider-utils.test.ts
@@ -3,6 +3,7 @@ import {
     buildSRecDataRecord,
     detectFormatFromParts,
     repairChecksums,
+    serializeIntelHex,
     serializeSRec,
 } from '../../core/document';
 import { migrateStructDefinitions } from '../../hexEditorProvider';
@@ -189,6 +190,29 @@ suite('buildSRecDataRecord()', () => {
         const rec = buildSRecDataRecord(1, 0x0000, data); // asz=2
         const byteCount = parseInt(rec.slice(2, 4), 16);
         assert.strictEqual(byteCount, 2 + 3 + 1);
+    });
+});
+
+suite('serializeIntelHex()', () => {
+    test('preserves blank lines and surrounding record whitespace when editing data', () => {
+        const raw = [
+            '  :020000040800F2  ',
+            '',
+            ' \t:0400000001020304F2  ',
+            '   ',
+            ':00000001FF',
+        ].join('\n');
+        const result = parseIntelHex(raw);
+        const out = serializeIntelHex(raw, result, new Map([[0x08000000, 0xFF]]));
+
+        assert.strictEqual(out, [
+            '  :020000040800F2  ',
+            '',
+            ' \t:04000000FF020304F4  ',
+            '   ',
+            ':00000001FF',
+        ].join('\n'));
+        assert.strictEqual(parseIntelHex(out).checksumErrors, 0);
     });
 });
 


### PR DESCRIPTION
## Summary
- Preserve original physical lines when saving edited records.
- Replace only records whose bytes changed while keeping blank lines and surrounding whitespace intact.