### PR TITLE
fix: enforce escaped webview HTML

### DIFF
--- a/.trellis/workspace/deviousprophet/index.md
+++ b/.trellis/workspace/deviousprophet/index.md
@@ -8,7 +8,7 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 7
+- **Total Sessions**: 8
 - **Last Active**: 2026-07-11
 <!-- @@@/auto:current-status -->
 
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~241 | Active |
+| `journal-1.md` | ~274 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 8 | 2026-07-11 | Audit innerHTML safety | `72a60b6` | `fix/audit-innerhtml` |
 | 7 | 2026-07-11 | Clear Fallow quality gates | `a341015` | `feat/large-file-pipeline` |
 | 6 | 2026-07-11 | Prepare large-file pipeline release | `1e1c752`, `61a7bf1` | `feat/large-file-pipeline` |
 | 5 | 2026-07-11 | Fix large-file search regression | `4ee0180` | `feat/large-file-pipeline` |

--- a/.trellis/workspace/deviousprophet/journal-1.md
+++ b/.trellis/workspace/deviousprophet/journal-1.md
@@ -239,3 +239,36 @@ Removed all dead-code, duplication, health, and refactor findings without suppre
 ### Next Steps
 
 - None - task complete
+
+
+## Session 8: Audit innerHTML safety
+
+**Date**: 2026-07-11
+**Task**: Audit innerHTML safety
+**Branch**: `fix/audit-innerhtml`
+
+### Summary
+
+Audited webview HTML sinks, added ESLint enforcement and regression tests, and escaped or named trusted fragments explicitly.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `72a60b6` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.12.2] - 2026-07-11
+
+### Fixed
+
+- Enforced escaping for dynamic webview HTML to prevent unsafe content injection
+
 ## [2.12.1] - 2026-07-11
 
 ### Fixed

--- a/eslint-rules/require-escaped-html.mjs
+++ b/eslint-rules/require-escaped-html.mjs
@@ -1,47 +1,77 @@
 const HTML_SINKS = new Set(['innerHTML', 'outerHTML']);
+const TRUSTED_HTML_NAME = /(?:Html|Class|Attr)$/;
+const PROPERTY_VALUE = {
+    Identifier: property => property.name,
+    Literal: property => property.value,
+};
 
 function propertyName(member) {
-    if (!member.computed && member.property.type === 'Identifier') { return member.property.name; }
-    if (member.computed && member.property.type === 'Literal') { return member.property.value; }
-    return undefined;
+    const property = member.property;
+    const expectedType = member.computed ? 'Literal' : 'Identifier';
+    return property.type === expectedType ? PROPERTY_VALUE[expectedType](property) : undefined;
 }
 
 function callableName(node) {
     if (node.type === 'Identifier') { return node.name; }
-    if (node.type === 'MemberExpression') { return propertyName(node); }
-    return undefined;
+    return node.type === 'MemberExpression' ? propertyName(node) : undefined;
 }
 
