### PR TITLE
chore: generalize skills and add fallow quality gate

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-create
+name: create-pr
 description: "Project-wide rules for creating, publishing, drafting, or updating a PR for this repository. Trigger on: 'open pr', 'create pull request', 'draft pr', 'publish branch', 'make a PR', or any similar request."
 ---
 

--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-changelog
-description: "Prepare or revise Hex Scope release changelog entries and synchronized package versions from committed changes since the latest release tag. Use when asked to update CHANGELOG.md, prepare release notes, choose the next release version, bump the release version, finalize an untagged changelog draft, or recheck changelog date/version before a push."
+description: "Prepare or revise release changelog entries and synchronized package versions from committed changes since the latest release tag. Use when asked to update CHANGELOG.md, prepare release notes, choose the next release version, bump the release version, finalize an untagged changelog draft, or recheck changelog date/version before a push."
 ---
 
 # Update Changelog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,13 @@ If you're using Codex or another agent-capable tool, additional project-scoped h
 Managed by Trellis. Edits outside this block are preserved; edits inside may be overwritten by a future `trellis update`.
 
 <!-- TRELLIS:END -->
+
+<!-- FALLOW:START -->
+# Fallow Quality Gate
+
+Before every `git push` that includes non-doc files, load fallow skill then run `npx fallow audit --base <target> --format json --quiet || true`. Parse JSON `verdict` (`pass`/`warn`/`fail`). Not `pass` → fix all warnings until green. Use `npx fallow` — no global install.
+
+Check PR CI checks for fallow verdict too. CI fallow failed → same as local fail — task undone.
+
+No suppression markers or config edits unless asked.
+<!-- FALLOW:END -->


### PR DESCRIPTION
## Summary

Generalize repo-specific references in project skills and add fallow-based quality gate to AGENTS.md.

## Main changes

- Removed project name from update-changelog skill description
- Renamed pr-create to create-pr for consistent verb-noun naming
- Added fallow quality gate requiring green audit before push
