### PR TITLE
chore: bump version to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.16.0] - 2026-07-25
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version from `2.15.0` to `2.16.0`