-function isHtmlSinkTemplate(node) {
-    const parent = node.parent;
-    if (parent?.type === 'AssignmentExpression' && parent.right === node && parent.left.type === 'MemberExpression') {
-        return HTML_SINKS.has(propertyName(parent.left));
-    }
-    if (parent?.type === 'CallExpression' && parent.arguments[1] === node && parent.callee.type === 'MemberExpression') {
-        return propertyName(parent.callee) === 'insertAdjacentHTML';
-    }
-    return false;
-}
+const SAFE_EXPRESSION = {
+    Literal: () => true,
+    Identifier: node => /Html$/.test(node.name),
+    CallExpression: node => {
+        const name = callableName(node.callee) ?? '';
+        return name === 'esc' || TRUSTED_HTML_NAME.test(name);
+    },
+    TemplateLiteral: node => node.expressions.every(isSafeHtmlExpression),
+    ConditionalExpression: node => [node.consequent, node.alternate].every(isSafeHtmlExpression),
+    LogicalExpression: node => [node.left, node.right].every(isSafeHtmlExpression),
+    UnaryExpression: () => true,
+    BinaryExpression: node => [node.left, node.right].every(isSafeHtmlExpression),
+};
 
 function isSafeHtmlExpression(node) {
-    if (node.type === 'Literal') { return true; }
-    if (node.type === 'Identifier') { return /Html$/.test(node.name); }
-    if (node.type === 'CallExpression') {
-        const name = callableName(node.callee) ?? '';
-        return name === 'esc' || /(?:Html|Class|Attr)$/.test(name);
-    }
-    if (node.type === 'TemplateLiteral') { return node.expressions.every(isSafeHtmlExpression); }
-    if (node.type === 'ConditionalExpression') {
-        return isSafeHtmlExpression(node.consequent) && isSafeHtmlExpression(node.alternate);
-    }
-    if (node.type === 'LogicalExpression') {
-        return isSafeHtmlExpression(node.left) && isSafeHtmlExpression(node.right);
-    }
-    if (node.type === 'UnaryExpression') { return true; }
-    if (node.type === 'BinaryExpression') {
-        return isSafeHtmlExpression(node.left) && isSafeHtmlExpression(node.right);
-    }
-    return false;
+    return SAFE_EXPRESSION[node.type]?.(node) ?? false;
+}
+
+function isHtmlAssignment(node) {
+    return node.left.type === 'MemberExpression' && HTML_SINKS.has(propertyName(node.left));
+}
+
+function isInsertAdjacentHtmlCall(node) {
+    return node.callee.type === 'MemberExpression' && propertyName(node.callee) === 'insertAdjacentHTML';
+}
+
+const SINK_TEMPLATE_PARENT = {
+    AssignmentExpression: (parent, node) => parent.right === node && isHtmlAssignment(parent),
+    CallExpression: (parent, node) => parent.arguments[1] === node && isInsertAdjacentHtmlCall(parent),
+};
+
+function isSinkTemplate(node) {
+    const parent = node.parent;
+    return SINK_TEMPLATE_PARENT[parent?.type]?.(parent, node) ?? false;
+}
+
+function reportUnsafeValue(context, node) {
+    if (node.type === 'TemplateLiteral' || isSafeHtmlExpression(node)) { return; }
+    context.report({ node, messageId: 'unescaped' });
+}
+
+function checkAssignment(context, node) {
+    if (isHtmlAssignment(node)) { reportUnsafeValue(context, node.right); }
+}
+
+function checkInsertAdjacentHtml(context, node) {
+    if (!isInsertAdjacentHtmlCall(node)) { return; }
+    const html = node.arguments[1];
+    if (html && html.type !== 'SpreadElement') { reportUnsafeValue(context, html); }
+}
+
+function checkTemplate(context, node) {
+    if (!isSinkTemplate(node)) { return; }
+    node.expressions
+        .filter(expression => !isSafeHtmlExpression(expression))
+        .forEach(expression => context.report({ node: expression, messageId: 'unescaped' }));
 }
 
 export const requireEscapedHtml = {
@@ -53,27 +83,9 @@ export const requireEscapedHtml = {
     },
     create(context) {
         return {
-            AssignmentExpression(node) {
-                if (node.left.type !== 'MemberExpression' || !HTML_SINKS.has(propertyName(node.left))) { return; }
-                if (node.right.type !== 'TemplateLiteral' && !isSafeHtmlExpression(node.right)) {
-                    context.report({ node: node.right, messageId: 'unescaped' });
-                }
-            },
-            CallExpression(node) {
-                if (node.callee.type !== 'MemberExpression' || propertyName(node.callee) !== 'insertAdjacentHTML') { return; }
-                const html = node.arguments[1];
-                if (html && html.type !== 'SpreadElement' && html.type !== 'TemplateLiteral' && !isSafeHtmlExpression(html)) {
-                    context.report({ node: html, messageId: 'unescaped' });
-                }
-            },
-            TemplateLiteral(node) {
-                if (!isHtmlSinkTemplate(node)) { return; }
-                for (const expression of node.expressions) {
-                    if (!isSafeHtmlExpression(expression)) {
-                        context.report({ node: expression, messageId: 'unescaped' });
-                    }
-                }
-            },
+            AssignmentExpression: node => checkAssignment(context, node),
+            CallExpression: node => checkInsertAdjacentHtml(context, node),
+            TemplateLiteral: node => checkTemplate(context, node),
         };
     },
 };

