### PR TITLE
fix: validate struct pin addresses

### DIFF
--- a/src/test/webview/struct-pins-model.test.ts
+++ b/src/test/webview/struct-pins-model.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import type { StructDef, StructPin } from '../../core/types';
 import {
     makeStructPin,
+    parseStructPinAddressInput,
     samePointerSource,
     uniqueStructPinName,
     upsertPointerStructPin,
@@ -12,6 +13,14 @@ import {
 } from '../../webview/sidebar/struct/structPinsModel';
 
 suite('struct pin model', () => {
+    test('parses full hex address input only', () => {
+        assert.strictEqual(parseStructPinAddressInput('123'), 0x123);
+        assert.strictEqual(parseStructPinAddressInput(' 0xDEADBEEF '), 0xDEADBEEF);
+        assert.strictEqual(parseStructPinAddressInput('123xyz'), null);
+        assert.strictEqual(parseStructPinAddressInput(''), null);
+        assert.strictEqual(parseStructPinAddressInput('0x100000000'), null);
+    });
+
     test('creates pins with injected ids', () => {
         const pin = makeStructPin({ structId: 's1', addr: 0x20, name: 'inst' }, () => 'pin_test');
 

--- a/src/webview/sidebar/struct/index.ts
+++ b/src/webview/sidebar/struct/index.ts
@@ -10,6 +10,7 @@ import { getByte }  from '../../memory/memoryData';
 import { persistStructPins, persistStructs, persistStructState } from './structPersistence';
 import {
     makeStructPin,
+    parseStructPinAddressInput,
     uniqueStructPinName as uniquePinName,
     upsertPointerStructPin,
     withEditedStructPin,
@@ -3686,8 +3687,8 @@ function savePinEditForm(editForm: HTMLElement, pinId: string): void {
 
 function readPinEditAddress(editForm: HTMLElement): number | null {
     const addrInput = editForm.querySelector('.si-pe-addr') as HTMLInputElement;
-    const addr = parseInt(addrInput.value.trim().replace(/^0x/i, ''), 16);
-    if (!isNaN(addr)) { return addr; }
+    const addr = parseStructPinAddressInput(addrInput.value);
+    if (addr !== null) { addrInput.style.borderColor = ''; return addr; }
     addrInput.style.borderColor = 'var(--err)';
     return null;
 }

--- a/src/webview/sidebar/struct/structPinsModel.ts
+++ b/src/webview/sidebar/struct/structPinsModel.ts
@@ -23,6 +23,14 @@ export type PointerStructPinResult = {
     pin: StructPin;
 };
 
+export function parseStructPinAddressInput(raw: string): number | null {
+    const text = raw.trim();
+    const hex = text.replace(/^0x/i, '');
+    if (!/^[0-9a-fA-F]+$/.test(hex)) { return null; }
+    const addr = Number.parseInt(hex, 16);
+    return Number.isSafeInteger(addr) && addr <= 0xFFFFFFFF ? addr : null;
+}
+
 export function makeStructPin(draft: StructPinDraft, makeId: PinIdFactory): StructPin {
     return {
         id: makeId(),


### PR DESCRIPTION
## Summary
- Validate struct pin address edits with full hex matching.
- Reject partial or out-of-range address input instead of accepting truncated values.