### PR TITLE
chore: remove Fallow Quality Gate from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,3 @@ Managed by Trellis. Edits outside this block are preserved; edits inside may be 
 
 <!-- TRELLIS:END -->
 
-<!-- FALLOW:START -->
-# Fallow Quality Gate
-
-Before every `git push` that includes non-doc files, load fallow skill then run `npx fallow audit --base <target> --format json --quiet || true`. Parse JSON `verdict` (`pass`/`warn`/`fail`). Not `pass` → fix all warnings until green. Use `npx fallow` — no global install.
-
-Check PR CI checks for fallow verdict too. CI fallow failed → same as local fail — task undone.
-
-No suppression markers or config edits unless asked.
-<!-- FALLOW:END -->


### PR DESCRIPTION
## Summary

Remove the Fallow Quality Gate instructions from AGENTS.md — the fallow check is handled externally via CI and the gate creates unnecessary friction during development.

## Main changes

- Removed the \<!-- FALLOW:START -->\ block from AGENTS.md