--- a/eslint-rules/require-escaped-html.mjs
+++ b/eslint-rules/require-escaped-html.mjs
@@ -1,0 +1,81 @@
+const HTML_SINKS = new Set(['innerHTML', 'outerHTML']);
+
+function propertyName(member) {
+    if (!member.computed && member.property.type === 'Identifier') { return member.property.name; }
+    if (member.computed && member.property.type === 'Literal') { return member.property.value; }
+    return undefined;
+}
+
+function callableName(node) {
+    if (node.type === 'Identifier') { return node.name; }
+    if (node.type === 'MemberExpression') { return propertyName(node); }
+    return undefined;
+}
+
+function isHtmlSinkTemplate(node) {
+    const parent = node.parent;
+    if (parent?.type === 'AssignmentExpression' && parent.right === node && parent.left.type === 'MemberExpression') {
+        return HTML_SINKS.has(propertyName(parent.left));
+    }
+    if (parent?.type === 'CallExpression' && parent.arguments[1] === node && parent.callee.type === 'MemberExpression') {
+        return propertyName(parent.callee) === 'insertAdjacentHTML';
+    }
+    return false;
+}
+
+function isSafeHtmlExpression(node) {
+    if (node.type === 'Literal') { return true; }
+    if (node.type === 'Identifier') { return /Html$/.test(node.name); }
+    if (node.type === 'CallExpression') {
+        const name = callableName(node.callee) ?? '';
+        return name === 'esc' || /(?:Html|Class|Attr)$/.test(name);
+    }
+    if (node.type === 'TemplateLiteral') { return node.expressions.every(isSafeHtmlExpression); }
+    if (node.type === 'ConditionalExpression') {
+        return isSafeHtmlExpression(node.consequent) && isSafeHtmlExpression(node.alternate);
+    }
+    if (node.type === 'LogicalExpression') {
+        return isSafeHtmlExpression(node.left) && isSafeHtmlExpression(node.right);
+    }
+    if (node.type === 'UnaryExpression') { return true; }
+    if (node.type === 'BinaryExpression') {
+        return isSafeHtmlExpression(node.left) && isSafeHtmlExpression(node.right);
+    }
+    return false;
+}
+
+export const requireEscapedHtml = {
+    meta: {
+        type: 'problem',
+        docs: { description: 'require dynamic text in HTML templates to be escaped' },
+        schema: [],
+        messages: { unescaped: 'Wrap dynamic text in esc(), or use an explicitly named trusted HTML builder or fragment.' },
+    },
+    create(context) {
+        return {
+            AssignmentExpression(node) {
+                if (node.left.type !== 'MemberExpression' || !HTML_SINKS.has(propertyName(node.left))) { return; }
+                if (node.right.type !== 'TemplateLiteral' && !isSafeHtmlExpression(node.right)) {
+                    context.report({ node: node.right, messageId: 'unescaped' });
+                }
+            },
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression' || propertyName(node.callee) !== 'insertAdjacentHTML') { return; }
+                const html = node.arguments[1];
+                if (html && html.type !== 'SpreadElement' && html.type !== 'TemplateLiteral' && !isSafeHtmlExpression(html)) {
+                    context.report({ node: html, messageId: 'unescaped' });
+                }
+            },
+            TemplateLiteral(node) {
+                if (!isHtmlSinkTemplate(node)) { return; }
+                for (const expression of node.expressions) {
+                    if (!isSafeHtmlExpression(expression)) {
+                        context.report({ node: expression, messageId: 'unescaped' });
+                    }
+                }
+            },
+        };
+    },
+};
+
+export default { rules: { 'require-escaped-html': requireEscapedHtml } };

