### PR TITLE
feat(scripting): add hex.readSelected() API

### DIFF
--- a/.trellis/spec/frontend/scripting.md
+++ b/.trellis/spec/frontend/scripting.md
@@ -19,11 +19,12 @@ interface ScriptHost {
     setResult(label: string, value: string): void;
     collectOutput(): { results: Array<{ label: string; value: string }>; log: string[] };
     stale?: boolean;
+    selectionRange?: { start: number; end: number };
 }
 
 // API injected into script vm context
 interface HexScopeAPI {
-    hex: { read(a: number, l: number): Uint8Array; write(a: number, d: Uint8Array): Promise<boolean>; size: number };
+    hex: { read(a: number, l: number): Uint8Array; readSelected(): Uint8Array; write(a: number, d: Uint8Array): Promise<boolean>; size: number };
     crc: { crc8(d: Uint8Array | number[]): number; crc16(d: Uint8Array | number[]): number; crc32(d: Uint8Array | number[]): number };
     hash: { sha1(d: Uint8Array): Promise<Uint8Array>; sha256(d: Uint8Array): Promise<Uint8Array>; sha512(d: Uint8Array): Promise<Uint8Array> };
     exec(cmd: string, args?: string[]): Promise<ExecResult | null>;
@@ -89,7 +90,7 @@ function execute(filePath: string, host: ScriptHost, timeoutMs?: number): Promis
 ```typescript
 // Webview → Provider
 | { type: 'requestScriptList' }
-| { type: 'runScript'; scriptPath: string; generation: number }
+| { type: 'runScript'; scriptPath: string; generation: number; selectionRange?: { start: number; end: number } }
 
 // Provider → Webview
 | { type: 'scriptInfo'; scripts: Array<{ name: string; filePath: string }> }

--- a/.trellis/workspace/deviousprophet/index.md
+++ b/.trellis/workspace/deviousprophet/index.md
@@ -8,8 +8,8 @@
 
 <!-- @@@auto:current-status -->
 - **Active File**: `journal-1.md`
-- **Total Sessions**: 14
-- **Last Active**: 2026-07-24
+- **Total Sessions**: 15
+- **Last Active**: 2026-07-25
 <!-- @@@/auto:current-status -->
 
 ---
@@ -19,7 +19,7 @@
 <!-- @@@auto:active-documents -->
 | File | Lines | Status |
 |------|-------|--------|
-| `journal-1.md` | ~203 | Active |
+| `journal-1.md` | ~237 | Active |
 <!-- @@@/auto:active-documents -->
 
 ---
@@ -29,6 +29,7 @@
 <!-- @@@auto:session-history -->
 | # | Date | Title | Commits | Branch |
 |---|------|-------|---------|--------|
+| 15 | 2026-07-25 | Add hex.readSelected() API | `de0c3c7`, `b0588fd` | `feat/read-selected-api` |
 | 14 | 2026-07-24 | Address search cleanup | `14fa689` | `fix/search-address-padding` |
 | 13 | 2026-07-24 | Fix address search padding | `6c7e0e7` | `fix/search-address-padding` |
 | 12 | 2026-07-23 | Direct-typing byte editing | `c3fe112` | `feat/edit-tedium` |

--- a/.trellis/workspace/deviousprophet/journal-1.md
+++ b/.trellis/workspace/deviousprophet/journal-1.md
@@ -201,3 +201,37 @@ Simplify AddressSearchBounds (rm dead fields), extract test helper, move addr te
 ### Next Steps
 
 - None - task complete
+
+
+## Session 15: Add hex.readSelected() API
+
+**Date**: 2026-07-25
+**Task**: Add hex.readSelected() API
+**Branch**: `feat/read-selected-api`
+
+### Summary
+
+Added hex.readSelected() script API to read the current editor selection. Threaded selection range from webview through runScript message to VSCodeScriptHost. Updated docs (SCRIPTING.md + scripting spec) and added 3 unit tests.
+
+### Main Changes
+
+(Add details)
+
+### Git Commits
+
+| Hash | Message |
+|------|---------|
+| `de0c3c7` | (see git log) |
+| `b0588fd` | (see git log) |
+
+### Testing
+
+- [OK] (Add test results)
+
+### Status
+
+[OK] **Completed**
+
+### Next Steps
+
+- None - task complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Fixed address search requiring leading zeros — short queries like `1A0` now correctly match address `0x1A0`
+- Added `hex.readSelected()` scripting API to read the current editor selection without hardcoding addresses
 
 ### Changed
 
-- Improved address search input with inline `0x` prefix, hex-only character filtering, and 8-character maximum
+- Improved address search input with inline `0x` prefix, hex-only character filtering, and an 8-character maximum
+
+### Fixed
+
+- Fixed address search requiring leading zeros so short queries like `1A0` correctly match `0x1A0`
 
 ## [2.15.0] - 2026-07-23
 

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -74,6 +74,7 @@ If using TypeScript, install the types from the extension's source or copy the `
 
 ```typescript
 api.hex.read(address: number, length: number): Uint8Array
+api.hex.readSelected(): Uint8Array
 api.hex.write(address: number, data: Uint8Array): Promise<boolean>
 api.hex.size: number
 ```
@@ -81,6 +82,7 @@ api.hex.size: number
 | Method | Description |
 |--------|-------------|
 | `read(address, length)` | Returns bytes from the currently open document at the given firmware address. Stops reading at the first unmapped byte |
+| `readSelected()` | Returns the bytes in the current editor selection. Captured at script-run time. Returns 1 byte when cursor sits on a single byte; empty `Uint8Array` when no selection |
 | `write(address, data)` | Writes bytes. **Shows a confirmation dialog.** Returns `true` if the user accepted |
 | `size` | Total number of mapped bytes in the document (sum of all segment lengths) |
 
@@ -92,6 +94,36 @@ Addresses are absolute firmware addresses from the parsed segments. If the addre
 const vectorTable = api.hex.read(0x08000000, 128);  // first 128 bytes at 0x08000000
 const stackPtr = new DataView(vectorTable.buffer).getUint32(0, true);  // first 4 bytes LE
 api.output(`Stack pointer: 0x${stackPtr.toString(16).toUpperCase()}`);
+```
+
+**Example — reading the current selection:**
+
+```typescript
+const selected = api.hex.readSelected();
+const hex = [...selected].map(b => b.toString(16).padStart(2, '0')).join(' ');
+api.setResult('Selected bytes', hex.toUpperCase());
+api.output(`Read ${selected.length} bytes from selection`);
+```
+
+**Example — patching bytes:**
+
+```typescript
+export async function run(api) {
+    const addr = 0x08000000;
+    const before = api.hex.read(addr, 1);
+    api.output(`Current: 0x${before[0].toString(16).toUpperCase()}`);
+
+    const ok = await api.hex.write(addr, new Uint8Array([0xFF]));
+    api.setResult('Write accepted', ok ? 'Yes' : 'No');
+}
+```
+
+**Example — total size:**
+
+```typescript
+api.setResult('Total size', `${api.hex.size} bytes`);
+const data = api.hex.read(0, api.hex.size);  // read everything
+api.output(`Read ${data.length} bytes`);
 ```
 
 ### `api.crc` — CRC algorithms

--- a/src/core/scripting/api/hexAPI.ts
+++ b/src/core/scripting/api/hexAPI.ts
@@ -5,6 +5,11 @@ export function hexAPI(host: ScriptHost) {
         read(address: number, length: number): Uint8Array {
             return host.readBytes(address, length);
         },
+        readSelected(): Uint8Array {
+            const range = host.selectionRange;
+            if (!range) { return new Uint8Array(0); }
+            return host.readBytes(range.start, range.end - range.start + 1);
+        },
         async write(address: number, data: Uint8Array): Promise<boolean> {
             const ok = await host.confirm('write', `Write ${data.length} bytes at 0x${address.toString(16).toUpperCase()}`);
             if (!ok || host.stale) { return false; }

--- a/src/core/scripting/types.ts
+++ b/src/core/scripting/types.ts
@@ -10,6 +10,8 @@ export interface ScriptHost {
     collectOutput(): { results: Array<{ label: string; value: string }>; log: string[] };
     /** If true, the host data is stale and writes should be rejected. */
     stale?: boolean;
+    /** Current editor selection range, if any. Set at script-run time. */
+    selectionRange?: { start: number; end: number };
 }
 
 export interface ExecResult {
@@ -36,6 +38,7 @@ export interface ScriptOutput {
 export interface HexScopeAPI {
     hex: {
         read(address: number, length: number): Uint8Array;
+        readSelected(): Uint8Array;
         write(address: number, data: Uint8Array): Promise<boolean>;
         size: number;
     };

--- a/src/hexEditorSession.ts
+++ b/src/hexEditorSession.ts
@@ -732,6 +732,7 @@ export class HexEditorSession {
                             `Script "${scriptPath}" wants to ${type}: ${detail}`, { modal: true }, 'Allow');
                         return btn === 'Allow';
                     },
+                    selectionRange: msg.selectionRange,
                 });
                 const output = await execute(scriptPath, host, undefined, signal);
                 // ponytail: guard with `if (currentAbort?.signal === signal)` if runs can overlap

--- a/src/scriptHost.ts
+++ b/src/scriptHost.ts
@@ -39,6 +39,7 @@ export class VSCodeScriptHost implements IScriptHost {
     private readonly _outputHook: (text: string) => void;
     private readonly _resultHook: (label: string, value: string) => void;
     private readonly _confirm: (type: 'write' | 'exec' | 'fetch', detail: string) => Promise<boolean>;
+    selectionRange?: { start: number; end: number };
 
     constructor(
         segments: MemorySegment[],
@@ -46,12 +47,14 @@ export class VSCodeScriptHost implements IScriptHost {
             output?: (text: string) => void;
             setResult?: (label: string, value: string) => void;
             confirm?: (type: 'write' | 'exec' | 'fetch', detail: string) => Promise<boolean>;
+            selectionRange?: { start: number; end: number };
         },
     ) {
         this.lookup = buildLookup(segments);
         this._outputHook = options.output ?? (() => {});
         this._resultHook = options.setResult ?? (() => {});
         this._confirm = options.confirm ?? (async () => false);
+        this.selectionRange = options.selectionRange;
     }
 
     get totalSize(): number {

--- a/src/test/core/scripting-runner.test.ts
+++ b/src/test/core/scripting-runner.test.ts
@@ -118,6 +118,54 @@ test('supports hex.read API', async () => {
     } finally { rmDir(dir); }
 });
 
+test('hex.readSelected returns selection bytes', async () => {
+    const dir = tmpDir();
+    try {
+        const fp = writeScript(dir, 'readsel.js', `
+            module.exports = { run(api) {
+                const data = api.hex.readSelected();
+                api.output(data.length.toString() + ':' + [...data].map(b => b.toString(16)).join(','));
+            }};
+        `);
+        const host = makeHost({ selectionRange: { start: 5, end: 9 } });
+        const out = await execute(fp, host);
+        assert.equal(out.error, undefined);
+        assert.ok((host as any)._log.some((l: string) => l === '5:5,6,7,8,9'));
+    } finally { rmDir(dir); }
+});
+
+test('hex.readSelected returns empty for no selection', async () => {
+    const dir = tmpDir();
+    try {
+        const fp = writeScript(dir, 'readsel-none.js', `
+            module.exports = { run(api) {
+                const data = api.hex.readSelected();
+                api.output(data.length.toString());
+            }};
+        `);
+        const host = makeHost();
+        const out = await execute(fp, host);
+        assert.equal(out.error, undefined);
+        assert.ok((host as any)._log.includes('0'));
+    } finally { rmDir(dir); }
+});
+
+test('hex.readSelected returns 1 byte for zero-length selection', async () => {
+    const dir = tmpDir();
+    try {
+        const fp = writeScript(dir, 'readsel-zero.js', `
+            module.exports = { run(api) {
+                const data = api.hex.readSelected();
+                api.output(data.length.toString() + ':' + data[0].toString(16));
+            }};
+        `);
+        const host = makeHost({ selectionRange: { start: 0xAB, end: 0xAB } });
+        const out = await execute(fp, host);
+        assert.equal(out.error, undefined);
+        assert.ok((host as any)._log.some((l: string) => l === '1:ab'));
+    } finally { rmDir(dir); }
+});
+
 test('supports crc API', async () => {
     const dir = tmpDir();
     try {

--- a/src/webview/sidebar/scripts/scriptList.ts
+++ b/src/webview/sidebar/scripts/scriptList.ts
@@ -1,6 +1,7 @@
 import { esc } from '../../utils';
 import { postProviderMessage } from '../../vscodeApi';
 import { S } from '../../state';
+import { currentSelectionRange } from '../../memory/selection';
 
 let currentScripts: Array<{ name: string; filePath: string }> = [];
 const scriptStatus = new Map<string, 'success' | 'error' | null>();
@@ -62,7 +63,8 @@ function runScript(filePath: string): void {
     if (runningPath) { return; }
     runStartCallback?.();
     setRunning(filePath);
-    postProviderMessage({ type: 'runScript', scriptPath: filePath, generation: S.documentGeneration });
+    const selectionRange = currentSelectionRange() ?? undefined;
+    postProviderMessage({ type: 'runScript', scriptPath: filePath, generation: S.documentGeneration, selectionRange });
 }
 
 function cancelScript(filePath: string): void {

--- a/src/webviewProtocol.ts
+++ b/src/webviewProtocol.ts
@@ -64,7 +64,7 @@ export type WebviewToProviderMessage =
     | { type: 'closePanel' }
     | { type: 'viewInNormalEditor' }
     | { type: 'requestScriptList' }
-    | { type: 'runScript'; scriptPath: string; generation: number }
+    | { type: 'runScript'; scriptPath: string; generation: number; selectionRange?: { start: number; end: number } }
     | { type: 'cancelScript'; scriptPath: string };
 
 export function messageType(message: unknown): string | undefined {


### PR DESCRIPTION
## Summary

Add `hex.readSelected()` to the scripting API so custom scripts can read the user's current hex editor selection without hardcoding addresses.

## Main changes

- Added `selectionRange` field to `ScriptHost` interface and protocol message threading it from webview to extension host
- Added `hex.readSelected()` method returning selected bytes as `Uint8Array`
- Documented new API in `SCRIPTING.md` with examples and updated internal scripting spec
