### PR TITLE
docs(workflow): exclude issue numbers from branch and task naming

### DIFF
--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -11,7 +11,7 @@
 5. **Capture learnings** — after each task, review and write new knowledge back to spec
 ## Repository Conventions
 
-- **Branch naming**: `feat/<slug>` (features), `fix/<slug>` (bug fixes), `chore/<slug>` (tooling/config/docs/skills), `refactor/<slug>` (restructuring, no behavior change), `perf/<slug>` (performance), `test/<slug>` (test-only). Always branch from `main` unless user specifies different base.
+- **Branch naming**: `feat/<slug>` (features), `fix/<slug>` (bug fixes), `chore/<slug>` (tooling/config/docs/skills), `refactor/<slug>` (restructuring, no behavior change), `perf/<slug>` (performance), `test/<slug>` (test-only). Always branch from `main` unless user specifies different base. `<slug>` is the task slug — do **not** include issue/PR numbers or `MM-DD-` prefixes in branch names or task slugs; task directories get `MM-DD-` automatically.
 - **Encoding**: Save all source files as UTF-8 (no BOM). Non-UTF-8 breaks fallow's AST parser, producing false-positive findings.
 ---
 
@@ -320,7 +320,7 @@ Create the task directory only after task-creation consent. The command sets sta
 python ./.trellis/scripts/task.py create "<task title>" --slug <name>
 ```
 
-`--slug` is the human-readable name only. Do **not** include the `MM-DD-` date prefix; `task.py create` adds that prefix automatically.
+`--slug` is the human-readable name only. Do **not** include the `MM-DD-` date prefix; `task.py create` adds that prefix automatically. Do **not** include issue/PR numbers in the slug — branch and task names stay issue-number-free; link the issue in the PR description instead.
 
 For task trees, create the parent task first and then create each child with `--parent <parent-dir>`. Do not start the parent just because children exist; start the child that owns the next independently verifiable deliverable.
 


### PR DESCRIPTION
﻿## Summary

Update the Trellis workflow conventions so branch names and task slugs never contain issue/PR numbers. The number belongs in the PR description, not in git or task naming — keeps branches and tasks stable and readable.

## Main changes

- Repository conventions: `<slug>` in branch naming must be the task slug, without issue/PR numbers or `MM-DD-` prefixes.
- Task creation (`--slug`): explicit rule that slugs exclude issue/PR numbers; link the issue in the PR description instead.
