### PR TITLE
fix: normalize encoding to UTF 8 and CRLF

### DIFF
--- a/src/test/extension/extension.test.ts
+++ b/src/test/extension/extension.test.ts
@@ -1,4 +1,4 @@
-﻿import * as assert from 'assert';
+import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('HexScope Extension', () => {

--- a/src/webview/memory/memoryView.ts
+++ b/src/webview/memory/memoryView.ts
@@ -1,4 +1,4 @@
-﻿//  Memory View
+//  Memory View
 // Renders the hex-grid memory view: column header, data rows, gap rows,
 // and segment label banners. Uses virtual scrolling to efficiently handle
 // large files by rendering only visible rows + a buffer.


### PR DESCRIPTION
Stripped UTF 8 BOM from extension.test.ts and memoryView.ts
Fixed 2 invalid Windows 1252 bytes in struct.css comments to proper UTF 8
Normalized 2 .opencode/ JSON files to CRLF consistent with repo

Full codebase scan 242 text files all valid UTF 8, 0 BOM, 0 invalid sequences
All 242 files CRLF, 0 mixed, 0 LF only
npm run check types and npm run lint pass
Zero behavior changes