### PR TITLE
chore: cleanup VSIX package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,5 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 .fallowrc.json
 .*/**
+scripts/**
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.12.1] - 2026-07-11
+
+### Fixed
+
+- Exclude the `scripts` directory and `AGENTS.md` from VSCE packaging to reduce the extension size
+
 ## [2.12.0] - 2026-07-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Exclude the `scripts` directory and `AGENTS.md` from VSCE packaging to reduce the extension size