### PR TITLE
fix: include CSS files in subdirectories for VSIX packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,7 @@
 out/**
 node_modules/**
 src/**
-!src/webview/*.css
+!src/webview/**/*.css
 .gitignore
 .yarnrc
 esbuild.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.14.1] - 2026-07-22
+
+### Fixed
+
+- Fixed missing CSS in VSIX package causing unstyled webview — CSS files moved to `styles/` subdirectory in v2.11.0 excluded by `.vscodeignore` glob pattern
+
 ## [2.14.0] - 2026-07-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fixes missing CSS in VSIX package that caused the webview to render unstyled since v2.11.0. The `.vscodeignore` glob `!src/webview/*.css` only matches one directory level, so CSS files moved to `src/webview/styles/` were silently excluded from packaging.

## Main changes

- Updated `.vscodeignore` CSS glob from `!src/webview/*.css` to `!src/webview/**/*.css` to match files in subdirectories