--- a/eslint-rules/require-escaped-html.test.mjs
+++ b/eslint-rules/require-escaped-html.test.mjs
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint';
+import { requireEscapedHtml } from './require-escaped-html.mjs';
+
+const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: 'module' } });
+
+tester.run('require-escaped-html', requireEscapedHtml, {
+    valid: [
+        'el.innerHTML = `<b>${esc(label)}</b>`;',
+        'el.innerHTML = `<b>${rowHtml}</b>`;',
+        'el.innerHTML = renderRowsHtml(rows);',
+        'el.innerHTML = `<b class="${activeClass(true)}">ok</b>`;',
+        'el.innerHTML = "<b>static</b>";',
+    ],
+    invalid: [
+        {
+            code: 'el.innerHTML = `<b>${label}</b>`;',
+            errors: [{ messageId: 'unescaped' }],
+        },
+        {
+            code: 'el.insertAdjacentHTML("beforeend", `<b>${label}</b>`);',
+            errors: [{ messageId: 'unescaped' }],
+        },
+        {
+            code: 'el.outerHTML = `<b>${label}</b>`;',
+            errors: [{ messageId: 'unescaped' }],
+        },
+        {
+            code: 'el.innerHTML = label;',
+            errors: [{ messageId: 'unescaped' }],
+        },
+    ],
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,12 @@
 import typescriptEslint from "typescript-eslint";
+import localHtmlSafety from "./eslint-rules/require-escaped-html.mjs";
 
 export default [{
     files: ["**/*.ts"],
 }, {
     plugins: {
         "@typescript-eslint": typescriptEslint.plugin,
+        "local-html-safety": localHtmlSafety,
     },
 
     languageOptions: {
@@ -23,5 +25,6 @@ export default [{
         eqeqeq: "warn",
         "no-throw-literal": "warn",
         semi: "warn",
+        "local-html-safety/require-escaped-html": "error",
     },
 }];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
-    "lint": "eslint src",
+    "lint": "node eslint-rules/require-escaped-html.test.mjs && eslint src",
     "test": "vscode-test",
     "test:performance": "node scripts/run-performance-large.cjs"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/webview/externalChangeUi.ts
+++ b/src/webview/externalChangeUi.ts
@@ -1,4 +1,5 @@
 import type { IncomingFile } from './appModel';
+import { esc } from './utils';
 
 export function removeAllExternalChangeBanners(): void {
     document.getElementById('ext-conflict-banner')?.remove();
@@ -18,7 +19,7 @@ export function showExternalChangeConflict(
     banner.className = 'ext-conflict-banner';
     banner.innerHTML =
         `<span class="ecb-icon">&#9888;</span>` +
-        `<span class="ecb-msg">File changed externally. You have <strong>${unsavedEditCount}</strong> unsaved edit${unsavedEditCount === 1 ? '' : 's'}. Changes must be reloaded.</span>` +
+        `<span class="ecb-msg">File changed externally. You have <strong>${esc(String(unsavedEditCount))}</strong> unsaved edit${unsavedEditCount === 1 ? '' : 's'}. Changes must be reloaded.</span>` +
         `<button class="ecb-btn ecb-reload"  id="ecb-reload">Reload &amp; discard my edits</button>`;
 
     document.getElementById('app')!.prepend(banner);

--- a/src/webview/memory/memoryView.ts
+++ b/src/webview/memory/memoryView.ts
@@ -119,15 +119,15 @@ function syncVirtualScrollMetrics(scrollContainer: HTMLElement): void {
 //  Column header 
 
 export function renderMemHeader(): void {
-    const hidden = `<div class="cell-group"><span class="addr-cell">00000000</span></div>`;
+    const hiddenHtml = `<div class="cell-group"><span class="addr-cell">00000000</span></div>`;
 
-    const hexHdr = Array.from({ length: BPR }, (_, i) =>
+    const hexHeaderHtml = Array.from({ length: BPR }, (_, i) =>
         `<span class="data-cell" data-col="${i}" style="cursor:default;color:var(--addr-active-fg)">${i.toString(16).toUpperCase().padStart(2, '0')}</span>`
     ).join('');
 
     document.getElementById('mem-header')!.innerHTML =
-        `${hidden}` +
-        `<div class="cell-group">${hexHdr}</div>` +
+        `${hiddenHtml}` +
+        `<div class="cell-group">${hexHeaderHtml}</div>` +
         `<div class="cell-group"><span class="mem-hdr-decoded">Decoded text</span></div>`;
 }
 

--- a/src/webview/sidebar/inspector/index.ts
+++ b/src/webview/sidebar/inspector/index.ts
@@ -50,16 +50,16 @@ function renderInspectorAddress(addrEl: HTMLElement, len: number): void {
     const startHex = S.selStart!.toString(16).toUpperCase().padStart(8, '0');
     addrEl.style.display = '';
     if (len === 1) {
-        addrEl.innerHTML = `<span class=\"insp-addr-value\">0x${startHex}</span>`;
+        addrEl.innerHTML = `<span class=\"insp-addr-value\">0x${esc(startHex)}</span>`;
         return;
     }
 
     const endHex = S.selEnd!.toString(16).toUpperCase().padStart(8, '0');
     addrEl.innerHTML =
-        `<span class=\"insp-addr-value\">0x${startHex}</span>` +
+        `<span class=\"insp-addr-value\">0x${esc(startHex)}</span>` +
         `<span class=\"insp-addr-sep\">–</span>` +
-        `<span class=\"insp-addr-value\">0x${endHex}</span>` +
-        `<span class=\"insp-addr-len\">${len} bytes</span>`;
+        `<span class=\"insp-addr-value\">0x${esc(endHex)}</span>` +
+        `<span class=\"insp-addr-len\">${esc(String(len))} bytes</span>`;
 }
 
 function singleByteInspectorHtml(val: number): string {
@@ -165,8 +165,8 @@ export function renderBits(val?: number): void {
         sec.innerHTML =
             `<div class="sb-hdr">Bit View</div>` +
             `<div class="sb-body">` +
-            `<div class="bitgrid-wrap">${bitIndexRow()}${byteRow(val, null)}</div>` +
-            `<span class="bit-pc">${pc}/8 bits set</span></div>`;
+            `<div class="bitgrid-wrap">${bitIndexRowHtml()}${byteRowHtml(val, null)}</div>` +
+            `<span class="bit-pc">${esc(String(pc))}/8 bits set</span></div>`;
     }
 
     applyCollapsibleSection(sec, true);
@@ -177,14 +177,14 @@ export function renderBits(val?: number): void {
 /** Multi-byte bit view — one 8-cell row per byte. */
 function renderBitsMulti(bytes: number[]): void {
     const sec   = document.getElementById('s-bits')!;
-    const rows  = bytes.map((b, i) => byteRow(b, `[${i}]`)).join('');
+    const rowsHtml = bytes.map((b, i) => byteRowHtml(b, `[${i}]`)).join('');
     const total = bytes.reduce((s, b) => s + popcount(b), 0);
     sec.innerHTML =
         `<div class="sb-hdr">Bit View ` +
-        `<span class="sb-badge" style="font-weight:400;opacity:.6">${bytes.length} byte${bytes.length > 1 ? 's' : ''}</span></div>` +
+        `<span class="sb-badge" style="font-weight:400;opacity:.6">${esc(String(bytes.length))} byte${bytes.length > 1 ? 's' : ''}</span></div>` +
         `<div class="sb-body">` +
-        `<div class="bitgrid-wrap">${bitIndexRow()}${rows}</div>` +
-        `<span class="bit-pc">${total}/${bytes.length * 8} bits set</span></div>`;
+        `<div class="bitgrid-wrap">${bitIndexRowHtml()}${rowsHtml}</div>` +
+        `<span class="bit-pc">${esc(String(total))}/${esc(String(bytes.length * 8))} bits set</span></div>`;
 
     // Persist collapsed state on the section element; default collapsed
     if (sec.dataset.collapsed === undefined) { sec.dataset.collapsed = 'true'; }
@@ -226,14 +226,14 @@ function popcount(v: number): number {
     return n;
 }
 
-function bitIndexRow(): string {
+function bitIndexRowHtml(): string {
     const cells = Array.from({ length: 8 }, (_, i) =>
         `<div class="bit-idx">${7 - i}</div>`
     ).join('');
     return `<div class="bit-row"><div></div>${cells}</div>`;
 }
 
-function byteRow(val: number, label: string | null): string {
+function byteRowHtml(val: number, label: string | null): string {
     const hexStr = val.toString(16).toUpperCase().padStart(2, '0');
     const cells = Array.from({ length: 8 }, (_, i) => {
         const bit = 7 - i;
@@ -368,11 +368,11 @@ function renderMultiInline(): void {
     const width = multiWidth(selLen);
     const le = S.endian === 'le';
     const raw = selectedPaddedBytes(width, selLen);
-    const group = multiValueGroupHtml(width, readMultiValues(raw, le));
+    const groupHtml = multiValueGroupHtml(width, readMultiValues(raw, le));
 
     el.innerHTML =
         multiPadNoteHtml(selLen, width) +
-        `<div class="mi-group">${group}</div>`;
+        `<div class="mi-group">${groupHtml}</div>`;
 
     wireMultiInlineControls(el);
 }

--- a/src/webview/sidebar/sidebar.ts
+++ b/src/webview/sidebar/sidebar.ts
@@ -84,12 +84,12 @@ export function renderSegments(): void {
 
 export function renderLabels(): void {
     const sec   = document.getElementById('s-labels')!;
-    const badge = labelBadgeHtml();
-    const items = labelItemsHtml(S.labels);
+    const badgeHtml = labelBadgeHtml();
+    const itemsHtml = labelItemsHtml(S.labels);
 
     sec.innerHTML = `
-        <div class="sb-hdr">Labels ${badge}</div>
-        <div class="sb-body">${items}
+        <div class="sb-hdr">Labels ${badgeHtml}</div>
+        <div class="sb-body">${itemsHtml}
         <button class="add-lbl-btn" id="btn-add-lbl">+ Add Segment Label</button>
         </div>`;
 


### PR DESCRIPTION
## Summary

Enforce safe dynamic HTML rendering across the webview and close the remaining innerHTML audit gap.

## Main changes

- Add a repository-local ESLint rule with regression tests for unsafe HTML sink usage
- Escape dynamic values and explicitly identify trusted HTML fragments
