### PR TITLE
chore(release): bump to 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.13.0] - 2026-07-19
+
+### Changed
+
+- Large file saves now use async chunked serialization to prevent UI freezes on Intel HEX and SREC files
+- Integrity checks on large memory segments now use async chunked CRC and MD5 algorithms to prevent UI freezes
+
 ## [2.12.2] - 2026-07-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.12.2",
+      "version": "2.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release 2.13.0: async chunked save and integrity check paths for large Intel HEX and SREC files.

## Main changes

- Async chunked serialization prevents UI freezes on large file saves
- Async chunked CRC/MD5 prevents UI freezes on large integrity checks