### PR TITLE
fix(search): pad address query left instead of right, add UI guard

### DIFF
--- a/.trellis/workspace/deviousprophet/index.md
+++ b/.trellis/workspace/deviousprophet/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 12
-- **Last Active**: 2026-07-23
+- **Total Sessions**: 14
+- **Last Active**: 2026-07-24
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~137 | Active |
+| `journal-1.md` | ~203 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,8 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 14 | 2026-07-24 | Address search cleanup | `14fa689` | `fix/search-address-padding` |
+| 13 | 2026-07-24 | Fix address search padding | `6c7e0e7` | `fix/search-address-padding` |
 | 12 | 2026-07-23 | Direct-typing byte editing | `c3fe112` | `feat/edit-tedium` |
 | 11 | 2026-07-21 | Implement scripts tab UI per finalized spec | `4481e78`, `4a2bc1e`, `7ccb06a` | `feat/scripting-support` |
 | 10 | 2026-07-20 | Add scripting support for custom HEX processing | `a564af9` | `feat/scripting-support` |

--- a/.trellis/workspace/deviousprophet/journal-1.md
+++ b/.trellis/workspace/deviousprophet/journal-1.md
@@ -135,3 +135,69 @@ Implement direct-typing byte editing in edit mode. User clicks a byte, types 2 h
 ### Next Steps
 
 - None - task complete
+
+
+## Session 13: Fix address search padding
+
+**Date**: 2026-07-24
+**Task**: Fix address search padding
+**Branch**: `fix/search-address-padding`
+
+### Summary
+
+buildAddressSearchBounds: fix padEnd->padStart so short queries like '1A0' find exact address 0x1A0. Add 8 addr search tests. Closes #123.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `6c7e0e7` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete
+
+
+## Session 14: Address search cleanup
+
+**Date**: 2026-07-24
+**Task**: Address search cleanup
+**Branch**: `fix/search-address-padding`
+
+### Summary
+
+Simplify AddressSearchBounds (rm dead fields), extract test helper, move addr tests to search.test.ts, add overflow tests. Refs #123.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `14fa689` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed address search requiring leading zeros — short queries like `1A0` now correctly match address `0x1A0`
+
+### Changed
+
+- Improved address search input with inline `0x` prefix, hex-only character filtering, and 8-character maximum
+
 ## [2.15.0] - 2026-07-23
 
 ### Added

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -17,11 +17,8 @@ interface SearchCursor {
     offset: number;
 }
 
