### PR TITLE
fix: normalize encoding to UTF 8 and CRLF

### DIFF
--- a/src/test/extension/extension.test.ts
+++ b/src/test/extension/extension.test.ts
@@ -1,4 +1,4 @@
-﻿import * as assert from 'assert';
+import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('HexScope Extension', () => {

--- a/src/webview/memory/memoryView.ts
+++ b/src/webview/memory/memoryView.ts
@@ -1,4 +1,4 @@
-﻿//  Memory View
+//  Memory View
 // Renders the hex-grid memory view: column header, data rows, gap rows,
 // and segment label banners. Uses virtual scrolling to efficiently handle
 // large files by rendering only visible rows + a buffer.


### PR DESCRIPTION
## Summary

Normalize all text files in the repository to valid UTF 8 without BOM and consistent CRLF line endings.

## Main changes

- Strip UTF 8 BOM from extension.test.ts and memoryView.ts
- Fix 2 invalid Windows 1252 bytes in struct.css comments to proper UTF 8
- Convert .opencode/package.json and package lock.json to CRLF
- Validate all 242 text files: 0 BOM, 0 invalid sequences, 0 mixed line endings
