### PR TITLE
chore(release): bump to 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.18.0] - 2026-08-22
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-hex-scope",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-hex-scope",
-      "version": "2.17.1",
+      "version": "2.18.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hex Scope",
   "publisher": "deviousprophet",
   "description": "Firmware memory explorer and editor for Intel HEX and Motorola SREC files.",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Releases the accumulated UI/UX work since v2.17.1 as 2.18.0 — hex-grid row selection and keyboard navigation, sidebar section layout with resizable panes, actionable script output, integrity-check naming and autofill, undo/redo shortcuts, and fast in-place save.

## Main changes

- Promote changelog `[Unreleased]` section to `[2.18.0] - 2026-08-22`
- Bump `package.json` and `package-lock.json` to `2.18.0`