-interface AddressSearchBounds {
-    queryMin: number;
-    queryMax: number;
-    prefixShift: number;
-    prefixValue: number;
+interface AddressSearchQuery {
+    queryValue: number;
 }
 
 interface SearchProgressState {
@@ -105,7 +102,7 @@ export class SearchEngine {
         const cursor: SearchCursor = { segmentIndex: 0, offset: 0 };
         const progress = createSearchProgress(segments);
 
-        const bounds = buildAddressSearchBounds(query);
+        const bounds = buildAddressSearchQuery(query);
         this.runChunkedSearch(token, segments.length, cursor, progress, handlers, matches, () =>
             scanAddressSearchChunk(segments, bounds, cursor, matches)
         );
@@ -205,18 +202,13 @@ function matchesAnyNeedle(segmentData: ArrayLike<number>, offset: number, needle
     return false;
 }
 
-function buildAddressSearchBounds(query: string): AddressSearchBounds {
-    return {
-        queryMin: parseInt(query.padEnd(8, '0'), 16),
-        queryMax: parseInt(query.padEnd(8, 'F'), 16),
-        prefixShift: (8 - query.length) * 4,
-        prefixValue: parseInt(query, 16) >>> 0,
-    };
+function buildAddressSearchQuery(query: string): AddressSearchQuery {
+    return { queryValue: parseInt(query.padStart(8, '0'), 16) >>> 0 };
 }
 
 function scanAddressSearchChunk(
     segments: SerializedSegment[],
-    bounds: AddressSearchBounds,
+    bounds: AddressSearchQuery,
     cursor: SearchCursor,
     matches: number[],
 ): number {
@@ -250,15 +242,15 @@ function scanSegmentsWithinBudget(
     return scanned;
 }
 
-function segmentOverlapsAddressBounds(seg: SerializedSegment, bounds: AddressSearchBounds): boolean {
+function segmentOverlapsAddressBounds(seg: SerializedSegment, bounds: AddressSearchQuery): boolean {
     const segStart = seg.startAddress;
     const segEnd = seg.startAddress + seg.data.length - 1;
-    return segEnd >= bounds.queryMin && segStart <= bounds.queryMax;
+    return segStart <= bounds.queryValue && segEnd >= bounds.queryValue;
 }
 
 function scanAddressSegment(
     seg: SerializedSegment,
-    bounds: AddressSearchBounds,
+    bounds: AddressSearchQuery,
     cursor: SearchCursor,
     matches: number[],
     deadline: number,
@@ -274,7 +266,7 @@ function scanAddressSegment(
 
 function scanAddressBatch(
     seg: SerializedSegment,
-    bounds: AddressSearchBounds,
+    bounds: AddressSearchQuery,
     cursor: SearchCursor,
     matches: number[],
     end: number,
@@ -282,7 +274,7 @@ function scanAddressBatch(
     const start = cursor.offset;
     while (cursor.offset < end) {
         const address = (seg.startAddress + cursor.offset) >>> 0;
-        if ((address >>> bounds.prefixShift) === bounds.prefixValue) { matches.push(address); }
+        if (address === bounds.queryValue) { matches.push(address); }
         cursor.offset++;
     }
     return cursor.offset - start;
@@ -290,7 +282,7 @@ function scanAddressBatch(
 
 function scanAddressSearchSegment(
     seg: SerializedSegment,
-    bounds: AddressSearchBounds,
+    bounds: AddressSearchQuery,
     cursor: SearchCursor,
     matches: number[],
     deadline: number,

--- a/src/test/core/search-performance.test.ts
+++ b/src/test/core/search-performance.test.ts
@@ -1,16 +1,20 @@
 import * as assert from 'assert';
 import { SearchEngine } from '../../core/search';
 
+function runSearch(mode: string, raw: string, segments: { startAddress: number; data: Uint8Array }[]): Promise<number[]> {
+    return new Promise(resolve => {
+        new SearchEngine().search(
+            { mode: mode as any, raw, segments } as any,
+            { onComplete: resolve },
+        );
+    });
+}
+
 suite('SearchEngine large-segment performance', () => {
     test('scans a 4 MiB typed segment without per-byte clock overhead', async () => {
         const data = new Uint8Array(4 * 1024 * 1024);
         const started = performance.now();
-        const matches = await new Promise<number[]>(resolve => {
-            new SearchEngine().search(
-                { mode: 'bytes', raw: 'FF', segments: [{ startAddress: 0, data }] },
-                { onComplete: resolve },
-            );
-        });
+        const matches = await runSearch('bytes', 'FF', [{ startAddress: 0, data }]);
         const elapsed = performance.now() - started;
 
         assert.deepStrictEqual(matches, []);

--- a/src/test/core/search.test.ts
+++ b/src/test/core/search.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'assert';
+import { SearchEngine, canonicalizeQuery } from '../../core/search';
+
+function segWithMarkerAt(length: number, markerAddr: number): { startAddress: number; data: Uint8Array } {
+    const data = new Uint8Array(length);
+    data[markerAddr] = 0xFF;
+    return { startAddress: 0, data };
+}
+
+function runSearch(mode: string, raw: string, segments: { startAddress: number; data: Uint8Array }[]): Promise<number[]> {
+    return new Promise(resolve => {
+        new SearchEngine().search(
+            { mode: mode as any, raw, segments } as any,
+            { onComplete: resolve },
+        );
+    });
+}
+
+suite('SearchEngine address search', () => {
+    test('short address "1A0" matches padded address 0x000001A0', async () => {
+        const matches = await runSearch('addr', '1A0', [segWithMarkerAt(417, 0x1A0)]);
+        assert.deepStrictEqual(matches, [0x1A0]);
+    });
+
+    test('"0x1A0" with prefix matches 0x000001A0', async () => {
+        const matches = await runSearch('addr', '0x1A0', [segWithMarkerAt(417, 0x1A0)]);
+        assert.deepStrictEqual(matches, [0x1A0]);
+    });
+
+    test('full padded "000001A0" finds address 0x1A0 (backward compat)', async () => {
+        const matches = await runSearch('addr', '000001A0', [segWithMarkerAt(417, 0x1A0)]);
+        assert.deepStrictEqual(matches, [0x1A0]);
+    });
+
+    test('address "FFFFFFFF" matches max 32-bit address', async () => {
+        const matches = await runSearch('addr', 'FFFFFFFF', [{ startAddress: 0xFFFFFFF0, data: new Uint8Array(16) }]);
+        assert.deepStrictEqual(matches, [0xFFFFFFFF]);
+    });
+
+    test('no false positive: "1A0" does not match 0x100001A0', async () => {
+        const matches = await runSearch('addr', '1A0', [{ startAddress: 0x100001A0, data: new Uint8Array(2) }]);
+        assert.deepStrictEqual(matches, []);
+    });
+
+    test('empty query returns empty matches', async () => {
+        const matches = await runSearch('addr', '', [{ startAddress: 0, data: new Uint8Array(10) }]);
+        assert.deepStrictEqual(matches, []);
+    });
+
+    test('non-hex query returns empty matches without crash', async () => {
+        const matches = await runSearch('addr', 'ZZZ', [{ startAddress: 0, data: new Uint8Array(10) }]);
+        assert.deepStrictEqual(matches, []);
+    });
+
+    test('overflow: >8 hex chars returns empty (no silent wrap)', async () => {
+        const matches = await runSearch('addr', '100000000', [{ startAddress: 0, data: new Uint8Array(10) }]);
+        assert.deepStrictEqual(matches, []);
+    });
+
+    test('overflow: 0x-prefixed >8 hex chars returns empty', async () => {
+        const matches = await runSearch('addr', '0x100000000', [{ startAddress: 0, data: new Uint8Array(10) }]);
+        assert.deepStrictEqual(matches, []);
+    });
+
+    test('canonicalizeQuery normalizes address inputs', () => {
+        assert.strictEqual(canonicalizeQuery('addr', '0x1A0'), '1A0');
+        assert.strictEqual(canonicalizeQuery('addr', '1A0'), '1A0');
+        assert.strictEqual(canonicalizeQuery('addr', '000001A0'), '000001A0');
+    });
+});

--- a/src/webview/hexViewer.ts
+++ b/src/webview/hexViewer.ts
@@ -456,7 +456,10 @@ function render(): void {
                     <option value="ascii" ${selectedAttr(S.searchMode === 'ascii')}>ASCII</option>
                     <option value="addr"  ${selectedAttr(S.searchMode === 'addr')}>Addr</option>
                 </select>
-                <input id="search-input" type="text" placeholder="Search…" autocomplete="off" spellcheck="false">
+                <div class="search-addr-wrap">
+                    <span id="search-addr-prefix" class="search-addr-prefix">0x</span>
+                    <input id="search-input" type="text" placeholder="Search…" autocomplete="off" spellcheck="false">
+                </div>
                 <button class="nav-btn search-btn" id="btn-search" title="Run search" aria-label="Run search">🔍</button>
                 <button class="nav-btn" id="btn-prev"         title="Previous match">▲</button>
                 <button class="nav-btn" id="btn-next"         title="Next match">▼</button>

--- a/src/webview/search/searchControls.ts
+++ b/src/webview/search/searchControls.ts
@@ -9,10 +9,27 @@ export function setupSearchControls(onUndo: () => void): void {
     const searchBtnLE = document.getElementById('search-btn-le') as HTMLButtonElement;
     const searchBtnBE = document.getElementById('search-btn-be') as HTMLButtonElement;
 
+    const addrPrefixEl = document.getElementById('search-addr-prefix')!;
+    const updateAddrOverlay = (): void => {
+        const show = S.searchMode === 'addr' && inputEl.value.length > 0;
+        addrPrefixEl.style.display = show ? '' : 'none';
+        inputEl.classList.toggle('search-addr-mode', show);
+    };
+
     const applySearchModeUi = (): void => {
         endianToggleEl.style.display = S.searchMode === 'value' ? 'inline-flex' : 'none';
         inputEl.placeholder = searchPlaceholder();
+        const isAddr = S.searchMode === 'addr';
+        inputEl.maxLength = isAddr ? 8 : 100;
+        if (!isAddr) { inputEl.classList.remove('search-addr-mode'); }
+        updateAddrOverlay();
     };
+
+    inputEl.addEventListener('input', () => {
+        if (S.searchMode !== 'addr') { return; }
+        inputEl.value = inputEl.value.replace(/[^0-9a-fA-F]/g, '');
+        updateAddrOverlay();
+    });
     const applyEndianUi = (): void => {
         searchBtnAuto.classList.toggle('active', S.searchEndianness === 'auto');
         searchBtnLE.classList.toggle('active', S.searchEndianness === 'le');
@@ -48,7 +65,7 @@ function searchPlaceholder(): string {
         bytes: 'Bytes (e.g. DE AD BE EF)',
         value: 'Value (e.g. 0x12345678 or 305419896)',
         ascii: 'ASCII text',
-        addr: 'Address (e.g. 0800 or 0x08001234)',
+        addr: 'Addr (e.g. 1A0)',
     };
     return placeholders[S.searchMode];
 }

--- a/src/webview/styles/toolbar.css
+++ b/src/webview/styles/toolbar.css
@@ -115,14 +115,22 @@
     border: 1px solid var(--input-bdr); border-radius: 3px;
     padding: 0 4px; height: 22px; font-size: 11px; cursor: pointer;
 }
+.search-addr-wrap { position: relative; display: inline-flex; align-items: center; }
+.search-addr-prefix {
+    position: absolute; left: 8px; top: 50%; transform: translateY(-50%);
+    color: var(--non-graphic); font-family: var(--font-editor); font-size: 12px;
+    pointer-events: none; z-index: 1; line-height: 1; user-select: none;
+}
 #search-input {
     background: var(--input-bg); color: var(--fg);
     border: 1px solid var(--input-bdr); border-radius: 3px;
     padding: 0 7px; height: 26px; width: 180px; outline: none;
     font-size: 12px; font-family: var(--font-editor); transition: border-color .12s;
 }
+#search-input.search-addr-mode { padding-left: 23px; }
 #search-input::placeholder { color: var(--non-graphic); }
 #search-input:focus { border-color: var(--focus-bdr); }
+
 
 .nav-btn {
     width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary

Fixed address search requiring full leading-zero padding — short queries like `1A0` now correctly find address `0x1A0` instead of matching wrong range `0x1A000000-0x1A0FFFFF`.

## Main changes

- Fixed address query padding direction (`padEnd` → `padStart` + exact match) so short hex input resolves to the correct address
- Simplified `AddressSearchBounds` to single-value `AddressSearchQuery` (removed dead range/prefix fields)
- Added inline `0x` prefix in address search input, hex-only character filtering, and 8-character maximum
- Added 10 address search tests covering short, padded, zero-prefixed, overflow, and invalid inputs
