### PR TITLE
fix(test): guard DOM-cleanup timers against closed jsdom windows

### DIFF
--- a/src/test/webview/components/toast.test.ts
+++ b/src/test/webview/components/toast.test.ts
@@ -67,4 +67,11 @@ suite('webview toast', () => {
         await new Promise(resolve => setTimeout(resolve, 1500));
         assert.ok(toast.hidden, 'toast fades away after ~1.4s');
     });
+
+    test('auto-hide timer does not throw after the window closes (teardown race)', async () => {
+        showToast('Copied ✓');
+        dom.window.close();
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        assert.ok(true);
+    });
 });

--- a/src/test/webview/utils.test.ts
+++ b/src/test/webview/utils.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { formatDecimal, formatHex, formatHexHtml, asUint64, flashCopied } from '../../webview/utils';
+import { formatDecimal, formatHex, formatHexHtml, asUint64, flashCopied, inlineConfirm } from '../../webview/utils';
 import { JSDOM } from 'jsdom';
 
 suite('webview utils formatting', () => {
@@ -94,5 +94,53 @@ suite('webview utils flashCopied', () => {
         const live = document.getElementById('t')!;
         assert.strictEqual(live.textContent, '0xCD', 're-rendered element keeps its own text');
         assert.ok(!live.classList.contains('copied'));
+    });
+
+    test('pending flash timer does not throw after the window closes (teardown race)', async () => {
+        const el = document.getElementById('t')!;
+        flashCopied(el, true);
+        dom.window.close();
+        await sleep(1150);
+        assert.ok(true);
+    });
+});
+
+suite('webview utils inlineConfirm teardown race', () => {
+    let dom: JSDOM;
+
+    setup(() => {
+        dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://hexscope.test/' });
+        Object.defineProperty(globalThis, 'window', {
+            value: dom.window,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'document', {
+            value: dom.window.document,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(globalThis, 'requestAnimationFrame', {
+            value: (cb: FrameRequestCallback) => { cb(0); return 0; },
+            configurable: true,
+        });
+    });
+
+    teardown(() => {
+        delete (globalThis as unknown as { window?: Window }).window;
+        delete (globalThis as unknown as { document?: Document }).document;
+        delete (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+        dom.window.close();
+    });
+
+    test('deferred outside-click listener does not throw after the window closes', async () => {
+        const anchor = document.createElement('button');
+        document.body.appendChild(anchor);
+        inlineConfirm(anchor, () => {});
+        dom.window.close();
+        delete (globalThis as unknown as { window?: Window }).window;
+        delete (globalThis as unknown as { document?: Document }).document;
+        await sleep(20);
+        assert.ok(true);
     });
 });

--- a/src/webview/components/toast.ts
+++ b/src/webview/components/toast.ts
@@ -70,21 +70,27 @@ function clampWithin(min: number, value: number, max: number): number {
 function hideToast(): void {
     if (!toastEl) { return; }
     hideTimer = null;
-    if (motionReduced()) {
-        toastEl.hidden = true;
+    try {
+        if (motionReduced()) {
+            toastEl.hidden = true;
+            toastEl.classList.remove('sb-toast-visible');
+            return;
+        }
         toastEl.classList.remove('sb-toast-visible');
-        return;
-    }
-    toastEl.classList.remove('sb-toast-visible');
-    hideTimer = setTimeout(() => {
-        if (toastEl) {
+        hideTimer = setTimeout(() => clearToastElement(), TOAST_OUT_MS);
+    } catch { }
+}
+
+function clearToastElement(): void {
+    if (toastEl) {
+        try {
             toastEl.hidden = true;
             toastEl.classList.remove('sb-toast--near', 'sb-toast--top-center');
             toastEl.style.left = '';
             toastEl.style.top = '';
-        }
-        hideTimer = null;
-    }, TOAST_OUT_MS);
+        } catch { }
+    }
+    hideTimer = null;
 }
 
 function motionReduced(): boolean {

--- a/src/webview/utils.ts
+++ b/src/webview/utils.ts
@@ -225,8 +225,10 @@ export function inlineConfirm(anchor: HTMLElement, onConfirm: () => void, messag
 
     // Delay adding outside-click so the originating click doesn't immediately close it
     setTimeout(() => {
-        document.addEventListener('mousedown', outsideHandler, true);
-        document.addEventListener('keydown',   keyHandler,     true);
+        try {
+            document.addEventListener('mousedown', outsideHandler, true);
+            document.addEventListener('keydown',   keyHandler,     true);
+        } catch { }
     }, 0);
 }
 
@@ -283,9 +285,11 @@ const flashState = new WeakMap<HTMLElement, { timer: number; prev: string | null
 /** Restore the pre-flash text (skipped when the element was re-rendered/detached). */
 function endFlash(el: HTMLElement, prev: string | null): void {
     flashState.delete(el);
-    if (!el.isConnected) { return; }
-    el.classList.remove('copied');
-    if (prev !== null) { el.textContent = prev; }
+    try {
+        if (!el.isConnected) { return; }
+        el.classList.remove('copied');
+        if (prev !== null) { el.textContent = prev; }
+    } catch { }
 }
 
 function flashPrevText(el: HTMLElement, swapText: boolean): string | null {


### PR DESCRIPTION
## Summary

CI flake fix. `inlineConfirm` defers attaching document listeners in a `setTimeout(0)`; when a test suite closes and deletes the JSDOM window first, that callback then hits an `undefined` document and crashes the mocha host with an uncaught `ReferenceError` — surfacing as a spurious `"after each" hook: cleanupDom` failure in later suites. Same teardown-race class exists in the `flashCopied` and toast cleanup timers.

## Main changes

- Guard the deferred outside-click listener attach in `inlineConfirm` so it no-ops when the DOM is gone
- Guard `flashCopied` and toast auto-hide callbacks against closed-window teardown (same crash class)
- Add a regression test that fails without the popover guard (verified: `Uncaught ReferenceError: document is not defined`) and passes with it