### PR TITLE
chore: release 2.17.1, changelog skill leaves no Unreleased heading

### DIFF
--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -7,7 +7,7 @@ description: "Prepare or revise release changelog entries synchronized with pack
 
 Two modes:
 - **update** (default) — append/overwrite `## [Unreleased]` section from `tag..HEAD`. Never touches versions or package.json.
-- **release** — on explicit "release" request: promote current `[Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`, bump package versions, leave `[Unreleased]` above for next cycle.
+- **release** — on explicit "release" request: replace current `[Unreleased]` with `## [X.Y.Z] - YYYY-MM-DD`, bump package versions, delete now-empty `[Unreleased]` heading. Release replaces `[Unreleased]` with the versioned section; no empty section left for next cycle.
 
 ## 1. Inspect Release State
 
@@ -97,7 +97,7 @@ Never modify a tagged release section.
 - ...
 ```
 
-If `[Unreleased]` section already exists (hand-written or from prior update), compare its topics with the new commit-derived entries:
+If no `[Unreleased]` section exists, create it with entries from `tag..HEAD`. If `[Unreleased]` section already exists (hand-written or from prior update), compare its topics with the new commit-derived entries:
 
 - **Related** — existing entries cover the same features/areas as new commits → **replace** with authoritative commit-derived content (it's the source of truth).
 - **Unrelated** — existing entries cover different features/areas than new commits → **merge**: keep existing entries and append new ones under appropriate sections.
@@ -117,7 +117,7 @@ If no qualifying changes since last tag → report "Nothing new to log." Change 
 - ...
 ```
 
-Promote current `[Unreleased]` content. If `[Unreleased]` is empty, fill from tag..HEAD. Place new versioned section **above** a fresh `## [Unreleased]`.
+Promote current `[Unreleased]` content. If `[Unreleased]` is empty, fill from tag..HEAD. Replace the `## [Unreleased]` heading with `## [X.Y.Z] - YYYY-MM-DD` and delete the now-empty section — the versioned section becomes topmost. No `[Unreleased]` heading is left behind; a future update run re-creates it.
 
 After release, `[Unreleased]` stays empty until new commits arrive after the tag.
 
@@ -157,7 +157,7 @@ Replace/create `## [Unreleased]` section at top of `CHANGELOG.md`. No other file
 
 ### release mode
 
-1. Promote `[Unreleased]` content into `## [X.Y.Z] - YYYY-MM-DD` below a fresh `## [Unreleased]`.
+1. Replace the `## [Unreleased]` heading with `## [X.Y.Z] - YYYY-MM-DD` (keep its content), then delete the now-empty `[Unreleased]` section so the versioned section is topmost.
 2. Update package versions without scripts or tags:
 
    ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.17.1] - 2026-08-01
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
﻿## Summary

Release v2.17.1 with three bug fixes and a changelog workflow update. The changelog skill now replaces `[Unreleased]` with the versioned release section instead of leaving an empty section for the next cycle.

## Main changes

- Fix context-menu Copy/Analyze emitting `0x00` bytes for unmapped gap addresses
- Fix fill-selection marking bytes dirty when re-filling with the current value
- Fix `crc16` computing CRC-16/ANSI instead of the documented CRC-16/Modbus
- Update `update-changelog` skill: release mode replaces `[Unreleased]` with the versioned heading and deletes the now-empty section
